### PR TITLE
feat: add file sharing, friend list and video test page

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -16,6 +16,8 @@
       <div v-else class="d-flex ga-3">
         <v-btn variant="tonal" color="pink" to="/match">매칭</v-btn>
         <v-btn variant="tonal" color="pink" to="/chat">채팅</v-btn>
+        <v-btn variant="tonal" color="pink" to="/rtc-test">영상테스트</v-btn>
+        <v-btn variant="tonal" color="pink" to="/vocabulary">단어장</v-btn>
         <v-btn variant="tonal" color="pink" to="/shop" disabled>상점</v-btn>
         <v-btn color="pink" to="/profile">프로필</v-btn>
       </div>

--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -1,14 +1,39 @@
 <template>
   <div class="d-flex flex-column h-100">
+    <div class="d-flex justify-end mb-1">
+      <v-btn size="small" variant="outlined" @click="addFriend">친구 추가</v-btn>
+    </div>
     <div class="flex-grow-1 overflow-y-auto pe-2" ref="messagesContainer">
       <div
         v-for="(msg, index) in messages"
         :key="index"
         class="my-1"
       >
-        <span class="text-body-2">{{ msg }}</span>
+        <template v-if="msg.fileUrl">
+          <div v-if="msg.isImage">
+            <img :src="msg.fileUrl" :alt="msg.original" class="max-w-100" />
+          </div>
+          <div v-else>
+            <a :href="msg.fileUrl" :download="msg.original">{{ msg.original }}</a>
+          </div>
+        </template>
+        <template v-else>
+          <div class="text-body-2">{{ msg.original }}</div>
+          <div v-if="msg.translated" class="text-caption text-grey">
+            {{ msg.translated }}
+            <v-icon size="small" class="ms-1 cursor-pointer" @click="saveWord(msg)">mdi-content-save</v-icon>
+          </div>
+        </template>
       </div>
     </div>
+    <v-file-input
+      v-model="file"
+      prepend-icon="mdi-paperclip"
+      hide-details
+      density="compact"
+      accept="image/*,application/*"
+      @change="sendFile"
+    />
     <v-text-field
       v-model="newMessage"
       @keyup.enter="send"
@@ -17,6 +42,7 @@
       hide-details
     >
       <template #append-inner>
+        <v-icon @click="toggleTranslate" :color="useTranslate ? 'primary' : undefined" class="me-1 cursor-pointer">mdi-translate</v-icon>
         <v-icon @click="send" class="cursor-pointer">mdi-send</v-icon>
       </template>
     </v-text-field>
@@ -25,10 +51,24 @@
 
 <script setup>
 import { ref, nextTick, onMounted } from 'vue';
+import { translate } from '../services/translator';
+import { useVocabularyStore } from '../stores/vocabulary';
+import { useFriendsStore } from '../stores/friends';
 
-const messages = ref(['안녕하세요!', '테스트 메시지']);
+const props = defineProps({
+  partner: { type: String, default: '' }
+})
+
+const messages = ref([
+  { original: '안녕하세요!', translated: '' },
+  { original: '테스트 메시지', translated: '' }
+]);
 const newMessage = ref('');
+const file = ref(null);
 const messagesContainer = ref(null);
