### PR TITLE
Update matching flow UI and add video chat page

### DIFF
--- a/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class MatchFoundResponseDto {
     private Long roomId;
     private String partnerNickName;
+    private String partnerLoginId;
     // 향후 파트너의 프로필 사진, 관심사 등 추가 정보 포함 가능
 }

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -90,8 +90,16 @@ public class MatchService {
             Room privateRoom = chatService.createPrivateRoom(me, opponent);
 
             // 양쪽 사용자에게 매칭 성공 알림 전송 (웹소켓)
-            MatchFoundResponseDto myResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), opponent.getNickName());
-            MatchFoundResponseDto opponentResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), me.getNickName());
+            MatchFoundResponseDto myResponse = new MatchFoundResponseDto(
+                    privateRoom.getRoomId(),
+                    opponent.getNickName(),
+                    opponent.getLoginId()
+            );
+            MatchFoundResponseDto opponentResponse = new MatchFoundResponseDto(
+                    privateRoom.getRoomId(),
+                    me.getNickName(),
+                    me.getLoginId()
+            );
 
             messagingTemplate.convertAndSendToUser(me.getLoginId(), "/queue/match-results", myResponse);
             messagingTemplate.convertAndSendToUser(opponent.getLoginId(), "/queue/match-results", opponentResponse);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,6 +12,7 @@ const routes = [
 
   { path: '/match',         name: 'match',         component: () => import('../views/MatchingSetup.vue'),  meta: { requiresAuth: true } },
   { path: '/match/result',  name: 'match-result',  component: () => import('../views/MatchingResult.vue'), meta: { requiresAuth: true } },
+  { path: '/match/video/:roomId', name: 'match-video', component: () => import('../views/MatchVideoChat.vue'), meta: { requiresAuth: true } },
   { path: '/chat',          name: 'chat',          component: () => import('../views/Chat.vue'),           meta: { requiresAuth: true } },
 
   { path: '/rtc-test',      name: 'rtc-test',      component: () => import('../views/RtcTest.vue'),       meta: { requiresAuth: true } },

--- a/frontend/src/views/MatchVideoChat.vue
+++ b/frontend/src/views/MatchVideoChat.vue
@@ -1,0 +1,358 @@
+<template>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="8">
+        <v-card class="pa-4">
+          <div class="header-row mb-4">
+            <div>
+              <div class="text-h6 text-pink-darken-2">영상 채팅</div>
+              <div class="text-caption text-medium-emphasis">
+                {{ partnerNickname ? `${partnerNickname}님과 연결 중` : '상대방을 기다리는 중입니다' }}
+              </div>
+            </div>
+            <v-btn color="grey" variant="tonal" @click="leaveCall">나가기</v-btn>
+          </div>
+
+          <v-alert
+            v-if="connectionError"
+            type="error"
+            variant="tonal"
+            class="mb-4"
+          >
+            {{ connectionError }}
+          </v-alert>
+
+          <div class="video-stage mb-4">
+            <video ref="remoteVideo" autoplay playsinline class="remote-video bg-grey-lighten-3"></video>
+            <video ref="localVideo" autoplay muted playsinline class="local-video bg-grey-lighten-1"></video>
+            <div v-if="connecting && !connectionError" class="video-overlay d-flex align-center justify-center">
+              <v-progress-circular indeterminate color="pink" size="56" />
+            </div>
+          </div>
+
+          <div class="control-buttons" v-if="!connectionError">
+            <v-btn
+              color="pink"
+              variant="flat"
+              @click="toggleMute"
+              :prepend-icon="muted ? 'mdi-microphone-off' : 'mdi-microphone'"
+            >
+              {{ muted ? '음소거 해제' : '음소거' }}
+            </v-btn>
+            <v-btn
+              color="pink"
+              variant="flat"
+              @click="toggleCamera"
+              :prepend-icon="cameraOff ? 'mdi-video-off' : 'mdi-video'"
+            >
+              {{ cameraOff ? '카메라 켜기' : '카메라 끄기' }}
+            </v-btn>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+import { createStompClient } from '../services/ws'
+import { setupSignalRoutes } from '../services/signaling'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const roomId = computed(() => Number(route.params.roomId || 0))
+const partnerNickname = ref(route.query.partnerNickname || '')
+const partnerLoginId = ref(route.query.partnerLoginId || '')
+
+const localVideo = ref(null)
+const remoteVideo = ref(null)
+const connectionError = ref('')
+const connecting = ref(true)
+const muted = ref(false)
+const cameraOff = ref(false)
+
+const myLoginId = computed(() => auth.user?.loginId || '')
+const shouldInitiate = computed(() => {
+  if (!myLoginId.value || !partnerLoginId.value) return false
+  return myLoginId.value.localeCompare(partnerLoginId.value) < 0
+})
+
+let client = null
+let signal = null
+let pc = null
+let localStream = null
+let hasSentOffer = false
+
+function ensureValidRoute() {
+  if (!roomId.value) {
+    connectionError.value = '유효하지 않은 방 정보입니다.'
+    connecting.value = false
+    return false
+  }
+  return true
+}
+
+async function preparePeerConnection() {
+  pc = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+  })
+
+  pc.ontrack = (event) => {
+    if (remoteVideo.value) {
+      remoteVideo.value.srcObject = event.streams[0]
+    }
+  }
+
+  pc.onicecandidate = (event) => {
+    if (event.candidate && partnerLoginId.value && signal) {
+      signal.sendSignal({
+        type: 'ice-candidate',
+        receiverLoginId: partnerLoginId.value,
+        data: event.candidate,
+      })
+    }
+  }
+}
+
+async function acquireMedia() {
+  try {
+    localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+    localStream.getTracks().forEach((track) => pc.addTrack(track, localStream))
+    if (localVideo.value) {
+      localVideo.value.srcObject = localStream
+    }
+  } catch (err) {
+    console.error('Failed to acquire media devices', err)
+    connectionError.value = '카메라 또는 마이크에 접근할 수 없습니다.'
+    connecting.value = false
+    throw err
+  }
+}
+
+async function createOffer() {
+  if (!pc || !signal || !partnerLoginId.value || hasSentOffer) return
+  try {
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+    signal.sendSignal({
+      type: 'offer',
+      receiverLoginId: partnerLoginId.value,
+      data: offer,
+    })
+    hasSentOffer = true
+  } catch (err) {
+    console.error('Failed to create or send offer', err)
+  }
+}
+
+async function handleSignalMessage(payload) {
+  if (!pc || !payload || payload.senderLoginId === myLoginId.value) {
+    return
+  }
+
+  if (!partnerLoginId.value) {
+    partnerLoginId.value = payload.senderLoginId || partnerLoginId.value
+  }
+
+  if (payload.type === 'offer') {
+    try {
+      await pc.setRemoteDescription(payload.data)
+      const answer = await pc.createAnswer()
+      await pc.setLocalDescription(answer)
+      signal.sendSignal({
+        type: 'answer',
+        receiverLoginId: payload.senderLoginId,
+        data: answer,
+      })
+    } catch (err) {
+      console.error('Failed to process offer', err)
+    }
+  } else if (payload.type === 'answer') {
+    try {
+      await pc.setRemoteDescription(payload.data)
+    } catch (err) {
+      console.error('Failed to process answer', err)
+    }
+  } else if (payload.type === 'ice-candidate') {
+    try {
+      await pc.addIceCandidate(payload.data)
+    } catch (err) {
+      console.warn('Failed to add ICE candidate', err)
+    }
+  }
+}
+
+function startStomp() {
+  client = createStompClient(auth.token)
+
+  client.onConnect = async () => {
+    connecting.value = false
+
+    signal = setupSignalRoutes(client, {
+      me: myLoginId.value,
+      subscribeDest: '/user/queue/signals',
+      onSignal: handleSignalMessage,
+    })
+
+    if (shouldInitiate.value) {
+      await createOffer()
+    }
+  }
+
+  client.onStompError = (frame) => {
+    console.error('STOMP error', frame.headers, frame.body)
+    connectionError.value =
+      frame.headers?.message || '시그널 서버와 통신하는 중 오류가 발생했습니다.'
+    connecting.value = false
+  }
+
+  client.onWebSocketError = (event) => {
+    console.error('WebSocket error', event)
+    connectionError.value = '시그널 서버와 연결할 수 없습니다.'
+    connecting.value = false
+  }
+
+  client.activate()
+}
+
+async function setupCall() {
+  if (!auth.isAuthenticated) {
+    router.replace({ name: 'login', query: { redirect: route.fullPath } })
+    return
+  }
+
+  if (!ensureValidRoute()) {
+    return
+  }
+
+  await nextTick()
+  await preparePeerConnection()
+  await acquireMedia()
+  startStomp()
+}
+
+function toggleMute() {
+  if (!localStream) return
+  muted.value = !muted.value
+  localStream.getAudioTracks().forEach((track) => {
+    track.enabled = !muted.value
+  })
+}
+
+function toggleCamera() {
+  if (!localStream) return
+  cameraOff.value = !cameraOff.value
+  localStream.getVideoTracks().forEach((track) => {
+    track.enabled = !cameraOff.value
+  })
+}
+
+function stopMedia() {
+  if (localStream) {
+    localStream.getTracks().forEach((track) => track.stop())
+    localStream = null
+  }
+}
+
+function cleanupConnections() {
+  try {
+    signal?.sub?.unsubscribe?.()
+  } catch (err) {
+    console.warn('Failed to unsubscribe from signaling channel', err)
+  }
+  try {
+    client?.deactivate?.()
+  } catch (err) {
+    console.warn('Failed to deactivate STOMP client', err)
+  }
+  try {
+    pc?.close?.()
+  } catch (err) {
+    console.warn('Failed to close peer connection', err)
+  }
+  stopMedia()
+}
+
+function leaveCall() {
+  cleanupConnections()
+  router.replace({ name: 'match' })
+}
+
+onMounted(() => {
+  setupCall().catch((err) => {
+    console.error('Failed to start call', err)
+    cleanupConnections()
+  })
+})
+
+onBeforeUnmount(() => {
+  cleanupConnections()
+})
+
+watch(partnerLoginId, (value) => {
+  if (value && client?.connected && shouldInitiate.value) {
+    createOffer()
+  }
+})
+</script>
+
+<style scoped>
+.video-stage {
+  position: relative;
+  width: 100%;
+  min-height: 320px;
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.remote-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.local-video {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: 30%;
+  max-width: 220px;
+  border: 2px solid white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  object-fit: cover;
+}
+
+.video-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.control-buttons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .local-video {
+    width: 40%;
+  }
+}
+</style>

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -1,49 +1,67 @@
 <template>
   <v-container class="py-10">
     <v-row justify="center">
