### PR TITLE
Implement random and group chat requirements

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -35,7 +35,12 @@ public class SecurityConfig {
     };
 
     private static final String[] PROTECTED_ENDPOINTS = {
-            "/api/match/**"
+            "/api/match/**",
+            "/api/rooms/**",
+            "/api/chat/**",
+            "/api/follows/**",
+            "/api/vocabulary/**",
+            "/api/translate/**"
     };
 
     /**

--- a/backend/src/main/java/net/datasa/project01/config/WebConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebConfig.java
@@ -2,6 +2,7 @@ package net.datasa.project01.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
@@ -16,5 +17,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns("https://*.ngrok-free.app","http://localhost:*")
                 .allowedMethods("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:uploads/");
     }
 }

--- a/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
@@ -26,10 +26,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final StompHandler stompHandler;
     private final StompInboundLoggingInterceptor stompInboundLoggingInterceptor;
 
-    private static final int INBOUND_CORE_POOL_SIZE = 4;
-    private static final int INBOUND_MAX_POOL_SIZE = 16;
-    private static final int INBOUND_QUEUE_CAPACITY = 200;
-    private static final int INBOUND_KEEP_ALIVE_SECONDS = 60;
+    private static final int INBOUND_CORE_POOL_SIZE = 8;
+    private static final int INBOUND_MAX_POOL_SIZE = 32;
+    private static final int INBOUND_QUEUE_CAPACITY = 1000;
+    private static final int INBOUND_KEEP_ALIVE_SECONDS = 120;
 
     @PostConstruct
     public void init() {

--- a/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -1,32 +1,88 @@
 package net.datasa.project01.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.ChatMessagePageResponseDto;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.dto.RoomCreateResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.service.ChatService;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/rooms")
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class ChatController {
 
     private final ChatService chatService;
 
     @PostMapping
-    public ResponseEntity<RoomCreateResponseDto> createGroupRoom() {
-        try {
-            Room createdRoom = chatService.createGroupRoom();
-            RoomCreateResponseDto responseDto = RoomCreateResponseDto.fromEntity(createdRoom);
-            log.info("Group room created successfully with ID: {}", createdRoom.getRoomId());
-            return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
-        } catch (Exception e) {
-            log.error("Error creating group room", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+    public ResponseEntity<RoomCreateResponseDto> createGroupRoom(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        Room room = chatService.createGroupRoom(requireUser(userDetails));
+        return ResponseEntity.ok(RoomCreateResponseDto.fromEntity(room));
     }
+
+    @PostMapping("/private")
+    public ResponseEntity<RoomCreateResponseDto> createPrivateRoom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid PrivateRoomRequest request) {
+
+        Room room = chatService.getOrCreatePrivateRoom(requireUser(userDetails), request.targetLoginId());
+        return ResponseEntity.ok(RoomCreateResponseDto.fromEntity(room));
+    }
+
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<ChatMessagePageResponseDto> getMessages(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "30") int size) {
+
+        return ResponseEntity.ok(chatService.getMessages(roomId, requireUser(userDetails), page, size));
+    }
+
+    @PostMapping(value = "/{roomId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageResponseDto> uploadFile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestPart("file") MultipartFile file) {
+
+        ChatMessageResponseDto response = chatService.saveFileMessage(roomId, file, requireUser(userDetails));
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{roomId}/invite")
+    public ResponseEntity<Void> invite(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestBody InviteRequest request) {
+
+        chatService.inviteMembers(roomId, requireUser(userDetails), request.targets());
+        return ResponseEntity.ok().build();
+    }
+
+    private String requireUser(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new IllegalStateException("인증 정보가 필요합니다.");
+        }
+        return userDetails.getUsername();
+    }
+
+    public record PrivateRoomRequest(@NotBlank String targetLoginId) { }
+
+    public record InviteRequest(List<@NotBlank String> targets) { }
 }

--- a/backend/src/main/java/net/datasa/project01/controller/FollowController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/FollowController.java
@@ -1,0 +1,58 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.service.FollowService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+@Slf4j
+@Validated
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/{targetLoginId}")
+    public ResponseEntity<FollowResponseDto> follow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable @NotBlank String targetLoginId) {
+
+        String loginId = requireUser(userDetails);
+        return ResponseEntity.ok(followService.follow(loginId, targetLoginId));
+    }
+
+    @DeleteMapping("/{targetLoginId}")
+    public ResponseEntity<Void> unfollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable @NotBlank String targetLoginId) {
+
+        String loginId = requireUser(userDetails);
+        followService.unfollow(loginId, targetLoginId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FollowResponseDto>> getFollowing(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String loginId = requireUser(userDetails);
+        return ResponseEntity.ok(followService.getFollowing(loginId));
+    }
+
+    private String requireUser(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new IllegalStateException("인증 정보가 필요합니다.");
+        }
+        return userDetails.getUsername();
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/controller/TranslationController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/TranslationController.java
@@ -1,0 +1,45 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.TranslationRequestDto;
+import net.datasa.project01.domain.dto.TranslationResponseDto;
+import net.datasa.project01.service.TranslationService;
+import net.datasa.project01.service.VocabularyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/translate")
+@RequiredArgsConstructor
+public class TranslationController {
+
+    private final TranslationService translationService;
+    private final VocabularyService vocabularyService;
+
+    @PostMapping
+    public ResponseEntity<TranslationResponseDto> translate(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TranslationRequestDto requestDto) {
+
+        String translated = translationService.translate(
+                requestDto.getText(),
+                requestDto.getSourceLang(),
+                requestDto.getTargetLang()
+        );
+
+        boolean saved = false;
+        if (requestDto.isSave() && userDetails != null) {
+            vocabularyService.addWord(
+                    userDetails.getUsername(),
+                    requestDto.getText(),
+                    translated
+            );
+            saved = true;
+        }
+
+        return ResponseEntity.ok(new TranslationResponseDto(translated, saved));
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/controller/VocabularyController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/VocabularyController.java
@@ -1,0 +1,52 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.VocabularyEntryResponseDto;
+import net.datasa.project01.service.VocabularyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/vocabulary")
+@RequiredArgsConstructor
+@Validated
+public class VocabularyController {
+
+    private final VocabularyService vocabularyService;
+
+    @GetMapping
+    public ResponseEntity<List<VocabularyEntryResponseDto>> list(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(vocabularyService.list(requireUser(userDetails)));
+    }
+
+    @PostMapping
+    public ResponseEntity<VocabularyEntryResponseDto> add(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid VocabularySaveRequest request) {
+
+        return ResponseEntity.ok(
+                vocabularyService.addWord(requireUser(userDetails), request.getOriginal(), request.getTranslated())
+        );
+    }
+
+    private String requireUser(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new IllegalStateException("인증 정보가 필요합니다.");
+        }
+        return userDetails.getUsername();
+    }
+
+    public record VocabularySaveRequest(
+            @NotBlank String original,
+            @NotBlank String translated
+    ) {
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessagePageResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessagePageResponseDto.java
@@ -1,0 +1,14 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessagePageResponseDto {
+
+    private final List<ChatMessageResponseDto> messages;
+    private final boolean hasMore;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageRequestDto.java
@@ -11,4 +11,9 @@ public class ChatMessageRequestDto {
      */
     private Long roomId;        // 메시지를 보낼 방
     private String content;     // 메시지 내용