+const useTranslate = ref(false);
+const vocab = useVocabularyStore();
+const friends = useFriendsStore();
 
 function scrollToBottom() {
   nextTick(() => {
@@ -39,12 +79,47 @@ function scrollToBottom() {
   });
 }
 
-function send() {
-  if (newMessage.value.trim()) {
-    messages.value.push(newMessage.value.trim());
+async function send() {
+  const text = newMessage.value.trim();
+  if (text) {
+    let translated = '';
+    if (useTranslate.value) {
+      translated = await translate(text);
+    }
+    messages.value.push({ original: text, translated });
     newMessage.value = '';
     scrollToBottom();
   }
+}
+
+function toggleTranslate() {
+  useTranslate.value = !useTranslate.value;
+}
+
+function saveWord(msg) {
+  if (msg.translated) {
+    vocab.addWord(msg.original, msg.translated);
+  }
+}
+
+function sendFile() {
+  const f = file.value;
+  if (!f) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    messages.value.push({
+      original: f.name,
+      fileUrl: reader.result,
+      isImage: f.type.startsWith('image/')
+    });
+    file.value = null;
+    scrollToBottom();
+  };
+  reader.readAsDataURL(f);
+}
+
+function addFriend() {
+  friends.add(props.partner);
 }
 
 onMounted(scrollToBottom);
@@ -52,4 +127,7 @@ onMounted(scrollToBottom);
 </script>
 
 <style scoped>
+.max-w-100 {
+  max-width: 100%;
+}
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,6 +16,8 @@ const routes = [
 
   { path: '/rtc-test',      name: 'rtc-test',      component: () => import('../views/RtcTest.vue'),       meta: { requiresAuth: true } },
 
+  { path: '/vocabulary',    name: 'vocabulary',    component: () => import('../views/Vocabulary.vue'),   meta: { requiresAuth: true } },
+
   { path: '/:pathMatch(.*)*', redirect: '/' },
 ]
 

--- a/frontend/src/services/translator.js
+++ b/frontend/src/services/translator.js
@@ -1,0 +1,5 @@
+export async function translate(text, targetLang = 'en') {
+  // 간단한 예시 번역기: 실제 서비스 연동 전까지는 문자열을 뒤집어 반환합니다.
+  // TODO: 외부 번역 API와 연동하여 실제 번역 결과를 제공하세요.
+  return text.split('').reverse().join('');
+}

--- a/frontend/src/stores/friends.js
+++ b/frontend/src/stores/friends.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+
+export const useFriendsStore = defineStore('friends', {
+  state: () => ({
+    list: JSON.parse(localStorage.getItem('friends') || '[]')
+  }),
+  actions: {
+    add(name) {
+      if (name && !this.list.includes(name)) {
+        this.list.push(name)
+        localStorage.setItem('friends', JSON.stringify(this.list))
+      }
+    },
+    remove(name) {
+      this.list = this.list.filter(f => f !== name)
+      localStorage.setItem('friends', JSON.stringify(this.list))
+    }
+  }
+})

--- a/frontend/src/stores/vocabulary.js
+++ b/frontend/src/stores/vocabulary.js
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia';
+
+export const useVocabularyStore = defineStore('vocabulary', {
+  state: () => ({
+    words: JSON.parse(localStorage.getItem('vocabulary') || '[]')
+  }),
+  actions: {
+    addWord(original, translated) {
+      this.words.push({ original, translated });
+      localStorage.setItem('vocabulary', JSON.stringify(this.words));
+    }
+  }
+});

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -121,7 +121,7 @@
 
 <script setup>
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
-import axios from 'axios'
+import { useFriendsStore } from '../stores/friends'
 
 const query = ref('')
 const tab = ref('direct')
@@ -138,18 +138,16 @@ const conversations = ref({
 
 const chatMessagesContainer = ref(null)
 
-onMounted(async () => {
-  try {
-    const { data } = await axios.get('/api/follows')
-    chats.value = data
-  } catch (e) {
-    chats.value = [
-      { id: 1, name: '김서연', last: '안녕하세요! 오늘 날씨가 정말 좋네요' },
-      { id: 2, name: '대학 동기', last: '오늘은 다음 주 모임 관련 이야기' }
-    ]
-  }
+const friendsStore = useFriendsStore()
+
+onMounted(() => {
+  chats.value = friendsStore.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
   current.value = chats.value[0] || groups.value[0]
   scrollToBottom()
+})
+
+friendsStore.$subscribe((_, state) => {
+  chats.value = state.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
 })
 
 

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -35,9 +35,9 @@
               </div>
             </v-col>
             <v-col cols="12" md="3">
-              <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
-                <ChatPanel class="flex-grow-1" />
-              </v-card>
+                <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
+                  <ChatPanel class="flex-grow-1" :partner="partnerName" />
+                </v-card>
             </v-col>
           </v-row>
 
@@ -79,9 +79,13 @@ import { createStompClient } from '../services/ws'
 import { setupSignalRoutes } from '../services/signaling'
 // import { setupChat } ...
 
-const me = ref(/* 로그인한 사용자 loginId */)
-const partner = ref(/* 매칭된 상대 loginId */)
-const pc = new RTCPeerConnection({
+  const me = ref(/* 로그인한 사용자 loginId */)
+  const partner = ref(/* 매칭된 상대 loginId */)
+  const partnerName = ref('홍길동')
+  const partnerAvatar = ref('https://via.placeholder.com/150')
+  const sessionStatus = ref('대기 중')
+  const mediaUrl = ref('')
+  const pc = new RTCPeerConnection({
   iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
 })
 const localVideo = ref(null)

--- a/frontend/src/views/RtcTest.vue
+++ b/frontend/src/views/RtcTest.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container class="py-4">
-    <div class="d-flex ga-4 mb-4">
-      <video ref="localVideo" autoplay muted playsinline class="w-50 bg-grey-lighten-2"></video>
-      <video ref="remoteVideo" autoplay playsinline class="w-50 bg-grey-lighten-2"></video>
+    <div class="video-wrapper mb-4">
+      <video ref="remoteVideo" autoplay playsinline class="remote-video bg-grey-lighten-2"></video>
+      <video ref="localVideo" autoplay muted playsinline class="local-video bg-grey-lighten-2"></video>
     </div>
     <div class="d-flex flex-column" style="max-width:400px">
       <div class="flex-grow-1 overflow-y-auto mb-2" style="height:200px;">
@@ -108,7 +108,20 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-video {
-  max-height: 240px;
+.video-wrapper {
+  position: relative;
+}
+.remote-video {
+  width: 100%;
+  max-height: 360px;
+}
+.local-video {
+  position: absolute;
+  width: 30%;
+  max-width: 200px;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  border: 2px solid white;
+  border-radius: 4px;
 }
 </style>

--- a/frontend/src/views/Vocabulary.vue
+++ b/frontend/src/views/Vocabulary.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="py-4">
+    <h2 class="text-h5 mb-4">단어장</h2>
+    <v-list>
+      <v-list-item v-for="(w, i) in words" :key="i">
+        <v-list-item-title>{{ w.original }} - {{ w.translated }}</v-list-item-title>
+      </v-list-item>
+      <v-list-item v-if="!words.length">
+        <v-list-item-title>저장된 단어가 없습니다.</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-container>
+</template>
+
+<script setup>
+import { storeToRefs } from 'pinia';
+import { useVocabularyStore } from '../stores/vocabulary';
+
+const store = useVocabularyStore();
+const { words } = storeToRefs(store);
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- show video chat test page from header
- support image/file messages and save partners as friends
- manage followed users with new Pinia store

## Testing
- `npm run build`
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68c25da623dc83259e56750ae0a944a7