### PR TITLE
Improve matching response handling and handshake auth

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.service.MatchService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,28 +28,31 @@ public class MatchController {
      * @return 요청 접수 결과
      */
     @PostMapping("/requests")
-    public ResponseEntity<String> startRandomMatch(
+    public ResponseEntity<MatchStartResponseDto> startRandomMatch(
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody MatchRequestDto dto) {
 
         if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
         try {
             String loginId = userDetails.getUsername();
             log.info("Match request received from user: {}", loginId);
-            matchService.startOrFindMatch(loginId, dto);
+            MatchStartResponseDto responseDto = matchService.startOrFindMatch(loginId, dto);
 
-            // TODO: MatchService의 결과에 따라 다른 응답 반환 (대기열 등록 or 매칭 성공)
-            return ResponseEntity.ok("매칭 요청이 성공적으로 접수되었습니다.");
+            return ResponseEntity.ok(responseDto);
 
         } catch (JsonProcessingException e) {
             log.error("JSON processing error during match request for user: {}", userDetails.getUsername(), e);
-            return ResponseEntity.internalServerError().body("매칭 요청 처리 중 오류가 발생했습니다.");
+            return ResponseEntity.internalServerError().body(MatchStartResponseDto.builder()
+                    .message("매칭 요청 처리 중 오류가 발생했습니다.")
+                    .build());
         } catch (IllegalArgumentException e) {
             log.warn("Invalid match request from user: {}. Reason: {}", userDetails.getUsername(), e.getMessage());
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseEntity.badRequest().body(MatchStartResponseDto.builder()
+                    .message(e.getMessage())
+                    .build());
         }
     }
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
@@ -1,0 +1,29 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchStartResponseDto {
+
+    public enum Status {
+        MATCHED,
+        QUEUED,
+        ALREADY_IN_QUEUE
+    }
+
+    public enum QueueState {
+        EMPTY,
+        WAITING
+    }
+
+    private Status status;
+    private QueueState queueState;
+    private MatchFoundResponseDto match;
+    private String message;
+}

--- a/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -22,12 +22,16 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
             "AND (:myChoiceGender = 'A' OR u.gender = :myChoiceGender) " +
             // 상대방의 나이가 나의 희망 나이 범위에 속함
             "AND FUNCTION('TIMESTAMPDIFF', YEAR, u.birthDate, CURRENT_DATE) BETWEEN :myMinAge AND :myMaxAge " +
+            "AND mr.regionCode = :myRegionCode " +
             "ORDER BY mr.requestedAt ASC")
     List<MatchRequest> findPotentialMatches(
             @Param("myPid") Long myPid,
             @Param("myChoiceGender") String myChoiceGender,
             @Param("myMinAge") Integer myMinAge,
             @Param("myMaxAge") Integer myMaxAge,
+            @Param("myRegionCode") String myRegionCode,
             @Param("status") MatchRequest.MatchStatus status
     );
+
+    boolean existsByStatusAndRegionCode(MatchRequest.MatchStatus status, String regionCode);
 }