+    private String contentType; // TEXT, IMAGE, FILE
+    private String fileName;
+    private String fileUrl;
+    private String mimeType;
+    private Long sizeBytes;
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -1,15 +1,39 @@
 package net.datasa.project01.domain.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import net.datasa.project01.domain.entity.RoomMessage;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class ChatMessageResponseDto {
+    private Long messageId;
     private Long roomId;
+    private String senderLoginId;
     private String senderNickName;
+    private RoomMessage.ContentType contentType;
     private String content;
+    private String fileName;
+    private String fileUrl;
+    private String mimeType;
+    private Long sizeBytes;
     private LocalDateTime sentAt;
+
+    public static ChatMessageResponseDto from(RoomMessage message) {
+        return ChatMessageResponseDto.builder()
+                .messageId(message.getMessageId())
+                .roomId(message.getRoom().getRoomId())
+                .senderLoginId(message.getSender() != null ? message.getSender().getLoginId() : null)
+                .senderNickName(message.getSender() != null ? message.getSender().getNickName() : "시스템")
+                .contentType(message.getContentType())
+                .content(message.getTextContent())
+                .fileName(message.getFileName())
+                .fileUrl(message.getFilePath())
+                .mimeType(message.getMimeType())
+                .sizeBytes(message.getSizeBytes())
+                .sentAt(message.getCreatedAt())
+                .build();
+    }
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
@@ -1,0 +1,17 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.datasa.project01.domain.entity.User;
+
+@Getter
+@AllArgsConstructor
+public class FollowResponseDto {
+
+    private final String loginId;
+    private final String nickName;
+
+    public static FollowResponseDto fromUser(User user) {
+        return new FollowResponseDto(user.getLoginId(), user.getNickName());
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/TranslationRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/TranslationRequestDto.java
@@ -1,0 +1,20 @@
+package net.datasa.project01.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TranslationRequestDto {
+
+    @NotBlank
+    private String text;
+
+    private String sourceLang = "auto";
+
+    @NotBlank
+    private String targetLang;
+
+    private boolean save;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
@@ -1,0 +1,13 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TranslationResponseDto {
+
+    private final String translatedText;
+
+    private final boolean saved;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/VocabularyEntryResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/VocabularyEntryResponseDto.java
@@ -1,0 +1,26 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.datasa.project01.domain.entity.VocabularyEntry;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class VocabularyEntryResponseDto {
+
+    private final Long id;
+    private final String originalText;
+    private final String translatedText;
+    private final LocalDateTime savedAt;
+
+    public static VocabularyEntryResponseDto from(VocabularyEntry entry) {
+        return new VocabularyEntryResponseDto(
+                entry.getId(),
+                entry.getOriginalText(),
+                entry.getTranslatedText(),
+                entry.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/Follow.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/Follow.java
@@ -1,0 +1,56 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "follows")
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "followee_id", nullable = false)
+    private User followee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 10, nullable = false)
+    private Status status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        REJECTED
+    }
+
+    public void accept() {
+        this.status = Status.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = Status.REJECTED;
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/VocabularyEntry.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/VocabularyEntry.java
@@ -1,0 +1,35 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "vocabulary_entries")
+public class VocabularyEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "entry_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_pid", nullable = false)
+    private User user;
+
+    @Column(name = "original_text", nullable = false, length = 500)
+    private String originalText;
+
+    @Column(name = "translated_text", nullable = false, length = 500)
+    private String translatedText;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
@@ -1,0 +1,17 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
+
+    List<Follow> findByFollowerAndStatus(User follower, Follow.Status status);
+
+    List<Follow> findByFolloweeAndStatus(User followee, Follow.Status status);
+}

--- a/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
@@ -1,11 +1,30 @@
 package net.datasa.project01.repository;
 
+import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.RoomMember;
 import net.datasa.project01.domain.entity.RoomMemberId;
+import net.datasa.project01.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 // JpaRepository의 두 번째 제네릭 타입으로 엔티티의 ID 클래스인 'RoomMemberId'를 지정
 public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemberId> {
-    // 예시: 특정 방의 모든 참여자를 찾는 커스텀 메소드
-    // List<RoomMember> findByRoom(Room room);
+    List<RoomMember> findByRoomAndLeftAtIsNull(Room room);
+
+    boolean existsByRoomAndUserAndLeftAtIsNull(Room room, User user);
+
+    long countByRoomAndLeftAtIsNull(Room room);
+
+    @Query("SELECT rm.room FROM RoomMember rm " +
+            "WHERE rm.user = :user1 " +
+            "AND rm.room.roomType = :roomType " +
+            "AND rm.leftAt IS NULL " +
+            "AND EXISTS (SELECT 1 FROM RoomMember rm2 WHERE rm2.room = rm.room AND rm2.user = :user2 AND rm2.leftAt IS NULL)")
+    Optional<Room> findActiveSharedRoom(@Param("user1") User user1,
+                                        @Param("user2") User user2,
+                                        @Param("roomType") Room.RoomType roomType);
 }

--- a/backend/src/main/java/net/datasa/project01/repository/VocabularyEntryRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/VocabularyEntryRepository.java
@@ -1,0 +1,12 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.domain.entity.VocabularyEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VocabularyEntryRepository extends JpaRepository<VocabularyEntry, Long> {
+
+    List<VocabularyEntry> findByUserOrderByCreatedAtDesc(User user);
+}

--- a/backend/src/main/java/net/datasa/project01/service/FollowService.java
+++ b/backend/src/main/java/net/datasa/project01/service/FollowService.java
@@ -1,0 +1,76 @@
+package net.datasa.project01.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.FollowRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    public FollowResponseDto follow(String followerLoginId, String targetLoginId) {
+        if (followerLoginId.equals(targetLoginId)) {
+            throw new IllegalArgumentException("자기 자신은 팔로우할 수 없습니다.");
+        }
+
+        User follower = userRepository.findByLoginId(followerLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("요청 사용자를 찾을 수 없습니다."));
+        User followee = userRepository.findByLoginId(targetLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 사용자를 찾을 수 없습니다."));
+
+        Follow follow = followRepository.findByFollowerAndFollowee(follower, followee)
+                .map(existing -> {
+                    if (existing.getStatus() != Follow.Status.ACCEPTED) {
+                        existing.accept();
+                    }
+                    return existing;
+                })
+                .orElseGet(() -> followRepository.save(
+                        Follow.builder()
+                                .follower(follower)
+                                .followee(followee)
+                                .status(Follow.Status.ACCEPTED)
+                                .build()
+                ));
+
+        log.info("User {} followed {} with status {}", followerLoginId, targetLoginId, follow.getStatus());
+        return FollowResponseDto.fromUser(follow.getFollowee());
+    }
+
+    public void unfollow(String followerLoginId, String targetLoginId) {
+        User follower = userRepository.findByLoginId(followerLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("요청 사용자를 찾을 수 없습니다."));
+        User followee = userRepository.findByLoginId(targetLoginId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 사용자를 찾을 수 없습니다."));
+
+        followRepository.findByFollowerAndFollowee(follower, followee)
+                .ifPresent(followRepository::delete);
+
+        log.info("User {} unfollowed {}", followerLoginId, targetLoginId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FollowResponseDto> getFollowing(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return followRepository.findByFollowerAndStatus(user, Follow.Status.ACCEPTED)
+                .stream()
+                .map(follow -> FollowResponseDto.fromUser(follow.getFollowee()))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -86,8 +86,8 @@ public class MatchService {
             // 두 요청의 상태를 MATCHED로 변경
             matchedOpponentRequest.setStatus(MatchRequest.MatchStatus.MATCHED);
 
-            // 1:1 채팅방 생성
-            Room privateRoom = chatService.createPrivateRoom(me, opponent);
+            // 1:1 채팅방 생성 (이미 존재한다면 재사용)
+            Room privateRoom = chatService.getOrCreatePrivateRoom(me.getLoginId(), opponent.getLoginId());
 
             // 양쪽 사용자에게 매칭 성공 알림 전송 (웹소켓)
             MatchFoundResponseDto myResponse = new MatchFoundResponseDto(

--- a/backend/src/main/java/net/datasa/project01/service/VocabularyService.java
+++ b/backend/src/main/java/net/datasa/project01/service/VocabularyService.java
@@ -1,0 +1,48 @@
+package net.datasa.project01.service;
+
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.VocabularyEntryResponseDto;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.domain.entity.VocabularyEntry;
+import net.datasa.project01.repository.UserRepository;
+import net.datasa.project01.repository.VocabularyEntryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VocabularyService {
+
+    private final VocabularyEntryRepository vocabularyEntryRepository;
+    private final UserRepository userRepository;
+
+    public VocabularyEntryResponseDto addWord(String loginId, String original, String translated) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        VocabularyEntry entry = vocabularyEntryRepository.save(
+                VocabularyEntry.builder()
+                        .user(user)
+                        .originalText(original)
+                        .translatedText(translated)
+                        .build()
+        );
+
+        return VocabularyEntryResponseDto.from(entry);
+    }
+
+    @Transactional(readOnly = true)
+    public List<VocabularyEntryResponseDto> list(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return vocabularyEntryRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(VocabularyEntryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/frontend/src/services/chat.js
+++ b/frontend/src/services/chat.js
@@ -1,13 +1,15 @@
 // src/services/chat.js
 export function setupChat(client, roomId, { onChat }) {
-    const sub = client.subscribe(`/topic/chat/${roomId}`, (msg) => {
-        onChat(JSON.parse(msg.body))
+  const subscription = client.subscribe(`/topic/rooms/${roomId}`, (msg) => {
+    onChat(JSON.parse(msg.body))
+  })
+
+  function sendChat(dto) {
+    client.publish({
+      destination: `/app/chat.sendMessage/${roomId}`,
+      body: JSON.stringify(dto),
     })
-    function sendChat(dto) {
-        client.publish({
-            destination: `/app/chat/${roomId}`,
-            body: JSON.stringify(dto) // { message: "...", sender: "...", ... }
-        })
-    }
-    return { sub, sendChat }
+  }
+
+  return { sub: subscription, sendChat }
 }

--- a/frontend/src/services/translator.js
+++ b/frontend/src/services/translator.js
@@ -1,5 +1,16 @@
-export async function translate(text, targetLang = 'en') {
-  // 간단한 예시 번역기: 실제 서비스 연동 전까지는 문자열을 뒤집어 반환합니다.
-  // TODO: 외부 번역 API와 연동하여 실제 번역 결과를 제공하세요.
-  return text.split('').reverse().join('');
+import api from './api'
+
+export async function translate(text, { sourceLang = 'auto', targetLang = 'en', save = false } = {}) {
+  const { data } = await api.post('/translate', {
+    text,
+    sourceLang,
+    targetLang,
+    save,
+  })
+  return data
+}
+
+export async function saveVocabulary(original, translated) {
+  const { data } = await api.post('/vocabulary', { original, translated })
+  return data
 }

--- a/frontend/src/stores/friends.js
+++ b/frontend/src/stores/friends.js
@@ -1,19 +1,30 @@
 import { defineStore } from 'pinia'
+import api from '../services/api'
 
 export const useFriendsStore = defineStore('friends', {
   state: () => ({
-    list: JSON.parse(localStorage.getItem('friends') || '[]')
+    list: [],
+    loading: false,
   }),
   actions: {
-    add(name) {
-      if (name && !this.list.includes(name)) {
-        this.list.push(name)
-        localStorage.setItem('friends', JSON.stringify(this.list))
+    async fetch() {
+      this.loading = true
+      try {
+        const { data } = await api.get('/follows')
+        this.list = data
+      } finally {
+        this.loading = false
       }
     },
-    remove(name) {
-      this.list = this.list.filter(f => f !== name)
-      localStorage.setItem('friends', JSON.stringify(this.list))
-    }
-  }
+    async add(loginId) {
+      if (!loginId) return
+      await api.post(`/follows/${encodeURIComponent(loginId)}`)
+      await this.fetch()
+    },
+    async remove(loginId) {
+      if (!loginId) return
+      await api.delete(`/follows/${encodeURIComponent(loginId)}`)
+      await this.fetch()
+    },
+  },
 })

--- a/frontend/src/stores/vocabulary.js
+++ b/frontend/src/stores/vocabulary.js
@@ -1,13 +1,24 @@
-import { defineStore } from 'pinia';
+import { defineStore } from 'pinia'
+import api from '../services/api'
 
 export const useVocabularyStore = defineStore('vocabulary', {
   state: () => ({
-    words: JSON.parse(localStorage.getItem('vocabulary') || '[]')
+    words: [],
+    loading: false,
   }),
   actions: {
-    addWord(original, translated) {
-      this.words.push({ original, translated });
-      localStorage.setItem('vocabulary', JSON.stringify(this.words));
-    }
-  }
-});
+    async fetch() {
+      this.loading = true
+      try {
+        const { data } = await api.get('/vocabulary')
+        this.words = data
+      } finally {
+        this.loading = false
+      }
+    },
+    async addWord(original, translated) {
+      await api.post('/vocabulary', { original, translated })
+      await this.fetch()
+    },
+  },
+})

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -1,20 +1,18 @@
 <template>
-  <v-container fluid class="chat-page  mt-4">
+  <v-container fluid class="chat-page mt-4">
     <v-row no-gutters class="h-100">
       <!-- Sidebar -->
       <v-col cols="12" md="3" class="chat-sidebar d-flex flex-column">
         <div class="sidebar-header d-flex align-center px-4 py-3">
           <div class="text-h6 font-weight-medium">채팅</div>
           <v-spacer />
-          <v-btn icon variant="text"><v-icon>mdi-message-plus-outline</v-icon></v-btn>
-          <v-btn icon variant="text"><v-icon>mdi-account-multiple-plus</v-icon></v-btn>
-          <v-btn icon variant="text"><v-icon>mdi-cog-outline</v-icon></v-btn>
-          <v-btn icon variant="text"><v-icon>mdi-dots-vertical</v-icon></v-btn>
+          <v-btn icon variant="text" @click="createGroupRoom"><v-icon>mdi-account-multiple-plus</v-icon></v-btn>
+          <v-btn icon variant="text" @click="refreshFriends"><v-icon>mdi-refresh</v-icon></v-btn>
         </div>
         <div class="px-4 pb-2">
           <v-text-field
             v-model="query"
-            placeholder="채팅방 검색 바"
+            placeholder="채팅방 검색"
             prepend-inner-icon="mdi-magnify"
             variant="solo"
             density="comfortable"
@@ -29,30 +27,38 @@
         <div class="flex-grow-1 overflow-y-auto">
           <v-list v-if="tab === 'direct'">
             <v-list-item
-              v-for="item in filteredChats"
-              :key="item.id"
-              @click="openChat(item)"
+              v-for="friend in filteredFriends"
+              :key="friend.loginId"
+              @click="openDirectChat(friend)"
+              :active="current?.type === 'direct' && current?.id === friend.loginId"
               lines="two"
             >
               <template #prepend>
                 <v-avatar size="40"><v-icon color="primary">mdi-account</v-icon></v-avatar>
               </template>
-              <v-list-item-title>{{ item.name }}</v-list-item-title>
-              <v-list-item-subtitle>{{ item.last }}</v-list-item-subtitle>
+              <v-list-item-title>{{ friend.nickName }}</v-list-item-title>
+              <v-list-item-subtitle>{{ getLastSnippet(getDirectRoomId(friend)) }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item v-if="!filteredFriends.length">
+              <v-list-item-title>팔로우한 사용자가 없습니다.</v-list-item-title>
             </v-list-item>
           </v-list>
           <v-list v-else>
             <v-list-item
-              v-for="item in filteredGroups"
-              :key="item.id"
-              @click="openChat(item)"
+              v-for="group in filteredGroups"
+              :key="group.id"
+              @click="openGroupChat(group)"
+              :active="current?.type === 'group' && current?.id === group.id"
               lines="two"
             >
               <template #prepend>
                 <v-avatar size="40"><v-icon color="primary">mdi-account-group</v-icon></v-avatar>
               </template>
-              <v-list-item-title>{{ item.name }}</v-list-item-title>
-              <v-list-item-subtitle>{{ item.last }}</v-list-item-subtitle>
+              <v-list-item-title>{{ group.name }}</v-list-item-title>
+              <v-list-item-subtitle>{{ getLastSnippet(group.roomId) }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item v-if="!filteredGroups.length">
+              <v-list-item-title>생성된 그룹이 없습니다.</v-list-item-title>
             </v-list-item>
           </v-list>
         </div>
@@ -60,189 +66,536 @@
 
       <!-- Conversation -->
       <v-col cols="12" md="9" class="chat-main d-flex flex-column">
-        <div class="chat-header d-flex align-center pa-4">
-          <v-avatar size="40"><v-icon color="primary">mdi-account</v-icon></v-avatar>
-          <div class="ml-3">
-            <div class="text-subtitle-1 font-weight-medium">{{ current.name }}</div>
-            <div class="text-caption text-grey" v-if="!isGroup">온라인</div>
-            <div class="text-caption text-grey" v-else>{{ groupParticipants }}</div>
-          </div>
-          <v-spacer />
-          <v-btn icon variant="text"><v-icon>mdi-magnify</v-icon></v-btn>
-          <v-btn v-if="!isGroup" icon variant="text"><v-icon>mdi-phone</v-icon></v-btn>
-          <v-btn v-if="isGroup" icon variant="text" @click="inviteParticipant"><v-icon>mdi-account-plus</v-icon></v-btn>
-          <v-btn v-if="isGroup" icon variant="text" @click="startVideoCall"><v-icon>mdi-video</v-icon></v-btn>
-          <v-btn v-else icon variant="text"><v-icon>mdi-video</v-icon></v-btn>
+        <div v-if="!current" class="h-100 d-flex align-center justify-center text-medium-emphasis">
+          대화를 시작할 상대를 선택하세요.
         </div>
-        <v-divider />
-        <div class="chat-messages flex-grow-1 pa-4 overflow-y-auto" ref="chatMessagesContainer">
-          <div class="text-center my-4 text-caption text-grey">2023년 1월 18일</div>
-          <div
-            v-for="(m, i) in messages"
-            :key="i"
-            class="d-flex mb-4"
-            :class="{ 'justify-end': m.me }"
-          >
-            <template v-if="!m.me">
-              <v-avatar size="32" class="mr-2"><v-icon color="primary">mdi-account</v-icon></v-avatar>
-              <div>
-                <div v-if="isGroup" class="text-caption font-weight-medium mb-1">{{ m.sender }}</div>
-                <div class="pa-3 bg-grey-lighten-4 rounded-xl">{{ m.text }}</div>
-                <div class="text-caption text-grey mt-1">{{ m.time }}</div>
-              </div>
-            </template>
-            <template v-else>
-              <div>
-                <div class="pa-3 bg-primary text-white rounded-xl">{{ m.text }}</div>
-                <div class="text-caption text-grey mt-1 text-right">{{ m.time }}</div>
-              </div>
-            </template>
-          </div>
-        </div>
-        <div class="chat-input d-flex align-center pa-4 ga-2">
-          <v-btn icon variant="outlined" color="success"><v-icon>mdi-plus</v-icon></v-btn>
-          <v-text-field
-            v-model="draft"
-            variant="outlined"
-            density="comfortable"
-            hide-details
-            placeholder="메시지를 입력하세요..."
-            class="flex-grow-1"
-            @keydown.enter.prevent="send"
-          />
-          <v-btn icon variant="text"><v-icon>mdi-emoticon-outline</v-icon></v-btn>
-          <v-btn icon color="success" @click="send"><v-icon>mdi-send</v-icon></v-btn>
 
-        </div>
+        <template v-else>
+          <div class="chat-header d-flex align-center pa-4">
+            <v-avatar size="40"><v-icon color="primary">{{ current.type === 'group' ? 'mdi-account-group' : 'mdi-account' }}</v-icon></v-avatar>
+            <div class="ml-3">
+              <div class="text-subtitle-1 font-weight-medium">{{ current.name }}</div>
+              <div class="text-caption text-grey" v-if="current.type === 'group'">
+                {{ current.participants.join(', ') }}
+              </div>
+              <div class="text-caption text-grey" v-else>온라인</div>
+            </div>
+            <v-spacer />
+            <v-select
+              v-model="targetLang"
+              :items="availableLanguages"
+              hide-details
+              density="compact"
+              variant="outlined"
+              class="lang-select"
+            />
+            <v-btn
+              icon
+              variant="text"
+              :color="translateEnabled ? 'pink' : undefined"
+              @click="toggleTranslate"
+            >
+              <v-icon>{{ translateEnabled ? 'mdi-translate' : 'mdi-translate-off' }}</v-icon>
+            </v-btn>
+            <v-btn v-if="current.type === 'group'" icon variant="text" @click="inviteParticipant">
+              <v-icon>mdi-account-plus</v-icon>
+            </v-btn>
+            <v-btn icon variant="text" @click="startVideoCall">
+              <v-icon>mdi-video</v-icon>
+            </v-btn>
+          </div>
+          <v-divider />
+          <div class="chat-messages flex-grow-1 pa-4 overflow-y-auto" ref="messageContainer">
+            <v-progress-linear v-if="chatLoading" indeterminate color="pink" class="mb-2" />
+            <div
+              v-for="(msg, i) in activeMessages"
+              :key="msg.id ?? i"
+              class="d-flex mb-4"
+              :class="{ 'justify-end': msg.senderLoginId === myLoginId }"
+            >
+              <template v-if="msg.senderLoginId !== myLoginId">
+                <v-avatar size="32" class="mr-2"><v-icon color="primary">mdi-account</v-icon></v-avatar>
+                <div>
+                  <div v-if="current.type === 'group'" class="text-caption font-weight-medium mb-1">{{ msg.senderNickName }}</div>
+                  <div v-if="msg.contentType === 'TEXT'" class="pa-3 bg-grey-lighten-4 rounded-xl">
+                    {{ msg.content }}
+                    <div v-if="msg.translatedText" class="text-caption text-grey mt-1 d-flex align-center">
+                      {{ msg.translatedText }}
+                      <v-btn
+                        size="x-small"
+                        variant="text"
+                        color="pink"
+                        :loading="msg.saving"
+                        class="ml-2"
+                        @click="storeWord(msg)"
+                      >저장</v-btn>
+                    </div>
+                  </div>
+                  <div v-else class="pa-3 bg-grey-lighten-4 rounded-xl">
+                    <template v-if="msg.contentType === 'IMAGE'">
+                      <img :src="msg.fileUrl" :alt="msg.fileName" class="max-w-220" />
+                    </template>
+                    <template v-else>
+                      <a :href="msg.fileUrl" target="_blank" rel="noopener">{{ msg.fileName }}</a>
+                    </template>
+                  </div>
+                  <div class="text-caption text-grey mt-1">{{ formatTime(msg.sentAt) }}</div>
+                </div>
+              </template>
+              <template v-else>
+                <div>
+                  <div v-if="msg.contentType === 'TEXT'" class="pa-3 bg-primary text-white rounded-xl">{{ msg.content }}</div>
+                  <div v-else class="pa-3 bg-primary text-white rounded-xl">
+                    <template v-if="msg.contentType === 'IMAGE'">
+                      <img :src="msg.fileUrl" :alt="msg.fileName" class="max-w-220" />
+                    </template>
+                    <template v-else>
+                      <a :href="msg.fileUrl" target="_blank" rel="noopener" class="text-white">{{ msg.fileName }}</a>
+                    </template>
+                  </div>
+                  <div class="text-caption text-grey mt-1 text-right">{{ formatTime(msg.sentAt) }}</div>
+                </div>
+              </template>
+            </div>
+          </div>
+          <div class="chat-input d-flex align-center pa-4 ga-2">
+            <input ref="fileInput" type="file" class="d-none" accept="image/*,application/*" @change="uploadFile" />
+            <v-btn icon variant="outlined" color="pink" :loading="uploading" @click="triggerFileSelect"><v-icon>mdi-paperclip</v-icon></v-btn>
+            <v-text-field
+              v-model="chatInput"
+              variant="outlined"
+              density="comfortable"
+              hide-details
+              placeholder="메시지를 입력하세요..."
+              class="flex-grow-1"
+              @keydown.enter.prevent="send"
+            />
+            <v-btn icon color="pink" :loading="sending" :disabled="!chatInput.trim()" @click="send"><v-icon>mdi-send</v-icon></v-btn>
+          </div>
+        </template>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick, watch } from 'vue'
+import { ref, computed, reactive, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
 import { useFriendsStore } from '../stores/friends'
+import { createStompClient } from '../services/ws'
+import { translate, saveVocabulary } from '../services/translator'
+import api from '../services/api'
 
 const query = ref('')
 const tab = ref('direct')
-const chats = ref([])
-const groups = ref([
-  { id: 3, name: '스터디 모임', last: '다음 주 모임 시간 안내', participants: ['김서연', '대학 동기'] }
-])
-
-const current = ref({})
-const draft = ref('')
-const conversations = ref({
-  3: []
-})
-
-const chatMessagesContainer = ref(null)
-
 const friendsStore = useFriendsStore()
+const auth = useAuthStore()
+const router = useRouter()
 
-onMounted(() => {
-  chats.value = friendsStore.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
-  current.value = chats.value[0] || groups.value[0]
-  scrollToBottom()
-})
+const groups = ref([])
+const current = ref(null)
+const conversations = reactive({})
+const directRooms = reactive({})
+const chatInput = ref('')
+const translateEnabled = ref(false)
+const targetLang = ref('en')
+const availableLanguages = [
+  { title: '영어', value: 'en' },
+  { title: '한국어', value: 'ko' },
+  { title: '일본어', value: 'ja' },
+  { title: '중국어', value: 'zh-CN' },
+  { title: '스페인어', value: 'es' },
+]
 
-friendsStore.$subscribe((_, state) => {
-  chats.value = state.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
-})
+const uploading = ref(false)
+const sending = ref(false)
+const chatLoading = ref(false)
+const messageContainer = ref(null)
+const fileInput = ref(null)
 
+const chatClient = ref(null)
+const isConnected = ref(false)
+const connectionResolvers = []
+const subscriptions = reactive({})
 
-const filteredChats = computed(() =>
-  chats.value.filter(c =>
-    c.name.includes(query.value) || c.last?.includes(query.value)
+const myLoginId = computed(() => auth.user?.loginId || '')
+
+const friends = computed(() => friendsStore.list)
+
+const filteredFriends = computed(() =>
+  friends.value.filter((friend) =>
+    friend.nickName.toLowerCase().includes(query.value.toLowerCase()) ||
+    friend.loginId.toLowerCase().includes(query.value.toLowerCase())
   )
 )
+
 const filteredGroups = computed(() =>
-  groups.value.filter(c =>
-    c.name.includes(query.value) || c.last?.includes(query.value)
+  groups.value.filter((group) =>
+    group.name.toLowerCase().includes(query.value.toLowerCase())
   )
 )
 
-const isGroup = computed(() =>
-    groups.value.some(g => g.id === current.value.id)
-)
-const groupParticipants = computed(() => {
-  const g = groups.value.find(g => g.id === current.value.id)
-  return g ? g.participants.join(', ') : ''
+const activeMessages = computed(() => {
+  if (!current.value) return []
+  const conv = conversations[current.value.roomId]
+  return conv ? conv.messages : []
 })
 
-const messages = computed(() => conversations.value[current.value.id] || [])
+function ensureConversation(roomId) {
+  if (!conversations[roomId]) {
+    conversations[roomId] = { messages: [], loaded: false }
+  }
+  return conversations[roomId]
+}
+
+function normalizeMessage(message) {
+  return {
+    id: message.messageId ?? `${Date.now()}-${Math.random()}`,
+    roomId: message.roomId,
+    senderLoginId: message.senderLoginId || '',
+    senderNickName: message.senderNickName || '시스템',
+    contentType: message.contentType || 'TEXT',
+    content: message.content || '',
+    fileUrl: message.fileUrl || '',
+    fileName: message.fileName || '',
+    mimeType: message.mimeType || '',
+    sizeBytes: message.sizeBytes || 0,
+    sentAt: message.sentAt || new Date().toISOString(),
+    translatedText: message.translatedText || null,
+    saving: false,
+  }
+}
+
+function waitForConnection() {
+  if (isConnected.value) return Promise.resolve()
+  return new Promise((resolve) => {
+    connectionResolvers.push(resolve)
+  })
+}
+
+function connectStomp() {
+  chatClient.value = createStompClient(auth.token)
+  chatClient.value.onConnect = () => {
+    isConnected.value = true
+    while (connectionResolvers.length) {
+      const resolve = connectionResolvers.shift()
+      resolve?.()
+    }
+  }
+  chatClient.value.onStompError = (frame) => {
+    console.error('STOMP error', frame.headers, frame.body)
+  }
+  chatClient.value.onWebSocketError = (event) => {
+    console.error('WebSocket error', event)
+  }
+  chatClient.value.activate()
+}
+
+async function subscribeRoom(roomId) {
+  await waitForConnection()
+  if (subscriptions[roomId]) return
+  subscriptions[roomId] = chatClient.value.subscribe(`/topic/rooms/${roomId}`, (frame) => {
+    try {
+      const payload = JSON.parse(frame.body)
+      handleIncomingMessage(roomId, payload)
+    } catch (error) {
+      console.error('Failed to process chat frame', error)
+    }
+  })
+}
+
+async function ensureTranslated(message) {
+  if (!translateEnabled.value) return
+  if (message.senderLoginId === myLoginId.value) return
+  if (message.contentType !== 'TEXT' || !message.content || message.translatedText) return
+  try {
+    const { translatedText } = await translate(message.content, { targetLang: targetLang.value })
+    message.translatedText = translatedText
+  } catch (error) {
+    console.error('번역 실패', error)
+  }
+}
+
+async function handleIncomingMessage(roomId, payload) {
+  const conv = ensureConversation(roomId)
+  const message = normalizeMessage(payload)
+  conv.messages.push(message)
+  if (current.value?.roomId === roomId) {
+    await ensureTranslated(message)
+    scrollToBottom()
+  }
+}
+
+async function loadHistory(roomId) {
+  const conv = ensureConversation(roomId)
+  chatLoading.value = true
+  try {
+    const { data } = await api.get(`/rooms/${roomId}/messages`, { params: { page: 0, size: 50 } })
+    conv.messages = (data.messages || []).map(normalizeMessage)
+    conv.loaded = true
+    if (translateEnabled.value) {
+      for (const message of conv.messages) {
+        await ensureTranslated(message)
+      }
+    }
+    scrollToBottom()
+  } catch (error) {
+    console.error('Failed to load history', error)
+  } finally {
+    chatLoading.value = false
+  }
+}
+
+async function openDirectChat(friend) {
+  try {
+    await waitForConnection()
+    const { data } = await api.post('/rooms/private', { targetLoginId: friend.loginId })
+    const roomId = data.roomId
+    directRooms[friend.loginId] = roomId
+    current.value = {
+      type: 'direct',
+      id: friend.loginId,
+      name: friend.nickName,
+      roomId,
+      loginId: friend.loginId,
+      participants: [friend.nickName],
+    }
+    await subscribeRoom(roomId)
+    await loadHistory(roomId)
+  } catch (error) {
+    console.error('Failed to open direct chat', error)
+  }
+}
+
+async function openGroupChat(group) {
+  try {
+    await waitForConnection()
+    current.value = group
+    await subscribeRoom(group.roomId)
+    await loadHistory(group.roomId)
+  } catch (error) {
+    console.error('Failed to open group chat', error)
+  }
+}
+
+async function createGroupRoom() {
+  try {
+    const { data } = await api.post('/rooms')
+    const roomId = data.roomId
+    const name = `그룹 ${groups.value.length + 1}`
+    const group = {
+      id: `group-${roomId}`,
+      name,
+      roomId,
+      type: 'group',
+      participants: [auth.user?.nickName || '나'],
+    }
+    groups.value.push(group)
+    tab.value = 'group'
+    await openGroupChat(group)
+  } catch (error) {
+    console.error('그룹 생성 실패', error)
+    alert('그룹 채팅방 생성에 실패했습니다.')
+  }
+}
+
+function getDirectRoomId(friend) {
+  return directRooms[friend.loginId]
+}
+
+function getLastSnippet(roomId) {
+  if (!roomId) return ''
+  const conv = conversations[roomId]
+  if (!conv || !conv.messages.length) return ''
+  const last = conv.messages[conv.messages.length - 1]
+  if (last.contentType === 'TEXT') return last.content
+  return last.fileName || '파일 공유'
+}
 
 function scrollToBottom() {
   nextTick(() => {
-    const el = chatMessagesContainer.value
+    const el = messageContainer.value
     if (el) {
       el.scrollTop = el.scrollHeight
     }
   })
 }
 
-function openChat(item) {
-  current.value = item
-  if (!conversations.value[item.id]) conversations.value[item.id] = []
-  scrollToBottom()
+async function send() {
+  if (!chatClient.value?.connected || !current.value?.roomId || !chatInput.value.trim()) return
+  sending.value = true
+  try {
+    chatClient.value.publish({
+      destination: `/app/chat.sendMessage/${current.value.roomId}`,
+      body: JSON.stringify({
+        roomId: current.value.roomId,
+        content: chatInput.value.trim(),
+        contentType: 'TEXT',
+      }),
+    })
+    chatInput.value = ''
+  } catch (error) {
+    console.error('메시지 전송 실패', error)
+  } finally {
+    sending.value = false
+  }
 }
 
-function inviteParticipant() {
-  const group = groups.value.find(g => g.id === current.value.id)
-  if (!group) return
-  if (group.participants.length >= 4) {
-    alert('최대 4명까지 초대할 수 있습니다.')
-    return
+function triggerFileSelect() {
+  fileInput.value?.click()
+}
+
+async function uploadFile(event) {
+  const file = event.target?.files?.[0]
+  event.target.value = ''
+  if (!file || !current.value?.roomId) return
+  uploading.value = true
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    await api.post(`/rooms/${current.value.roomId}/files`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  } catch (error) {
+    console.error('파일 업로드 실패', error)
+    alert('파일 업로드에 실패했습니다.')
+  } finally {
+    uploading.value = false
   }
-  const name = prompt('초대할 사용자의 이름을 입력하세요:')
-  if (name) group.participants.push(name)
+}
+
+function toggleTranslate() {
+  translateEnabled.value = !translateEnabled.value
+  if (translateEnabled.value) {
+    activeMessages.value.forEach((message) => {
+      ensureTranslated(message)
+    })
+  }
+}
+
+async function storeWord(message) {
+  if (!message.translatedText) return
+  message.saving = true
+  try {
+    await saveVocabulary(message.content, message.translatedText)
+  } catch (error) {
+    console.error('단어 저장 실패', error)
+  } finally {
+    message.saving = false
+  }
+}
+
+async function inviteParticipant() {
+  if (!current.value || current.value.type !== 'group') return
+  const input = prompt('초대할 사용자의 로그인 ID를 입력하세요 (콤마로 구분, 최대 2명)')
+  if (!input) return
+  const targets = input.split(',').map((id) => id.trim()).filter(Boolean)
+  if (!targets.length) return
+  try {
+    await api.post(`/rooms/${current.value.roomId}/invite`, { targets })
+    targets.forEach((target) => {
+      const friend = friends.value.find((f) => f.loginId === target)
+      current.value.participants.push(friend?.nickName || target)
+    })
+  } catch (error) {
+    console.error('초대 실패', error)
+    alert('초대에 실패했습니다.')
+  }
 }
 
 function startVideoCall() {
-  alert('영상 통화를 시작합니다')
-}
-
-function send() {
-  if (!draft.value) return
-  const formatted = new Date().toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit'
+  if (!current.value?.roomId) return
+  const partnerLogin = current.value.type === 'direct' ? current.value.loginId : ''
+  router.push({
+    name: 'match-video',
+    params: { roomId: String(current.value.roomId) },
+    query: {
+      partnerNickname: current.value.name,
+      partnerLoginId: partnerLogin,
+    },
   })
-  const msg = { text: draft.value, time: formatted, me: true }
-  conversations.value[current.value.id] = conversations.value[current.value.id] || []
-  conversations.value[current.value.id].push(msg)
-  let chat = chats.value.find(c => c.id === current.value.id)
-  if (!chat) chat = groups.value.find(c => c.id === current.value.id)
-  if (chat) chat.last = draft.value
-
-  draft.value = ''
-  scrollToBottom()
 }
 
-watch(messages, () => scrollToBottom())
+function formatTime(timestamp) {
+  if (!timestamp) return ''
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+async function refreshFriends() {
+  try {
+    await friendsStore.fetch()
+  } catch (error) {
+    console.error('친구 목록 갱신 실패', error)
+  }
+}
+
+onMounted(async () => {
+  await refreshFriends()
+  connectStomp()
+})
+
+onBeforeUnmount(() => {
+  try {
+    Object.values(subscriptions).forEach((sub) => sub?.unsubscribe?.())
+  } catch (error) {
+    console.warn('Failed to unsubscribe from rooms', error)
+  }
+  chatClient.value?.deactivate?.()
+})
+
+watch(activeMessages, () => {
+  scrollToBottom()
+})
+
+watch(targetLang, () => {
+  if (translateEnabled.value) {
+    activeMessages.value.forEach((message) => {
+      message.translatedText = null
+      ensureTranslated(message)
+    })
+  }
+})
 </script>
 
 <style scoped>
 .chat-page {
   height: calc(100vh - var(--v-layout-top));
 }
+
 .chat-sidebar {
   background: #fff;
-  border-right: 2px solid #000000;
-
+  border-right: 2px solid #f5c6d6;
   height: 100%;
 }
+
 .chat-main {
   background: #fff;
   border-left: 2px solid #ffb6c1;
   height: 100%;
 }
+
 .chat-messages {
   background: #fff;
 }
+
 .chat-input {
   border-top: 1px solid #eee;
+}
 
+.sidebar-header {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.lang-select {
+  max-width: 120px;
+  margin-right: 8px;
+}
+
+.max-w-220 {
+  max-width: 220px;
+  border-radius: 10px;
 }
 </style>
-

--- a/frontend/src/views/MatchVideoChat.vue
+++ b/frontend/src/views/MatchVideoChat.vue
@@ -1,53 +1,192 @@
 <template>
   <v-container class="py-8">
     <v-row justify="center">
-      <v-col cols="12" md="10" lg="8">
-        <v-card class="pa-4">
+      <v-col cols="12" xl="10">
+        <v-card class="pa-4 video-chat-card">
           <div class="header-row mb-4">
             <div>
-              <div class="text-h6 text-pink-darken-2">영상 채팅</div>
+              <div class="text-h6 text-pink-darken-2">랜덤 영상 채팅</div>
               <div class="text-caption text-medium-emphasis">
                 {{ partnerNickname ? `${partnerNickname}님과 연결 중` : '상대방을 기다리는 중입니다' }}
               </div>
             </div>
-            <v-btn color="grey" variant="tonal" @click="leaveCall">나가기</v-btn>
-          </div>
-
-          <v-alert
-            v-if="connectionError"
-            type="error"
-            variant="tonal"
-            class="mb-4"
-          >
-            {{ connectionError }}
-          </v-alert>
-
-          <div class="video-stage mb-4">
-            <video ref="remoteVideo" autoplay playsinline class="remote-video bg-grey-lighten-3"></video>
-            <video ref="localVideo" autoplay muted playsinline class="local-video bg-grey-lighten-1"></video>
-            <div v-if="connecting && !connectionError" class="video-overlay d-flex align-center justify-center">
-              <v-progress-circular indeterminate color="pink" size="56" />
+            <div class="d-flex flex-wrap gap-2">
+              <v-btn
+                v-if="partnerLoginId && !isFollowing"
+                color="pink"
+                variant="tonal"
+                :disabled="friendLoading"
+                @click="followPartner"
+              >친구 추가</v-btn>
+              <v-btn color="grey" variant="tonal" @click="leaveCall">나가기</v-btn>
             </div>
           </div>
 
-          <div class="control-buttons" v-if="!connectionError">
-            <v-btn
-              color="pink"
-              variant="flat"
-              @click="toggleMute"
-              :prepend-icon="muted ? 'mdi-microphone-off' : 'mdi-microphone'"
-            >
-              {{ muted ? '음소거 해제' : '음소거' }}
-            </v-btn>
-            <v-btn
-              color="pink"
-              variant="flat"
-              @click="toggleCamera"
-              :prepend-icon="cameraOff ? 'mdi-video-off' : 'mdi-video'"
-            >
-              {{ cameraOff ? '카메라 켜기' : '카메라 끄기' }}
-            </v-btn>
-          </div>
+          <v-row class="g-4">
+            <v-col cols="12" md="7" class="d-flex">
+              <div class="video-stage mb-4 flex-grow-1">
+                <video ref="remoteVideo" autoplay playsinline class="remote-video bg-grey-lighten-3"></video>
+                <video ref="localVideo" autoplay muted playsinline class="local-video bg-grey-lighten-1"></video>
+                <div v-if="connecting && !connectionError" class="video-overlay d-flex align-center justify-center">
+                  <v-progress-circular indeterminate color="pink" size="56" />
+                </div>
+              </div>
+
+              <v-alert
+                v-if="connectionError"
+                type="error"
+                variant="tonal"
+                class="mb-4 w-100"
+              >
+                {{ connectionError }}
+              </v-alert>
+
+              <div class="control-buttons" v-if="!connectionError">
+                <v-btn
+                  color="pink"
+                  variant="flat"
+                  class="mr-2"
+                  @click="toggleMute"
+                  :prepend-icon="muted ? 'mdi-microphone-off' : 'mdi-microphone'"
+                >
+                  {{ muted ? '음소거 해제' : '음소거' }}
+                </v-btn>
+                <v-btn
+                  color="pink"
+                  variant="flat"
+                  @click="toggleCamera"
+                  :prepend-icon="cameraOff ? 'mdi-video-off' : 'mdi-video'"
+                >
+                  {{ cameraOff ? '카메라 켜기' : '카메라 끄기' }}
+                </v-btn>
+              </div>
+            </v-col>
+
+            <v-col cols="12" md="5">
+              <section class="chat-panel">
+                <header class="chat-header">
+                  <div class="d-flex align-center gap-2">
+                    <v-icon color="pink">mdi-chat-processing</v-icon>
+                    <span class="text-subtitle-1">텍스트 채팅</span>
+                  </div>
+                  <div class="d-flex align-center gap-2">
+                    <v-select
+                      v-model="targetLang"
+                      :items="availableLanguages"
+                      density="compact"
+                      variant="outlined"
+                      hide-details
+                      class="lang-select"
+                    />
+                    <v-btn
+                      size="small"
+                      color="pink"
+                      variant="tonal"
+                      :prepend-icon="translateEnabled ? 'mdi-translate' : 'mdi-translate-off'"
+                      @click="toggleTranslate"
+                    >
+                      {{ translateEnabled ? '번역 끄기' : '번역 켜기' }}
+                    </v-btn>
+                  </div>
+                </header>
+
+                <div class="chat-messages" ref="messageContainer">
+                  <v-progress-linear
+                    v-if="chatLoading"
+                    indeterminate
+                    color="pink"
+                    class="mb-4"
+                  />
+                  <div
+                    v-for="msg in chatMessages"
+                    :key="msg.id"
+                    class="chat-message"
+                    :class="{ mine: msg.senderLoginId === myLoginId }"
+                  >
+                    <div class="meta">
+                      <span class="name">{{ msg.senderNickName }}</span>
+                      <span class="time">{{ formatTime(msg.sentAt) }}</span>
+                    </div>
+
+                    <div v-if="msg.contentType === 'TEXT'" class="bubble">
+                      <div>{{ msg.content }}</div>
+                      <div
+                        v-if="msg.translatedText && msg.senderLoginId !== myLoginId"
+                        class="translated"
+                      >
+                        {{ msg.translatedText }}
+                        <v-btn
+                          v-if="!msg.saving"
+                          size="x-small"
+                          variant="text"
+                          color="pink"
+                          class="ml-2"
+                          @click="storeWord(msg)"
+                        >저장</v-btn>
+                        <v-progress-circular
+                          v-else
+                          indeterminate
+                          size="16"
+                          color="pink"
+                        />
+                      </div>
+                    </div>
+
+                    <div v-else class="bubble file-bubble">
+                      <template v-if="msg.contentType === 'IMAGE'">
+                        <img :src="msg.fileUrl" :alt="msg.fileName" class="chat-image" />
+                      </template>
+                      <template v-else>
+                        <a :href="msg.fileUrl" target="_blank" rel="noopener" class="file-link">
+                          <v-icon class="mr-1">mdi-file</v-icon>
+                          {{ msg.fileName }}
+                        </a>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+
+                <footer class="chat-input">
+                  <input
+                    ref="fileInput"
+                    type="file"
+                    class="d-none"
+                    accept="image/*,application/*"
+                    @change="onFileSelected"
+                  />
+                  <v-btn
+                    icon
+                    variant="text"
+                    color="pink"
+                    :loading="uploading"
+                    @click="triggerFileSelect"
+                  >
+                    <v-icon>mdi-paperclip</v-icon>
+                  </v-btn>
+                  <v-text-field
+                    v-model="chatInput"
+                    :disabled="!client?.connected"
+                    density="comfortable"
+                    variant="outlined"
+                    placeholder="메시지를 입력하세요"
+                    hide-details
+                    class="flex-grow-1"
+                    @keydown.enter.prevent="sendChat"
+                  />
+                  <v-btn
+                    icon
+                    color="pink"
+                    variant="flat"
+                    :disabled="sending || !chatInput.trim()"
+                    :loading="sending"
+                    @click="sendChat"
+                  >
+                    <v-icon>mdi-send</v-icon>
+                  </v-btn>
+                </footer>
+              </section>
+            </v-col>
+          </v-row>
         </v-card>
       </v-col>
     </v-row>
@@ -58,12 +197,16 @@
 import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { useFriendsStore } from '../stores/friends'
 import { createStompClient } from '../services/ws'
 import { setupSignalRoutes } from '../services/signaling'
+import api from '../services/api'
+import { translate, saveVocabulary } from '../services/translator'
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
+const friendsStore = useFriendsStore()
 
 const roomId = computed(() => Number(route.params.roomId || 0))
 const partnerNickname = ref(route.query.partnerNickname || '')
@@ -76,17 +219,41 @@ const connecting = ref(true)
 const muted = ref(false)
 const cameraOff = ref(false)
 
+const chatMessages = ref([])
+const chatInput = ref('')
+const chatLoading = ref(false)
+const translateEnabled = ref(false)
+const targetLang = ref('en')
+const messageContainer = ref(null)
+const fileInput = ref(null)
+const uploading = ref(false)
+const sending = ref(false)
+
+const availableLanguages = [
+  { title: '영어', value: 'en' },
+  { title: '한국어', value: 'ko' },
+  { title: '일본어', value: 'ja' },
+  { title: '중국어', value: 'zh-CN' },
+  { title: '스페인어', value: 'es' },
+]
+
 const myLoginId = computed(() => auth.user?.loginId || '')
 const shouldInitiate = computed(() => {
   if (!myLoginId.value || !partnerLoginId.value) return false
   return myLoginId.value.localeCompare(partnerLoginId.value) < 0
 })
 
+const isFollowing = computed(() =>
+  friendsStore.list.some((friend) => friend.loginId === partnerLoginId.value)
+)
+const friendLoading = computed(() => friendsStore.loading)
+
 let client = null
 let signal = null
 let pc = null
 let localStream = null
 let hasSentOffer = false
+let chatSubscription = null
 
 function ensureValidRoute() {
   if (!roomId.value) {
@@ -150,6 +317,160 @@ async function createOffer() {
   }
 }
 
+function normalizeMessage(message) {
+  return {
+    id: message.messageId ?? `${Date.now()}-${Math.random()}`,
+    roomId: message.roomId,
+    senderLoginId: message.senderLoginId || '',
+    senderNickName: message.senderNickName || '시스템',
+    contentType: message.contentType || 'TEXT',
+    content: message.content || '',
+    fileUrl: message.fileUrl || '',
+    fileName: message.fileName || '',
+    mimeType: message.mimeType || '',
+    sizeBytes: message.sizeBytes || 0,
+    sentAt: message.sentAt || new Date().toISOString(),
+    translatedText: message.translatedText || null,
+    saving: false,
+  }
+}
+
+async function ensureTranslated(message) {
+  if (!translateEnabled.value) return
+  if (message.senderLoginId === myLoginId.value) return
+  if (message.contentType !== 'TEXT' || !message.content) return
+  if (message.translatedText) return
+  try {
+    const { translatedText } = await translate(message.content, { targetLang: targetLang.value })
+    message.translatedText = translatedText
+  } catch (error) {
+    console.error('번역 실패', error)
+  }
+}
+
+async function loadHistory() {
+  chatLoading.value = true
+  try {
+    const { data } = await api.get(`/rooms/${roomId.value}/messages`, {
+      params: { page: 0, size: 50 },
+    })
+    chatMessages.value = (data.messages || []).map(normalizeMessage)
+    if (translateEnabled.value) {
+      for (const message of chatMessages.value) {
+        await ensureTranslated(message)
+      }
+    }
+    scrollChatToBottom()
+  } catch (error) {
+    console.error('Failed to load chat history', error)
+  } finally {
+    chatLoading.value = false
+  }
+}
+
+function subscribeChat() {
+  if (!client?.connected || !roomId.value) return
+  chatSubscription?.unsubscribe?.()
+  chatSubscription = client.subscribe(`/topic/rooms/${roomId.value}`, (frame) => {
+    try {
+      const payload = JSON.parse(frame.body)
+      const message = normalizeMessage(payload)
+      chatMessages.value.push(message)
+      ensureTranslated(message)
+      scrollChatToBottom()
+    } catch (error) {
+      console.error('Failed to handle chat frame', error)
+    }
+  })
+}
+
+function scrollChatToBottom() {
+  nextTick(() => {
+    const el = messageContainer.value
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  })
+}
+
+async function sendChat() {
+  if (!client?.connected || !chatInput.value.trim()) {
+    return
+  }
+
+  sending.value = true
+  try {
+    const payload = {
+      roomId: roomId.value,
+      content: chatInput.value.trim(),
+      contentType: 'TEXT',
+    }
+    client.publish({
+      destination: `/app/chat.sendMessage/${roomId.value}`,
+      body: JSON.stringify(payload),
+    })
+    chatInput.value = ''
+  } catch (error) {
+    console.error('Failed to send chat message', error)
+  } finally {
+    sending.value = false
+  }
+}
+
+function triggerFileSelect() {
+  fileInput.value?.click()
+}
+
+async function onFileSelected(event) {
+  const file = event.target?.files?.[0]
+  event.target.value = ''
+  if (!file) return
+  uploading.value = true
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    await api.post(`/rooms/${roomId.value}/files`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  } catch (error) {
+    console.error('Failed to upload file', error)
+    alert('파일 업로드에 실패했습니다. 다시 시도해주세요.')
+  } finally {
+    uploading.value = false
+  }
+}
+
+function toggleTranslate() {
+  translateEnabled.value = !translateEnabled.value
+  if (translateEnabled.value) {
+    chatMessages.value.forEach((message) => {
+      ensureTranslated(message)
+    })
+  }
+}
+
+async function storeWord(message) {
+  if (!message.translatedText) return
+  message.saving = true
+  try {
+    await saveVocabulary(message.content, message.translatedText)
+  } catch (error) {
+    console.error('단어 저장 실패', error)
+  } finally {
+    message.saving = false
+  }
+}
+
+async function followPartner() {
+  if (!partnerLoginId.value) return
+  try {
+    await friendsStore.add(partnerLoginId.value)
+  } catch (error) {
+    console.error('친구 추가 실패', error)
+    alert('친구 추가에 실패했습니다. 다시 시도해주세요.')
+  }
+}
+
 async function handleSignalMessage(payload) {
   if (!pc || !payload || payload.senderLoginId === myLoginId.value) {
     return
@@ -198,6 +519,9 @@ function startStomp() {
       subscribeDest: '/user/queue/signals',
       onSignal: handleSignalMessage,
     })
+
+    subscribeChat()
+    await loadHistory()
 
     if (shouldInitiate.value) {
       await createOffer()
@@ -261,6 +585,11 @@ function stopMedia() {
 
 function cleanupConnections() {
   try {
+    chatSubscription?.unsubscribe?.()
+  } catch (err) {
+    console.warn('Failed to unsubscribe from chat topic', err)
+  }
+  try {
     signal?.sub?.unsubscribe?.()
   } catch (err) {
     console.warn('Failed to unsubscribe from signaling channel', err)
@@ -283,7 +612,15 @@ function leaveCall() {
   router.replace({ name: 'match' })
 }
 
+function formatTime(timestamp) {
+  if (!timestamp) return ''
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
 onMounted(() => {
+  friendsStore.fetch()
   setupCall().catch((err) => {
     console.error('Failed to start call', err)
     cleanupConnections()
@@ -299,13 +636,26 @@ watch(partnerLoginId, (value) => {
     createOffer()
   }
 })
+
+watch(targetLang, () => {
+  if (translateEnabled.value) {
+    chatMessages.value.forEach((message) => {
+      message.translatedText = null
+      ensureTranslated(message)
+    })
+  }
+})
 </script>
 
 <style scoped>
+.video-chat-card {
+  min-height: 520px;
+}
+
 .video-stage {
   position: relative;
   width: 100%;
-  min-height: 320px;
+  min-height: 360px;
   background-color: #f5f5f5;
   border-radius: 12px;
   overflow: hidden;
@@ -345,9 +695,103 @@ watch(partnerLoginId, (value) => {
 
 .control-buttons {
   display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 16px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.chat-panel {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  padding: 16px;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 8px;
+  margin-bottom: 12px;
+  max-height: 400px;
+}
+
+.chat-message {
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-message.mine {
+  align-items: flex-end;
+}
+
+.chat-message .meta {
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.54);
+  margin-bottom: 4px;
+}
+
+.chat-message.mine .bubble {
+  background-color: #f48fb1;
+  color: #fff;
+}
+
+.bubble {
+  padding: 10px 12px;
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 10px;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+.translated {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+}
+
+.file-bubble {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.chat-image {
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+.file-link {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+.chat-input {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.lang-select {
+  min-width: 110px;
+}
+
+@media (max-width: 960px) {
+  .chat-messages {
+    max-height: 280px;
+  }
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/views/Vocabulary.vue
+++ b/frontend/src/views/Vocabulary.vue
@@ -1,9 +1,10 @@
 <template>
   <v-container class="py-4">
     <h2 class="text-h5 mb-4">단어장</h2>
-    <v-list>
-      <v-list-item v-for="(w, i) in words" :key="i">
-        <v-list-item-title>{{ w.original }} - {{ w.translated }}</v-list-item-title>
+    <v-progress-circular v-if="loading" indeterminate color="pink" class="my-6" />
+    <v-list v-else>
+      <v-list-item v-for="(w, i) in words" :key="w.id ?? i">
+        <v-list-item-title>{{ w.originalText ?? w.original }} - {{ w.translatedText ?? w.translated }}</v-list-item-title>
       </v-list-item>
       <v-list-item v-if="!words.length">
         <v-list-item-title>저장된 단어가 없습니다.</v-list-item-title>
@@ -13,11 +14,16 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useVocabularyStore } from '../stores/vocabulary';
 
 const store = useVocabularyStore();
-const { words } = storeToRefs(store);
+const { words, loading } = storeToRefs(store);
+
+onMounted(() => {
+  store.fetch();
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- expand the messaging backend with follow management, translation/vocabulary APIs, and file-capable chat payloads
- reuse or create private rooms during matchmaking, expose history and invite endpoints, and secure the new APIs with JWT
- redesign the random video and messenger UIs to host side-by-side text chat with translation toggles, file sharing, and follow controls wired to the new services

## Testing
- `./gradlew test` *(fails: Java 17 toolchain not provisioned in container)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c937d5932c8325a2388893eadbfa97