### PR TITLE
Update matching flow for waiting and video chat

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,6 +12,7 @@ const routes = [
 
   { path: '/match',         name: 'match',         component: () => import('../views/MatchingSetup.vue'),  meta: { requiresAuth: true } },
   { path: '/match/result',  name: 'match-result',  component: () => import('../views/MatchingResult.vue'), meta: { requiresAuth: true } },
+  { path: '/match/video',   name: 'video-chat',    component: () => import('../views/VideoChat.vue'),     meta: { requiresAuth: true } },
   { path: '/chat',          name: 'chat',          component: () => import('../views/Chat.vue'),           meta: { requiresAuth: true } },
 
   { path: '/:pathMatch(.*)*', redirect: '/' },

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -1,50 +1,52 @@
 <template>
   <v-container class="py-10">
     <v-row justify="center">
-      <v-col cols="12" md="10">
-        <v-card class="pa-6">
-          <v-row class="align-center mb-6">
-            <v-avatar size="40" class="me-3">
-              <v-img :src="partnerAvatar" alt="avatar" />
-            </v-avatar>
-            <div>
-              <div class="text-h6 text-pink-darken-2">{{ partnerName }}님과 매칭되었습니다</div>
-              <div class="text-caption text-medium-emphasis">{{ sessionStatus }}</div>
-            </div>
-          </v-row>
+      <v-col cols="12" md="8">
+        <v-card class="pa-8 text-center" elevation="2">
+          <v-icon size="56" color="pink" class="mb-4">mdi-heart-outline</v-icon>
+          <div class="text-h5 text-pink-darken-2 mb-2">{{ statusTitle }}</div>
+          <div class="text-body-2 text-medium-emphasis mb-8">{{ statusDescription }}</div>
 
-          <v-row>
-            <v-col cols="12" md="9">
-              <v-img
-                v-if="mediaUrl"
-                :src="mediaUrl"
-                class="rounded-lg bg-grey-lighten-2 media-wrapper"
-                cover
-              >
-                <template #placeholder>
-                  <v-row class="fill-height ma-0" align="center" justify="center">
-                    <v-progress-circular indeterminate color="pink" />
-                  </v-row>
-                </template>
-              </v-img>
-              <div
-                v-else
-                class="rounded-lg bg-pink-lighten-5 d-flex align-center justify-center media-wrapper"
-              >
-                <div class="text-subtitle-1">매칭 이미지 / 영상이 없습니다.</div>
+          <transition name="fade">
+            <div v-if="isWaiting" key="waiting" class="d-flex flex-column align-center waiting-block">
+              <v-progress-circular indeterminate size="64" color="pink" class="mb-4" />
+              <div class="text-body-2 text-medium-emphasis">
+                새로운 인연을 찾는 중입니다. 잠시만 기다려 주세요.
               </div>
-            </v-col>
-            <v-col cols="12" md="3">
-              <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
-                <ChatPanel class="flex-grow-1" />
-              </v-card>
-            </v-col>
-          </v-row>
+            </div>
+          </transition>
 
-          <div class="d-flex justify-center gap-4 mt-6">
-            <v-btn color="pink" variant="tonal" @click="acceptMatch">수락</v-btn>
-            <v-btn color="grey" variant="outlined" @click="declineMatch">거절</v-btn>
+          <transition name="fade">
+            <div v-if="matchedUser" key="matched" class="matched-block">
+              <div class="text-h4 font-weight-medium mb-2">{{ matchedUser.nickname }}</div>
+              <div class="text-body-2 text-medium-emphasis">님과 연결되었습니다.</div>
+            </div>
+          </transition>
+
+          <div v-if="matchedUser" class="d-flex justify-center flex-wrap gap-4 mt-10">
+            <v-btn
+              color="pink"
+              size="large"
+              variant="flat"
+              :loading="actionLoading"
+              :disabled="actionLoading"
+              @click="acceptMatch"
+            >
+              수락
+            </v-btn>
+            <v-btn
+              color="grey"
+              variant="outlined"
+              size="large"
+              :loading="actionLoading"
+              :disabled="actionLoading"
+              @click="declineMatch"
+            >
+              거절
+            </v-btn>
           </div>
+
+          <div v-if="errorMessage" class="text-error text-body-2 mt-8">{{ errorMessage }}</div>
         </v-card>
       </v-col>
     </v-row>
@@ -52,33 +54,138 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import ChatPanel from '../components/ChatPanel.vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import api from '../services/api'
 
-const partnerName = ref('홍길동');
-const partnerAvatar = ref('https://via.placeholder.com/150');
-const sessionStatus = ref('대기 중');
-const mediaUrl = ref('https://via.placeholder.com/640x360');
+const router = useRouter()
+const route = useRoute()
 
-function acceptMatch() {
-  if (window.confirm('매칭을 수락하시겠습니까?')) {
-    // TODO: 매칭 수락 로직
+const matchedUser = ref(null)
+const isWaiting = ref(true)
+const errorMessage = ref('')
+const actionLoading = ref(false)
+const sessionId = ref(null)
+const pollerId = ref(null)
+
+const requestId = computed(() => route.query.requestId ?? null)
+
+const statusTitle = computed(() => (isWaiting.value ? '매칭 대기 중입니다' : '매칭이 완료되었어요'))
+
+const statusDescription = computed(() =>
+  isWaiting.value
+    ? '회원님의 조건에 맞는 상대를 찾고 있습니다.'
+    : '상대방과 연결하기 전에 매칭을 수락하거나 거절할 수 있습니다.'
+)
+
+function stopPolling() {
+  if (pollerId.value) {
+    clearInterval(pollerId.value)
+    pollerId.value = null
   }
 }
 
-function declineMatch() {
-  if (window.confirm('매칭을 거절하시겠습니까?')) {
-    // TODO: 매칭 거절 로직
+async function fetchMatchStatus() {
+  try {
+    const { data } = await api.get('/match/result', {
+      params: requestId.value ? { requestId: requestId.value } : undefined,
+    })
+
+    if (data?.status === 'MATCHED' && data?.partner) {
+      matchedUser.value = {
+        nickname: data.partner.nickname ?? '상대방',
+        userId: data.partner.userId ?? data.partner.id ?? null,
+      }
+      sessionId.value = data.sessionId ?? null
+      isWaiting.value = false
+      errorMessage.value = ''
+      stopPolling()
+    } else if (data?.status === 'WAITING') {
+      isWaiting.value = true
+      errorMessage.value = ''
+    } else if (data?.status === 'CANCELLED') {
+      isWaiting.value = false
+      errorMessage.value = '매칭이 취소되었어요. 다시 시도해 주세요.'
+      stopPolling()
+    }
+  } catch (error) {
+    console.error('failed to fetch match status', error)
+    if (!matchedUser.value) {
+      errorMessage.value = '매칭 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.'
+    }
   }
 }
+
+function startPolling() {
+  fetchMatchStatus()
+  pollerId.value = setInterval(fetchMatchStatus, 4000)
+}
+
+async function acceptMatch() {
+  if (!matchedUser.value) return
+  actionLoading.value = true
+  try {
+    await api.post('/match/accept', {
+      requestId: requestId.value,
+      partnerId: matchedUser.value.userId,
+    })
+  } catch (error) {
+    console.warn('failed to accept match', error)
+  } finally {
+    actionLoading.value = false
+  }
+
+  await router.push({
+    name: 'video-chat',
+    query: {
+      nickname: matchedUser.value.nickname,
+      sessionId: sessionId.value ?? undefined,
+    },
+  })
+}
+
+async function declineMatch() {
+  if (!matchedUser.value) return
+  actionLoading.value = true
+  try {
+    await api.post('/match/decline', {
+      requestId: requestId.value,
+      partnerId: matchedUser.value.userId,
+    })
+  } catch (error) {
+    console.warn('failed to decline match', error)
+  } finally {
+    actionLoading.value = false
+  }
+
+  await router.push({ name: 'match' })
+}
+
+onMounted(() => {
+  startPolling()
+})
+
+onBeforeUnmount(() => {
+  stopPolling()
+})
 </script>
 
 <style scoped>
-.media-wrapper {
-  max-height: 380px;
+.waiting-block {
+  min-height: 120px;
 }
 
-.chat-wrapper {
-  max-height: 380px;
+.matched-block {
+  min-height: 80px;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/views/MatchingSetup.vue
+++ b/frontend/src/views/MatchingSetup.vue
@@ -137,10 +137,13 @@ async function startMatch(){
     interests_json: interests.value,
   }
   try{
-    // await api.post('/match/requests', payload)
-    router.push('/match/result')
+    const { data } = await api.post('/match/requests', payload)
+    const query = data?.requestId ? { requestId: data.requestId } : {}
+    await router.push({ name: 'match-result', query })
   }catch(e){
+    console.error('failed to start match request', e)
     alert('매칭 실패: ' + (e?.response?.data?.message || e.message))
+    await router.push({ name: 'match-result' })
   }finally{
     loading.value = false
   }

--- a/frontend/src/views/VideoChat.vue
+++ b/frontend/src/views/VideoChat.vue
@@ -1,0 +1,94 @@
+<template>
+  <v-container class="py-10">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="8">
+        <v-card class="pa-8 video-chat-card" elevation="2">
+          <div class="d-flex flex-column align-center text-center">
+            <v-icon size="64" color="pink" class="mb-4">mdi-video-wireless</v-icon>
+            <div class="text-h5 text-pink-darken-2 mb-2">영상 채팅 대기 중</div>
+            <div class="text-body-2 text-medium-emphasis mb-6">
+              {{ partnerHeadline }}
+            </div>
+
+            <div class="video-stage d-flex flex-column flex-md-row justify-center ga-4 mb-8">
+              <div class="video-frame remote d-flex flex-column align-center justify-center">
+                <v-icon size="48" color="grey-lighten-2">mdi-account-circle-outline</v-icon>
+                <div class="text-caption mt-2">상대 영상</div>
+              </div>
+              <div class="video-frame local d-flex flex-column align-center justify-center">
+                <v-icon size="48" color="grey-lighten-1">mdi-account</v-icon>
+                <div class="text-caption mt-2">내 영상</div>
+              </div>
+            </div>
+
+            <div class="d-flex flex-wrap justify-center ga-4">
+              <v-btn color="error" variant="tonal" size="large" @click="endCall">
+                통화 종료
+              </v-btn>
+              <v-btn color="grey" variant="outlined" size="large" @click="returnToHome">
+                나가기
+              </v-btn>
+            </div>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+const partnerHeadline = computed(() => {
+  const nickname = route.query.nickname
+  if (nickname) {
+    return `${nickname}님과 연결 준비 중입니다. 통화를 시작해보세요!`
+  }
+  return '상대방과 연결을 준비하고 있습니다. 잠시만 기다려 주세요.'
+})
+
+async function endCall() {
+  await router.push({ name: 'chat' })
+}
+
+async function returnToHome() {
+  await router.push({ name: 'home' })
+}
+</script>
+
+<style scoped>
+.video-chat-card {
+  border-radius: 16px;
+}
+
+.video-stage {
+  width: 100%;
+}
+
+.video-frame {
+  flex: 1 1 280px;
+  min-height: 220px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 192, 203, 0.2), rgba(255, 192, 203, 0.05));
+  border: 1px dashed rgba(255, 105, 180, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.video-frame.remote:hover,
+.video-frame.local:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 28px rgba(255, 182, 193, 0.35);
+}
+
+.video-frame.remote {
+  background: linear-gradient(135deg, rgba(255, 240, 245, 0.9), rgba(255, 228, 225, 0.8));
+}
+
+.video-frame.local {
+  background: linear-gradient(135deg, rgba(255, 235, 238, 0.9), rgba(255, 205, 210, 0.8));
+}
+</style>


### PR DESCRIPTION
## Summary
- streamline the matching result screen to show a waiting state, reveal the matched nickname, and provide accept/decline actions
- hook the matching setup flow into the new result screen, including API calls and routing to a dedicated video chat route
- add a placeholder video chat view with basic layout and navigation helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c916f34a7c8325954a66df836ec19f