### PR TITLE
feat: secure websocket handshake with jwt

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/JwtHandshakeHandler.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtHandshakeHandler.java
@@ -1,0 +1,33 @@
+package net.datasa.project01.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class JwtHandshakeHandler extends DefaultHandshakeHandler {
+
+    @Override
+    @Nullable
+    protected Principal determineUser(
+            ServerHttpRequest request,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes) {
+
+        Object principal = attributes.get(JwtHandshakeInterceptor.WEBSOCKET_PRINCIPAL_ATTR);
+
+        if (principal instanceof Principal resolvedPrincipal) {
+            log.debug("Using principal from handshake attributes: {}", resolvedPrincipal.getName());
+            return resolvedPrincipal;
+        }
+
+        return super.determineUser(request, wsHandler, attributes);
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/config/JwtHandshakeInterceptor.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtHandshakeInterceptor.java
@@ -1,0 +1,112 @@
+package net.datasa.project01.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.util.JwtUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    static final String WEBSOCKET_PRINCIPAL_ATTR = "WEBSOCKET_PRINCIPAL";
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String TOKEN_QUERY_PARAM = "token";
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes) {
+
+        String token = resolveToken(request);
+
+        if (!StringUtils.hasText(token)) {
+            log.debug("No JWT provided during WebSocket handshake. uri={}", request.getURI());
+            return true;
+        }
+
+        try {
+            if (jwtUtil.validateToken(token)) {
+                String username = jwtUtil.getUsernameFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities());
+
+                attributes.put(WEBSOCKET_PRINCIPAL_ATTR, authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                if (request instanceof ServletServerHttpRequest servletRequest) {
+                    servletRequest.getServletRequest()
+                            .setAttribute(WEBSOCKET_PRINCIPAL_ATTR, authentication);
+                }
+
+                log.info("WebSocket handshake authenticated for user: {}", username);
+            } else {
+                log.warn("JWT validation failed during WebSocket handshake. uri={}", request.getURI());
+            }
+        } catch (Exception ex) {
+            log.error("Unexpected error during WebSocket handshake authentication", ex);
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception) {
+        SecurityContextHolder.clearContext();
+    }
+
+    private String resolveToken(ServerHttpRequest request) {
+        HttpHeaders headers = request.getHeaders();
+        String authHeader = headers.getFirst(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length());
+        }
+
+        URI uri = request.getURI();
+        MultiValueMap<String, String> queryParams = UriComponentsBuilder.fromUri(uri)
+                .build()
+                .getQueryParams();
+
+        String queryToken = queryParams.getFirst(TOKEN_QUERY_PARAM);
+
+        if (StringUtils.hasText(queryToken)) {
+            return queryToken;
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/**",
             "/api/users/**",
-            "/api/auth/**"
+            "/api/auth/**",
+            "/ws-stomp/**"
     };
 
     private static final String[] PROTECTED_ENDPOINTS = {

--- a/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
@@ -25,6 +25,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompHandler stompHandler;
     private final StompInboundLoggingInterceptor stompInboundLoggingInterceptor;
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+    private final JwtHandshakeHandler jwtHandshakeHandler;
 
     private static final int INBOUND_CORE_POOL_SIZE = 8;
     private static final int INBOUND_MAX_POOL_SIZE = 32;
@@ -39,7 +41,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
-                .setAllowedOriginPatterns("http://localhost:5173") // 개발용
+                .addInterceptors(jwtHandshakeInterceptor)
+                .setHandshakeHandler(jwtHandshakeHandler)
+                .setAllowedOriginPatterns(
+                        "http://localhost:5173",
+                        "https://*.ngrok-free.app",
+                        "https://matcha-talk.datasa.app")
                 .withSockJS();  // ★ SockJS 필수
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,6 +30,7 @@ logging.level.root=INFO
 logging.level.org.springframework.web=INFO
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.net.datasa.project01=DEBUG
 
 ############################################
 # === mock ?? ??: JPA/DB ???? ???? ===

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -10,8 +10,12 @@ const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api'
 const origin = apiBase.replace(/\/api\/?$/, '')
 
 export function createStompClient(token) {
+    const sockJsUrl = token
+        ? `${origin}${WS_PATH}?token=${encodeURIComponent(token)}`
+        : `${origin}${WS_PATH}`
+
     const client = new Client({
-        webSocketFactory: () => new SockJS(origin + WS_PATH),
+        webSocketFactory: () => new SockJS(sockJsUrl),
         connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
         reconnectDelay: 3000,
         debug: () => {} // 필요 시 콘솔 출력


### PR DESCRIPTION
## Summary
- add a JWT-based HandshakeInterceptor/handler pair to preload principals during the WebSocket handshake
- permit the `/ws-stomp/**` handshake path while expanding allowed origins and debug logging for diagnostics
- send JWTs via SockJS query strings alongside STOMP headers so both interceptors can read them

## Testing
- `./gradlew test` *(fails: Gradle toolchain cannot locate a Java 17 installation in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c969b321608325be02b7a1e7ffb525