### PR TITLE
Implement JWT authentication flow

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -1,20 +1,16 @@
 package net.datasa.project01.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchRequestDto;
-import net.datasa.project01.domain.entity.MatchRequest;
-import net.datasa.project01.repository.MatchRequestRepository;
 import net.datasa.project01.service.MatchService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/match")
@@ -34,6 +30,10 @@ public class MatchController {
     public ResponseEntity<String> startRandomMatch(
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody MatchRequestDto dto) {
+
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+        }
 
         try {
             String loginId = userDetails.getUsername();

--- a/backend/src/main/java/net/datasa/project01/domain/dto/LoginResponse.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/LoginResponse.java
@@ -1,0 +1,27 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 성공 시 프론트엔드로 반환되는 응답 모델.
+ *
+ * <p>액세스 토큰(JWT)과 화면에 필요한 최소한의 사용자 요약 정보를 함께 전달한다.</p>
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+
+    /** JWT 액세스 토큰 */
+    private String token;
+
+    /** 토큰 타입 (예: Bearer) */
+    private String tokenType;
+
+    /** 화면 상태 유지를 위한 사용자 요약 정보 */
+    private UserSummary user;
+}


### PR DESCRIPTION
## Summary
- add a dedicated login response that includes a JWT access token alongside the existing user summary
- wire the JWT authentication filter into the Spring Security chain and require authentication for match APIs
- guard the matching setup view so unauthenticated users are redirected to login and stale tokens trigger logout

## Testing
- ⚠️ `./gradlew test` *(fails: JDK 17 toolchain is unavailable in the execution environment)*
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8f0a5bdac83259e2b2a17e26f8f21