### PR TITLE
Fix auth handling and align match request payload

### DIFF
--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,26 +1,41 @@
 import { defineStore } from 'pinia'
 
+const initialToken = localStorage.getItem('token') || null
+const initialUser = initialToken
+  ? JSON.parse(localStorage.getItem('user') || 'null')
+  : null
+
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    token: localStorage.getItem('token'),
-    user: JSON.parse(localStorage.getItem('user') || 'null'),
+    token: initialToken,
+    user: initialUser,
   }),
   getters: {
-    // ✅ 토큰 또는 사용자 요약 중 하나만 있어도 로그인된 것으로 간주
-    isAuthenticated: (s) => !!(s.token || s.user),
+    // JWT 토큰이 있어야 보호된 API에 접근할 수 있으므로 토큰 존재만으로 인증 여부를 판단한다
+    isAuthenticated: (s) => !!s.token,
   },
   actions: {
     login({ token, user }) {
       this.token = token ?? null
-      this.user  = user  ?? null
-      if (this.token) localStorage.setItem('token', this.token); else localStorage.removeItem('token')
-      if (this.user)  localStorage.setItem('user', JSON.stringify(this.user)); else localStorage.removeItem('user')
+      this.user = token ? (user ?? null) : null
+
+      if (this.token) {
+        localStorage.setItem('token', this.token)
+      } else {
+        localStorage.removeItem('token')
+      }
+
+      if (this.user) {
+        localStorage.setItem('user', JSON.stringify(this.user))
+      } else {
+        localStorage.removeItem('user')
+      }
     },
     logout() {
       this.token = null
-      this.user  = null
+      this.user = null
       localStorage.removeItem('token')
       localStorage.removeItem('user')
-    }
-  }
+    },
+  },
 })

--- a/frontend/src/views/MatchingSetup.vue
+++ b/frontend/src/views/MatchingSetup.vue
@@ -150,7 +150,7 @@ async function startMatch(){
     min_age: ageRange.value[0],
     max_age: ageRange.value[1],
     region_code: region.value,
-    interests_json: interests.value,
+    interests: interests.value,
   }
   try{
     await api.post('/match/requests', payload)
@@ -162,7 +162,8 @@ async function startMatch(){
       redirectToLogin()
       return
     }
-    alert('매칭 실패: ' + (e?.response?.data?.message || e.message))
+    const message = e?.response?.data?.message || e?.response?.data || e.message
+    alert('매칭 실패: ' + message)
   }finally{
     loading.value = false
   }


### PR DESCRIPTION
## Summary
- ensure the Pinia auth store treats users as authenticated only when a JWT token is present and cleanly hydrates persisted state
- clear persisted profile data when no token is issued and keep localStorage in sync on login/logout
- send the updated interests field in the matching request and improve client-side error handling when the backend responds with an error

## Testing
- npm run build
- ./gradlew test *(fails: Java 17 toolchain is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f5fddc4c832596a68f4a0d5b48b9