### PR TITLE
fix: align frontend API casing with backend expectations

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,13 +1,42 @@
 import axios from 'axios'
+import { camelizeKeys, snakifyKeys, isTransformable } from '../utils/case'
+
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   withCredentials: true,
 })
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token')
   if (token) config.headers.Authorization = `Bearer ${token}`
+
   const user = JSON.parse(localStorage.getItem('user') || 'null')
   if (user?.id) config.headers['X-USER-PID'] = user.id
+
+  if (config.params && isTransformable(config.params)) {
+    config.params = snakifyKeys(config.params)
+  }
+
+  if (config.data && isTransformable(config.data)) {
+    config.data = snakifyKeys(config.data)
+  }
+
   return config
 })
+
+api.interceptors.response.use(
+  (response) => {
+    if (response?.data && isTransformable(response.data)) {
+      response.data = camelizeKeys(response.data)
+    }
+    return response
+  },
+  (error) => {
+    if (error?.response?.data && isTransformable(error.response.data)) {
+      error.response.data = camelizeKeys(error.response.data)
+    }
+    return Promise.reject(error)
+  }
+)
+
 export default api

--- a/frontend/src/utils/case.js
+++ b/frontend/src/utils/case.js
@@ -1,0 +1,46 @@
+const toCamel = (key = '') => {
+  const normalized = key.replace(/[_-]+(\w)/g, (_, c) => (c ? c.toUpperCase() : ''))
+  if (!normalized) return normalized
+  return normalized.charAt(0).toLowerCase() + normalized.slice(1)
+}
+
+const toSnake = (key = '') =>
+  key
+    .replace(/([A-Z]+)/g, '_$1')
+    .replace(/[-\s]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+/, '')
+    .toLowerCase()
+
+const isPlainObject = (value) =>
+  Object.prototype.toString.call(value) === '[object Object]'
+
+export const camelizeKeys = (input) => {
+  if (Array.isArray(input)) {
+    return input.map((item) => camelizeKeys(item))
+  }
+  if (isPlainObject(input)) {
+    return Object.entries(input).reduce((acc, [key, value]) => {
+      const camelKey = toCamel(key)
+      acc[camelKey] = camelizeKeys(value)
+      return acc
+    }, {})
+  }
+  return input
+}
+
+export const snakifyKeys = (input) => {
+  if (Array.isArray(input)) {
+    return input.map((item) => snakifyKeys(item))
+  }
+  if (isPlainObject(input)) {
+    return Object.entries(input).reduce((acc, [key, value]) => {
+      const snakeKey = toSnake(key)
+      acc[snakeKey] = snakifyKeys(value)
+      return acc
+    }, {})
+  }
+  return input
+}
+
+export const isTransformable = (value) => Array.isArray(value) || isPlainObject(value)


### PR DESCRIPTION
## Summary
- add key casing utilities to convert between camelCase and snake_case
- update axios service to send snake_case payloads and normalize API responses

## Testing
- npm run build *(fails: Cannot find module vite/dist/node/chunks/dep-D_zLpgQd.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5a25b6d08325a730a5feba9f0f6c