### PR TITLE
feat: add match request queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+frontend/node_modules/
+frontend/dist/
+backend/build/

--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -1,0 +1,33 @@
+package net.datasa.project01.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.entity.MatchRequest;
+import net.datasa.project01.repository.MatchRequestRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/match")
+@RequiredArgsConstructor
+public class MatchController {
+
+    private final MatchRequestRepository matchRequestRepository;
+    private final ObjectMapper objectMapper;
+
+    @PostMapping("/requests")
+    public ResponseEntity<Map<String, Long>> createMatchRequest(@RequestBody MatchRequestDto dto) throws JsonProcessingException {
+        MatchRequest saved = matchRequestRepository.save(MatchRequest.builder()
+                .choiceGender(dto.getChoiceGender())
+                .minAge(dto.getMinAge())
+                .maxAge(dto.getMaxAge())
+                .regionCode(dto.getRegionCode())
+                .interestsJson(objectMapper.writeValueAsString(dto.getInterestsJson()))
+                .build());
+        return ResponseEntity.ok(Map.of("requestId", saved.getMatchRequestId()));
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
@@ -1,0 +1,16 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.Data;
+import java.util.List;
+
+/**
+ * 매칭 요청 DTO.
+ */
+@Data
+public class MatchRequestDto {
+    private String choiceGender;
+    private int minAge;
+    private int maxAge;
+    private String regionCode;
+    private List<String> interestsJson;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
@@ -1,0 +1,44 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 매칭 요청 정보를 저장하는 엔티티
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "match_requests")
+public class MatchRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "match_request_id")
+    private Long matchRequestId;
+
+    @Column(name = "choice_gender", length = 1, nullable = false)
+    private String choiceGender;
+
+    @Column(name = "min_age", nullable = false)
+    private int minAge;
+
+    @Column(name = "max_age", nullable = false)
+    private int maxAge;
+
+    @Column(name = "region_code", length = 30, nullable = false)
+    private String regionCode;
+
+    @Column(name = "interests_json", columnDefinition = "TEXT", nullable = false)
+    private String interestsJson;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -1,0 +1,7 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.MatchRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
+}

--- a/frontend/src/views/MatchingSetup.vue
+++ b/frontend/src/views/MatchingSetup.vue
@@ -117,11 +117,14 @@ const regions = [
   { title: '오사카', value: 'OSAKA' },
   { title: '후쿠오카', value: 'FUKUOKA' },
   { title: '제주', value: 'JEJU' },
+  { title: '인천', value: 'INCHEON' },
+  { title: '대구', value: 'DAEGU' },
+  { title: '광주', value: 'GWANGJU' },
   { title: '기타', value: 'OTHER' }
 ]
 const region = ref('')
 const dialog = ref(false)
-const interestPool = ['음악','영화','게임','여행','요리','운동','독서']
+const interestPool = ['음악','영화','게임','여행','요리','운동','독서','사진','패션','반려동물']
 const interests = ref([])
 const loading = ref(false)
 const isValid = computed(() => !!gender.value && !!region.value && interests.value.length > 0)
@@ -137,7 +140,7 @@ async function startMatch(){
     interests_json: interests.value,
   }
   try{
-    // await api.post('/match/requests', payload)
+    await api.post('/match/requests', payload)
     router.push('/match/result')
   }catch(e){
     alert('매칭 실패: ' + (e?.response?.data?.message || e.message))


### PR DESCRIPTION
## Summary
- extend matching setup with more regions and interests
- store match requests via new endpoint

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching {languageVersion=17})*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c11e7601cc832592c38756d696cc37