-      <v-col cols="12" md="10">
-        <v-card class="pa-6">
-          <v-row class="align-center mb-6">
-            <v-avatar size="40" class="me-3">
-              <v-img :src="partnerAvatar" alt="avatar" />
-            </v-avatar>
-            <div>
-              <div class="text-h6 text-pink-darken-2">{{ partnerName }}님과 매칭되었습니다</div>
-              <div class="text-caption text-medium-emphasis">{{ sessionStatus }}</div>
+      <v-col cols="12" md="8" lg="6">
+        <v-card class="pa-8 text-center">
+          <div class="text-h5 text-pink-darken-2 mb-4">랜덤 매칭 진행 중</div>
+
+          <v-alert
+            v-if="errorMessage"
+            type="error"
+            variant="tonal"
+            class="mb-6 text-start"
+          >
+            {{ errorMessage }}
+          </v-alert>
+
+          <div v-if="isWaiting && !errorMessage" class="py-8">
+            <v-progress-circular indeterminate color="pink" size="56" class="mb-4" />
+            <div class="text-subtitle-1 text-medium-emphasis">
+              매칭 가능한 상대를 찾는 중입니다...
             </div>
-          </v-row>
+          </div>
 
-          <v-row>
-            <v-col cols="12" md="9">
-              <v-img
-                v-if="mediaUrl"
-                :src="mediaUrl"
-                class="rounded-lg bg-grey-lighten-2 media-wrapper"
-                cover
-              >
-                <template #placeholder>
-                  <v-row class="fill-height ma-0" align="center" justify="center">
-                    <v-progress-circular indeterminate color="pink" />
-                  </v-row>
-                </template>
-              </v-img>
-              <div
-                v-else
-                class="rounded-lg bg-pink-lighten-5 d-flex align-center justify-center media-wrapper"
-              >
-                <div class="text-subtitle-1">매칭 이미지 / 영상이 없습니다.</div>
-              </div>
-            </v-col>
-            <v-col cols="12" md="3">
-                <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
-                  <ChatPanel class="flex-grow-1" :partner="partnerName" />
-                </v-card>
-            </v-col>
-          </v-row>
+          <div v-else-if="!isWaiting && !errorMessage" class="py-6">
+            <div class="text-h6 text-pink-darken-2 mb-2">
+              {{ partnerNickname }}님과 매칭되었어요!
+            </div>
+            <div class="text-body-2 text-medium-emphasis mb-6">
+              지금 바로 영상 채팅을 시작해보세요.
+            </div>
 
