### PR TITLE
Fix signup form payload and login check params

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -13,12 +13,18 @@ api.interceptors.request.use((config) => {
   const user = JSON.parse(localStorage.getItem('user') || 'null')
   if (user?.id) config.headers['X-USER-PID'] = user.id
 
-  if (config.params && isTransformable(config.params)) {
+  const { skipSnakifyParams } = config
+
+  if (config.params && !skipSnakifyParams && isTransformable(config.params)) {
     config.params = snakifyKeys(config.params)
   }
 
   if (config.data && isTransformable(config.data)) {
     config.data = snakifyKeys(config.data)
+  }
+
+  if (skipSnakifyParams) {
+    delete config.skipSnakifyParams
   }
 
   return config


### PR DESCRIPTION
## Summary
- allow axios requests to opt out of snake_casing query parameters so the login ID check hits the expected backend signature
- capture the user's preferred language during sign-up, ensure the verification code field name matches the backend DTO, and keep camelCase query params when checking duplicate IDs

## Testing
- npm run build *(fails: Vite CLI looks for dep-D_zLpgQd.js which is missing even after reinstalling dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca719025d883258750273fbf1c60bf