--- a/backend/src/test/java/net/datasa/project01/Project01ApplicationTests.java
+++ b/backend/src/test/java/net/datasa/project01/Project01ApplicationTests.java
@@ -2,12 +2,14 @@ package net.datasa.project01;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class Project01ApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/backend/src/test/java/net/datasa/project01/service/MatchServiceTest.java
+++ b/backend/src/test/java/net/datasa/project01/service/MatchServiceTest.java
@@ -1,0 +1,210 @@
+package net.datasa.project01.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
+import net.datasa.project01.domain.entity.MatchRequest;
+import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.MatchRequestRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceTest {
+
+    @Mock
+    private MatchRequestRepository matchRequestRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatService chatService;
+
+    @Mock
+    private SimpMessageSendingOperations messagingTemplate;
+
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private MatchService matchService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        matchService = new MatchService(
+                matchRequestRepository,
+                userRepository,
+                chatService,
+                messagingTemplate,
+                objectMapper
+        );
+    }
+
+    @Test
+    @DisplayName("조건을 모두 만족하는 상대가 있으면 즉시 매칭 상태를 반환한다")
+    void startOrFindMatch_shouldReturnMatchedResponse() throws Exception {
+        User me = createUser(1L, "me", "M", LocalDate.now().minusYears(25));
+        User opponent = createUser(2L, "you", "F", LocalDate.now().minusYears(24));
+
+        MatchRequestDto requestDto = createRequestDto("F", 20, 30, "SEOUL", List.of("음악", "게임"));
+
+        MatchRequest opponentRequest = MatchRequest.builder()
+                .user(opponent)
+                .choiceGender(MatchRequest.Gender.M)
+                .minAge(20)
+                .maxAge(32)
+                .regionCode("SEOUL")
+                .interestsJson(objectMapper.writeValueAsString(List.of("음악", "여행")))
+                .status(MatchRequest.MatchStatus.WAITING)
+                .build();
+
+        Room room = Room.builder()
+                .roomId(101L)
+                .roomType(Room.RoomType.PRIVATE)
+                .capacity(2)
+                .build();
+
+        given(userRepository.findByLoginId("me")).willReturn(Optional.of(me));
+        given(matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING)).willReturn(Optional.empty());
+        given(matchRequestRepository.existsByStatusAndRegionCode(MatchRequest.MatchStatus.WAITING, "SEOUL")).willReturn(true);
+        given(matchRequestRepository.findPotentialMatches(
+                me.getUserPid(),
+                requestDto.getChoiceGender(),
+                requestDto.getMinAge(),
+                requestDto.getMaxAge(),
+                requestDto.getRegionCode(),
+                MatchRequest.MatchStatus.WAITING
+        )).willReturn(List.of(opponentRequest));
+        given(chatService.getOrCreatePrivateRoom("me", "you")).willReturn(room);
+
+        MatchStartResponseDto response = matchService.startOrFindMatch("me", requestDto);
+
+        assertThat(response.getStatus()).isEqualTo(MatchStartResponseDto.Status.MATCHED);
+        assertThat(response.getMatch()).isNotNull();
+        assertThat(response.getMatch().getRoomId()).isEqualTo(101L);
+        assertThat(response.getMatch().getPartnerNickName()).isEqualTo(opponent.getNickName());
+
+        verify(messagingTemplate).convertAndSendToUser(eq("me"), eq("/queue/match-results"), any());
+        verify(messagingTemplate).convertAndSendToUser(eq("you"), eq("/queue/match-results"), any());
+        verify(matchRequestRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("조건에 맞는 사용자가 없고 대기열도 비어있으면 EMPTY 상태로 대기열 등록을 알린다")
+    void startOrFindMatch_shouldReturnQueuedEmptyWhenNoWaitingUsers() throws Exception {
+        User me = createUser(10L, "alpha", "F", LocalDate.now().minusYears(27));
+        MatchRequestDto requestDto = createRequestDto("M", 23, 33, "BUSAN", List.of("독서"));
+
+        given(userRepository.findByLoginId("alpha")).willReturn(Optional.of(me));
+        given(matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING)).willReturn(Optional.empty());
+        given(matchRequestRepository.existsByStatusAndRegionCode(MatchRequest.MatchStatus.WAITING, "BUSAN")).willReturn(false);
+        given(matchRequestRepository.findPotentialMatches(
+                me.getUserPid(),
+                requestDto.getChoiceGender(),
+                requestDto.getMinAge(),
+                requestDto.getMaxAge(),
+                requestDto.getRegionCode(),
+                MatchRequest.MatchStatus.WAITING
+        )).willReturn(List.of());
+
+        MatchStartResponseDto response = matchService.startOrFindMatch("alpha", requestDto);
+
+        assertThat(response.getStatus()).isEqualTo(MatchStartResponseDto.Status.QUEUED);
+        assertThat(response.getQueueState()).isEqualTo(MatchStartResponseDto.QueueState.EMPTY);
+        assertThat(response.getMessage()).contains("대기열에 등록");
+
+        ArgumentCaptor<MatchRequest> captor = ArgumentCaptor.forClass(MatchRequest.class);
+        verify(matchRequestRepository).save(captor.capture());
+        MatchRequest saved = captor.getValue();
+        assertThat(saved.getRegionCode()).isEqualTo("BUSAN");
+        assertThat(saved.getChoiceGender()).isEqualTo(MatchRequest.Gender.M);
+    }
+
+    @Test
+    @DisplayName("관심사가 겹치지 않는 경우 대기열 유지 상태를 반환한다")
+    void startOrFindMatch_shouldReturnQueuedWaitingWhenInterestsDoNotOverlap() throws Exception {
+        User me = createUser(21L, "beta", "M", LocalDate.now().minusYears(22));
+        User opponent = createUser(30L, "gamma", "F", LocalDate.now().minusYears(23));
+
+        MatchRequestDto requestDto = createRequestDto("F", 20, 30, "SEOUL", List.of("여행"));
+
+        MatchRequest opponentRequest = MatchRequest.builder()
+                .user(opponent)
+                .choiceGender(MatchRequest.Gender.M)
+                .minAge(20)
+                .maxAge(30)
+                .regionCode("SEOUL")
+                .interestsJson(objectMapper.writeValueAsString(List.of("독서")))
+                .status(MatchRequest.MatchStatus.WAITING)
+                .build();
+
+        given(userRepository.findByLoginId("beta")).willReturn(Optional.of(me));
+        given(matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING)).willReturn(Optional.empty());
+        given(matchRequestRepository.existsByStatusAndRegionCode(MatchRequest.MatchStatus.WAITING, "SEOUL")).willReturn(true);
+        given(matchRequestRepository.findPotentialMatches(
+                me.getUserPid(),
+                requestDto.getChoiceGender(),
+                requestDto.getMinAge(),
+                requestDto.getMaxAge(),
+                requestDto.getRegionCode(),
+                MatchRequest.MatchStatus.WAITING
+        )).willReturn(List.of(opponentRequest));
+
+        MatchStartResponseDto response = matchService.startOrFindMatch("beta", requestDto);
+
+        assertThat(response.getStatus()).isEqualTo(MatchStartResponseDto.Status.QUEUED);
+        assertThat(response.getQueueState()).isEqualTo(MatchStartResponseDto.QueueState.WAITING);
+        assertThat(response.getMessage()).contains("조건에 맞는 사용자를 찾지 못했습니다");
+
+        verify(matchRequestRepository).save(any(MatchRequest.class));
+        verify(messagingTemplate, never()).convertAndSendToUser(eq("beta"), eq("/queue/match-results"), any());
+    }
+
+    private MatchRequestDto createRequestDto(String gender, int minAge, int maxAge, String region, List<String> interests) {
+        MatchRequestDto dto = new MatchRequestDto();
+        dto.setChoiceGender(gender);
+        dto.setMinAge(minAge);
+        dto.setMaxAge(maxAge);
+        dto.setRegionCode(region);
+        dto.setInterests(interests);
+        return dto;
+    }
+
+    private User createUser(Long id, String loginId, String gender, LocalDate birthDate) {
+        return User.builder()
+                .userPid(id)
+                .loginId(loginId)
+                .passwordHash("password")
+                .nickName(loginId + "-nick")
+                .email(loginId + "@example.com")
+                .countryCode("KR")
+                .gender(gender)
+                .birthDate(birthDate)
+                .emailVerified(true)
+                .failedLoginCount(0)
+                .enabled(true)
+                .roleName("ROLE_USER")
+                .build();
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,15 @@
+spring.datasource.url=jdbc:h2:mem:matchtalk;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.profiles.active=test
+spring.main.allow-bean-definition-overriding=true
+
+jwt.secret=TestSecretKeyForJwtTokenThatIsLongEnoughToPassValidation1234567890
+jwt.expiration=3600000

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -10,7 +10,12 @@ const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api'
 const origin = apiBase.replace(/\/api\/?$/, '')
 
 export function createStompClient(token) {
-    const sockJsUrl = `${origin}${WS_PATH}`
+    let sockJsUrl = `${origin}${WS_PATH}`
+
+    if (token) {
+        const separator = sockJsUrl.includes('?') ? '&' : '?'
+        sockJsUrl = `${sockJsUrl}${separator}token=${encodeURIComponent(token)}`
+    }
 
     const client = new Client({
         webSocketFactory: () => new SockJS(sockJsUrl),

--- a/frontend/src/views/MatchingSetup.vue
+++ b/frontend/src/views/MatchingSetup.vue
@@ -156,8 +156,15 @@ async function startMatch() {
     interests: interests.value,
   }
   try {
-    await api.post('/match/requests', payload)
-    router.push('/match/result')
+    const { data } = await api.post('/match/requests', payload)
+    if (data) {
+      try {
+        sessionStorage.setItem('matchStartResponse', JSON.stringify(data))
+      } catch (storageError) {
+        console.warn('Failed to persist match start response to sessionStorage', storageError)
+      }
+    }
+    router.push({ name: 'match-result' })
   } catch (e) {
     const status = e?.response?.status
     if (status === 401) {


### PR DESCRIPTION
## Summary
- return structured `MatchStartResponseDto` results, apply region/interest checks when finding opponents, and cover the scenarios with unit tests
- surface the new response through the controller while providing H2-backed test configuration
- persist match-start responses on the client, display queue feedback, and include the JWT in the SockJS handshake URL

## Testing
- ⚠️ `./gradlew test` *(fails to download Maven Central artifacts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca04980a308325b439f83515b80252