-          <div class="d-flex justify-center gap-4 mt-6">
-            <v-btn color="pink" variant="tonal" @click="acceptMatch">수락</v-btn>
-            <v-btn color="grey" variant="outlined" @click="declineMatch">거절</v-btn>
+            <div class="action-buttons">
+              <v-btn
+                color="pink"
+                size="large"
+                variant="flat"
+                :disabled="!roomId"
+                @click="acceptMatch"
+              >
+                수락
+              </v-btn>
+              <v-btn
+                color="grey"
+                size="large"
+                variant="outlined"
+                @click="declineMatch"
+              >
+                거절
+              </v-btn>
+            </div>
+          </div>
+
+          <div v-else-if="errorMessage" class="py-6">
+            <div class="text-body-2 text-medium-emphasis">
+              문제가 계속되면 잠시 후 다시 시도해주세요.
+            </div>
+            <v-btn
+              class="mt-4"
+              color="pink"
+              variant="tonal"
+              @click="returnToMatch"
+            >
+              매칭 조건 다시 선택
+            </v-btn>
           </div>
         </v-card>
       </v-col>
@@ -51,113 +69,138 @@
   </v-container>
 </template>
 
-<!--script setup>
-import { ref } from 'vue';
-import ChatPanel from '../components/ChatPanel.vue';
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+import { createStompClient } from '../services/ws'
 
