### PR TITLE
feat: enhance match request entity

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.repository.MatchRequestRepository;
+import net.datasa.project01.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -18,16 +20,26 @@ public class MatchController {
 
     private final MatchRequestRepository matchRequestRepository;
     private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
 
     @PostMapping("/requests")
     public ResponseEntity<Map<String, Long>> createMatchRequest(@RequestBody MatchRequestDto dto) throws JsonProcessingException {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        Long userPid = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."))
+                .getUserPid();
+
         MatchRequest saved = matchRequestRepository.save(MatchRequest.builder()
+                .userPid(userPid)
                 .choiceGender(dto.getChoiceGender())
                 .minAge(dto.getMinAge())
                 .maxAge(dto.getMaxAge())
                 .regionCode(dto.getRegionCode())
                 .interestsJson(objectMapper.writeValueAsString(dto.getInterestsJson()))
+                .status(dto.getStatus() != null ? dto.getStatus() : "WAITING")
                 .build());
+
         return ResponseEntity.ok(Map.of("requestId", saved.getMatchRequestId()));
     }
 }
+

--- a/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
@@ -8,9 +8,11 @@ import java.util.List;
  */
 @Data
 public class MatchRequestDto {
+    private Long userPid;
     private String choiceGender;
     private int minAge;
     private int maxAge;
     private String regionCode;
     private List<String> interestsJson;
+    private String status;
 }

--- a/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
@@ -20,8 +20,11 @@ public class MatchRequest {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "match_request_id")
+    @Column(name = "request_id")
     private Long matchRequestId;
+
+    @Column(name = "user_pid", nullable = false)
+    private Long userPid;
 
     @Column(name = "choice_gender", length = 1, nullable = false)
     private String choiceGender;
@@ -32,13 +35,16 @@ public class MatchRequest {
     @Column(name = "max_age", nullable = false)
     private int maxAge;
 
-    @Column(name = "region_code", length = 30, nullable = false)
+    @Column(name = "region_code", length = 10, nullable = false)
     private String regionCode;
 
-    @Column(name = "interests_json", columnDefinition = "TEXT", nullable = false)
+    @Column(name = "interests_json", columnDefinition = "JSON", nullable = false)
     private String interestsJson;
 
+    @Column(name = "status", length = 10, nullable = false)
+    private String status;
+
     @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "requested_at", updatable = false)
+    private LocalDateTime requestedAt;
 }


### PR DESCRIPTION
## Summary
- track user, status, and timestamp on match requests
- expose user and status on match request DTO
- capture authenticated user when creating match request

## Testing
- `./gradlew build` *(fails: Could not determine the dependencies of task ':bootJar' ... Cannot find a Java installation matching: {languageVersion=17})*


------
https://chatgpt.com/codex/tasks/task_e_68c125475cd8832586bb2cf1e603d079