### PR TITLE
Add JWT entry point and strict token handling

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package net.datasa.project01.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{ \"message\": \"인증이 필요합니다\" }");
+        response.getWriter().flush();
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationFilter.java
@@ -35,40 +35,60 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         
         try {
             String token = extractTokenFromRequest(request);
-            
-            if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                authenticateUser(token, request);
+
+            if (token == null) {
+                log.warn("Missing JWT token in Authorization header");
+                sendUnauthorizedError(response);
+                return;
+            }
+
+            if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                boolean authenticated = authenticateUser(token, request);
+                if (!authenticated) {
+                    sendUnauthorizedError(response);
+                    return;
+                }
             }
         } catch (Exception e) {
             log.error("Cannot set user authentication", e);
         }
-        
+
         filterChain.doFilter(request, response);
     }
-    
+
     private String extractTokenFromRequest(HttpServletRequest request) {
         String authHeader = request.getHeader(AUTHORIZATION_HEADER);
-        
+
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
             return authHeader.substring(BEARER_PREFIX.length());
         }
-        
+
         return null;
     }
-    
-    private void authenticateUser(String token, HttpServletRequest request) {
-        if (jwtUtil.validateToken(token)) {
-            String loginId = jwtUtil.getUsernameFromToken(token);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
-            
-            UsernamePasswordAuthenticationToken authentication = 
-                new UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.getAuthorities());
-            
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            
-            log.debug("Authentication successful for user: {}", loginId);
+
+    private boolean authenticateUser(String token, HttpServletRequest request) {
+        if (!jwtUtil.validateToken(token)) {
+            log.warn("Invalid JWT token provided");
+            return false;
+        }
+
+        String loginId = jwtUtil.getUsernameFromToken(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        log.debug("Authentication successful for user: {}", loginId);
+        return true;
+    }
+
+    private void sendUnauthorizedError(HttpServletResponse response) throws IOException {
+        if (!response.isCommitted()) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or missing token");
         }
     }
 }

--- a/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import net.datasa.project01.service.UserDetailsServiceImpl;
 import net.datasa.project01.util.JwtUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -50,8 +49,8 @@ public class SecurityConfig {
                 )
                 // JWT 인증 필터 등록
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                // HTTP Basic 인증 활성화 (테스트용, 실제 서비스에서는 비활성화 권장)
-                .httpBasic(Customizer.withDefaults())
+                // 인증 실패 시 처리 핸들러 등록
+                .exceptionHandling(e -> e.authenticationEntryPoint(new JwtAuthenticationEntryPoint()))
                 // 폼 로그인 비활성화 (REST API 환경에서는 사용하지 않음)
                 .formLogin(form -> form.disable());
         // 최종 SecurityFilterChain 반환


### PR DESCRIPTION
## Summary
- log and reject requests with missing or invalid JWT tokens directly in the authentication filter
- register a custom authentication entry point that produces a JSON 401 response
- add a JwtAuthenticationEntryPoint implementation for consistent unauthorized messaging

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c90b1aafc08325abb38af428721547