-const partnerName = ref('홍길동');
-const partnerAvatar = ref('https://via.placeholder.com/150');
-const sessionStatus = ref('대기 중');
-const mediaUrl = ref('https://via.placeholder.com/640x360');
+const router = useRouter()
+const auth = useAuthStore()
+
+const isWaiting = ref(true)
+const partnerNickname = ref('')
+const partnerLoginId = ref('')
+const roomId = ref(null)
+const errorMessage = ref('')
+
+let client = null
+let subscription = null
+
+function goToLogin() {
+  router.replace({
+    name: 'login',
+    query: { redirect: router.currentRoute.value.fullPath },
+  })
+}
+
+function handleMatchMessage(message) {
+  try {
+    const payload = JSON.parse(message.body || '{}')
+    partnerNickname.value = payload.partnerNickName ?? ''
+    partnerLoginId.value = payload.partnerLoginId ?? ''
+    roomId.value = payload.roomId ?? null
+
+    if (!roomId.value || !partnerNickname.value) {
+      throw new Error('Incomplete match information')
+    }
+
+    isWaiting.value = false
+
+    try {
+      subscription?.unsubscribe?.()
+      subscription = null
+    } catch (unsubError) {
+      console.warn('Failed to unsubscribe from match queue after receiving result', unsubError)
+    }
+  } catch (err) {
+    console.error('Failed to process match result message:', err)
+    errorMessage.value = '매칭 결과를 불러오는 중 오류가 발생했습니다.'
+    isWaiting.value = false
+  }
+}
+
+function setupStomp() {
+  client = createStompClient(auth.token)
+
+  client.onConnect = () => {
+    subscription = client.subscribe('/user/queue/match-results', handleMatchMessage)
+  }
+
+  client.onWebSocketError = (event) => {
+    console.error('WebSocket error', event)
+    errorMessage.value = '매칭 서버와 연결할 수 없습니다.'
+    isWaiting.value = false
+  }
+
+  client.onStompError = (frame) => {
+    console.error('STOMP error', frame.headers, frame.body)
+    errorMessage.value =
+      frame.headers?.message || '매칭 서버에서 오류가 발생했습니다.'
+    isWaiting.value = false
+  }
+
+  client.activate()
+}
 
 function acceptMatch() {
-  if (window.confirm('매칭을 수락하시겠습니까?')) {
-    // TODO: 매칭 수락 로직
+  if (!roomId.value) {
+    return
   }
+
+  if (!partnerLoginId.value) {
+    alert('상대방 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.')
+    return
+  }
+
+  router.push({
+    name: 'match-video',
+    params: { roomId: String(roomId.value) },
+    query: {
+      partnerNickname: partnerNickname.value,
+      partnerLoginId: partnerLoginId.value,
+    },
+  })
 }
 
 function declineMatch() {
-  if (window.confirm('매칭을 거절하시겠습니까?')) {
-    // TODO: 매칭 거절 로직
+  if (window.confirm('매칭을 거절하시겠습니까? 다시 조건을 선택할 수 있습니다.')) {
+    router.replace({ name: 'match' })
   }
 }
-</script-->
 
-<script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
-import { createStompClient } from '../services/ws'
-import { setupSignalRoutes } from '../services/signaling'
-import { useAuthStore } from '../stores/auth'
-// import { setupChat } ...
+function returnToMatch() {
+  router.replace({ name: 'match' })
+}
 
-  const me = ref(/* 로그인한 사용자 loginId */)
-  const partner = ref(/* 매칭된 상대 loginId */)
-  const partnerName = ref('홍길동')
-  const partnerAvatar = ref('https://via.placeholder.com/150')
-  const sessionStatus = ref('대기 중')
-  const mediaUrl = ref('')
-  const pc = new RTCPeerConnection({
-  iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
-})
-const localVideo = ref(null)
-const remoteVideo = ref(null)
-const auth = useAuthStore()
-let client, signal, subs = []
-
-onMounted(async () => {
-  // 1) STOMP 연결
-  client = createStompClient(auth.token)
-  client.onConnect = async () => {
-    // 2) 시그널 구독
-    signal = setupSignalRoutes(client, {
-      me: me.value,
-      subscribeDest: `/topic/signal.${me.value}`, // 컨트롤러 전송 목적지와 일치시킬 것
-      onSignal: async (msg) => {
-        if (msg.type === 'offer') {
-          await pc.setRemoteDescription(msg.data)
-          const answer = await pc.createAnswer()
-          await pc.setLocalDescription(answer)
-          signal.sendSignal({ type:'answer', senderLoginId: me.value, receiverLoginId: partner.value, data: answer })
-        } else if (msg.type === 'answer') {
-          await pc.setRemoteDescription(msg.data)
-        } else if (msg.type === 'ice-candidate') {
-          try { await pc.addIceCandidate(msg.data) } catch {}
-        }
-      }
-    })
-
-    // 3) 미디어
-    const stream = await navigator.mediaDevices.getUserMedia({ video:true, audio:true })
-    stream.getTracks().forEach(t => pc.addTrack(t, stream))
-    localVideo.value.srcObject = stream
-
-    pc.ontrack = (e) => {
-      remoteVideo.value.srcObject = e.streams[0]
-    }
-    pc.onicecandidate = (e) => {
-      if (e.candidate) {
-        signal.sendSignal({
-          type:'ice-candidate',
-          senderLoginId: me.value,
-          receiverLoginId: partner.value,
-          data: e.candidate
-        })
-      }
-    }
-
-    // 4) 내가 발신자라면 Offer 생성
-    // (역할은 매칭 API 결과에 따라 결정)
-    const offer = await pc.createOffer()
-    await pc.setLocalDescription(offer)
-    signal.sendSignal({ type:'offer', senderLoginId: me.value, receiverLoginId: partner.value, data: offer })
+onMounted(() => {
+  if (!auth.isAuthenticated) {
+    goToLogin()
+    return
   }
-  client.activate()
+
+  setupStomp()
 })
 
 onBeforeUnmount(() => {
-  subs.forEach(s => s?.unsubscribe?.())
-  client?.deactivate?.()
-  pc?.close?.()
+  try {
+    subscription?.unsubscribe?.()
+  } catch (e) {
+    console.warn('Failed to unsubscribe from match result queue', e)
+  }
+  try {
+    client?.deactivate?.()
+  } catch (e) {
+    console.warn('Failed to deactivate STOMP client', e)
+  }
 })
 </script>
 
-
 <style scoped>
-.media-wrapper {
-  max-height: 380px;
-}
-
-.chat-wrapper {
-  max-height: 380px;
+.action-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
 }
 </style>


### PR DESCRIPTION
## Summary
- replace the matching result layout with a waiting-first flow that listens to `/user/queue/match-results` and removes unused media/chat sections
- extend the match result payload to include the partner login id and route accepted matches to a new dedicated video chat view
- add a MatchVideoChat page that boots STOMP/WebRTC signaling, basic media controls, and a protected router entry

## Testing
- npm run build
- ./gradlew test *(fails: missing Java 17 toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c91c85b0f08325af02ec82369449e2