### PR TITLE
Align JWT auth and match API contracts

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package net.datasa.project01.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 인증이 필요한 경로에 토큰 없이 접근할 경우 401 JSON 응답을 내려주는 엔트리 포인트.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        log.debug("Unauthorized request to {}", request.getRequestURI());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        var body = Map.of("message", "인증이 필요한 요청입니다.");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtAuthenticationFilter.java
@@ -48,11 +48,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private String extractTokenFromRequest(HttpServletRequest request) {
         String authHeader = request.getHeader(AUTHORIZATION_HEADER);
-        
+
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
             return authHeader.substring(BEARER_PREFIX.length());
         }
-        
+
+        String tokenParam = request.getParameter("access_token");
+        if (tokenParam != null && !tokenParam.isBlank()) {
+            return tokenParam;
+        }
+
         return null;
     }
     

--- a/backend/src/main/java/net/datasa/project01/controller/AuthController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/AuthController.java
@@ -2,7 +2,7 @@ package net.datasa.project01.controller;
 
 import lombok.RequiredArgsConstructor;
 import net.datasa.project01.domain.dto.LoginRequest;
-import net.datasa.project01.domain.dto.UserSummary;
+import net.datasa.project01.domain.dto.LoginResponse;
 import net.datasa.project01.service.AuthService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +44,10 @@ public class AuthController {
      * - 성공 시: UserSummary만 내려 UI가 필요한 최소 정보만 제공한다(민감정보 제외).
      */
     @PostMapping(value = "/login", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<UserSummary> loginLocal(@RequestBody @Validated LoginRequest req) {
+    public ResponseEntity<LoginResponse> loginLocal(@RequestBody @Validated LoginRequest req) {
         // 서비스 계층에 실제 인증을 위임한다.
-        UserSummary user = authService.loginLocal(req.getLoginId(), req.getPassword());
-        // 성공 응답: 200 OK + UserSummary(JSON)
-        return ResponseEntity.ok(user);
+        LoginResponse response = authService.loginLocal(req.getLoginId(), req.getPassword());
+        // 성공 응답: 200 OK + LoginResponse(JSON)
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/LoginResponse.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/LoginResponse.java
@@ -1,0 +1,19 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 성공 시 JWT 토큰과 사용자 요약 정보를 함께 내려주는 응답 DTO.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String token;
+    private UserSummary user;
+}

--- a/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
     // 현재 사용자가 대기열에 있는지 확인하는 메소드는 그대로 유지합니다.
     Optional<MatchRequest> findByUserAndStatus(User user, MatchRequest.MatchStatus status);
+    Optional<MatchRequest> findTopByUserAndStatusOrderByRequestedAtDesc(User user, MatchRequest.MatchStatus status);
+    Optional<MatchRequest> findFirstByRoomAndUserNot(Room room, User user);
+    long countByStatus(MatchRequest.MatchStatus status);
 
     // [수정됨] '나의 조건'에 맞는 잠재적 매칭 상대를 찾는 더 간단한 쿼리
     @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user u " +

--- a/backend/src/main/java/net/datasa/project01/service/AuthService.java
+++ b/backend/src/main/java/net/datasa/project01/service/AuthService.java
@@ -1,6 +1,6 @@
 package net.datasa.project01.service;
 
-import net.datasa.project01.domain.dto.UserSummary;
+import net.datasa.project01.domain.dto.LoginResponse;
 
 /**
  * 로그인 기능 "계약" (저장소가 mock이든 JPA든 동일 규칙)
@@ -14,5 +14,5 @@ public interface AuthService {
      * @return 로그인 성공한 User의 안전한 요약
      * @throws IllegalArgumentException 인증 실패/잠금/비활성 등
      */
-    UserSummary loginLocal(String loginId, String rawPassword);
+    LoginResponse loginLocal(String loginId, String rawPassword);
 }

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.datasa.project01.domain.dto.MatchFoundResponseDto;
+import net.datasa.project01.domain.dto.MatchDecisionResponseDto;
+import net.datasa.project01.domain.dto.MatchEventMessage;
 import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
@@ -32,92 +34,319 @@ public class MatchService {
     private final SimpMessageSendingOperations messagingTemplate;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 랜덤 매칭을 시작하거나 대기열에서 상대를 찾기
-     * @param loginId 요청한 사용자의 ID
-     * @param requestDto 매칭 조건
-     * 주요 로직들이 다수 들어가있으므로 매우 중요함
-     * 작동 안할 시 로직에 대해 다시 고려해볼 것
-     */
-    public void startOrFindMatch(String loginId, MatchRequestDto requestDto) throws JsonProcessingException {
+    public MatchStartResponseDto startOrFindMatch(String loginId, MatchRequestDto requestDto) throws JsonProcessingException {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 1. 이미 대기열에 있는지 확인
-        Optional<MatchRequest> existingRequest = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING);
-        if (existingRequest.isPresent()) {
-            log.info("User {} is already in the matching queue.", loginId);
-            return; // 이미 대기 중이므로 아무것도 하지 않음
+        MatchRequest existingMatch = findLatestByStatuses(me,
+                List.of(MatchRequest.MatchStatus.MATCHED, MatchRequest.MatchStatus.CONFIRMED));
+        if (existingMatch != null) {
+            MatchRequest partnerRequest = findPartnerRequest(existingMatch).orElse(null);
+            Room room = existingMatch.getRoom();
+            boolean shouldCreateOffer = partnerRequest != null && room != null
+                    && shouldCreateOffer(me, partnerRequest.getUser());
+
+            return buildMatchStartResponse(
+                    MatchStartResponseDto.MatchState.MATCHED,
+                    existingMatch,
+                    partnerRequest,
+                    room,
+                    "이미 매칭된 상대가 있습니다.",
+                    shouldCreateOffer
+            );
         }
 
-        // 2. 나의 조건에 맞는 잠재적 매칭 상대 목록 조회
+        MatchRequest waitingRequest = findLatestByStatuses(me, List.of(MatchRequest.MatchStatus.WAITING));
+        if (waitingRequest != null) {
+            long waitingCount = matchRequestRepository.countByStatus(MatchRequest.MatchStatus.WAITING);
+            return MatchStartResponseDto.builder()
+                    .state(MatchStartResponseDto.MatchState.ALREADY_WAITING)
+                    .myRequestId(waitingRequest.getRequestId())
+                    .waitingCount(waitingCount)
+                    .message("이미 매칭 대기 중입니다.")
+                    .build();
+        }
+
+        Optional<MatchRequest> opponentOptional = findCompatibleWaitingRequest(me, requestDto);
+        if (opponentOptional.isPresent()) {
+            MatchRequest opponentRequest = opponentOptional.get();
+            User partner = opponentRequest.getUser();
+
+            opponentRequest.setStatus(MatchRequest.MatchStatus.MATCHED);
+
+            MatchRequest myRequest = MatchRequest.builder()
+                    .user(me)
+                    .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
+                    .minAge(requestDto.getMinAge())
+                    .maxAge(requestDto.getMaxAge())
+                    .regionCode(requestDto.getRegionCode())
+                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
+                    .status(MatchRequest.MatchStatus.MATCHED)
+                    .build();
+            matchRequestRepository.save(myRequest);
+
+            Room room = chatService.createPrivateRoom(me, partner);
+            myRequest.setRoom(room);
+            opponentRequest.setRoom(room);
+
+            matchRequestRepository.save(opponentRequest);
+            matchRequestRepository.save(myRequest);
+
+            boolean myOffer = shouldCreateOffer(me, partner);
+            boolean partnerOffer = shouldCreateOffer(partner, me);
+
+            String message = "새로운 상대와 매칭되었습니다.";
+
+            sendMatchEvent(me, myRequest, opponentRequest, room, MatchEventMessage.EventType.MATCH_FOUND, message, myOffer);
+            sendMatchEvent(partner, opponentRequest, myRequest, room, MatchEventMessage.EventType.MATCH_FOUND, message, partnerOffer);
+
+            return buildMatchStartResponse(
+                    MatchStartResponseDto.MatchState.MATCHED,
+                    myRequest,
+                    opponentRequest,
+                    room,
+                    message,
+                    myOffer
+            );
+        }
+
+        MatchRequest newWaitingRequest = MatchRequest.builder()
+                .user(me)
+                .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
+                .minAge(requestDto.getMinAge())
+                .maxAge(requestDto.getMaxAge())
+                .regionCode(requestDto.getRegionCode())
+                .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
+                .status(MatchRequest.MatchStatus.WAITING)
+                .build();
+        matchRequestRepository.save(newWaitingRequest);
+
+        long waitingCount = matchRequestRepository.countByStatus(MatchRequest.MatchStatus.WAITING);
+        return MatchStartResponseDto.builder()
+                .state(MatchStartResponseDto.MatchState.WAITING)
+                .myRequestId(newWaitingRequest.getRequestId())
+                .waitingCount(waitingCount)
+                .message("매칭 대기열에 등록되었습니다.")
+                .shouldCreateOffer(false)
+                .build();
+    }
+
+    public MatchDecisionResponseDto acceptMatch(String loginId, Long requestId) {
+        User me = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        MatchRequest myRequest = matchRequestRepository.findById(requestId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        validateOwnership(me, myRequest);
+        if (myRequest.getStatus() != MatchRequest.MatchStatus.MATCHED
+                && myRequest.getStatus() != MatchRequest.MatchStatus.CONFIRMED) {
+            throw new IllegalArgumentException("현재 상태에서는 매칭을 수락할 수 없습니다.");
+        }
+
+        myRequest.setStatus(MatchRequest.MatchStatus.CONFIRMED);
+        matchRequestRepository.save(myRequest);
+
+        MatchRequest partnerRequest = findPartnerRequest(myRequest)
+                .orElseThrow(() -> new IllegalArgumentException("상대방 매칭 정보를 찾을 수 없습니다."));
+
+        boolean bothAccepted = partnerRequest.getStatus() == MatchRequest.MatchStatus.CONFIRMED;
+        Room room = myRequest.getRoom();
+
+        sendMatchEvent(
+                partnerRequest.getUser(),
+                partnerRequest,
+                myRequest,
+                room,
+                MatchEventMessage.EventType.PARTNER_ACCEPTED,
+                "상대방이 매칭을 수락했습니다.",
+                shouldCreateOffer(partnerRequest.getUser(), me)
+        );
+
+        if (bothAccepted) {
+            String confirmedMessage = "매칭이 확정되었습니다.";
+            sendMatchEvent(me, myRequest, partnerRequest, room, MatchEventMessage.EventType.BOTH_CONFIRMED, confirmedMessage, shouldCreateOffer(me, partnerRequest.getUser()));
+            sendMatchEvent(partnerRequest.getUser(), partnerRequest, myRequest, room, MatchEventMessage.EventType.BOTH_CONFIRMED, confirmedMessage, shouldCreateOffer(partnerRequest.getUser(), me));
+        }
+
+        return MatchDecisionResponseDto.builder()
+                .decision(MatchDecisionResponseDto.Decision.ACCEPTED)
+                .roomId(room != null ? room.getRoomId() : null)
+                .myRequestId(myRequest.getRequestId())
+                .partnerRequestId(partnerRequest.getRequestId())
+                .myStatus(myRequest.getStatus())
+                .partnerStatus(partnerRequest.getStatus())
+                .bothAccepted(bothAccepted)
+                .message(bothAccepted ? "상대와 연결이 확정되었습니다." : "매칭을 수락했습니다. 상대 응답을 기다리는 중입니다.")
+                .build();
+    }
+
+    public MatchDecisionResponseDto declineMatch(String loginId, Long requestId) {
+        User me = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        MatchRequest myRequest = matchRequestRepository.findById(requestId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        validateOwnership(me, myRequest);
+        if (myRequest.getStatus() == MatchRequest.MatchStatus.DECLINED
+                || myRequest.getStatus() == MatchRequest.MatchStatus.CANCELLED) {
+            return buildDeclineResponse(myRequest, null, "이미 종료된 매칭입니다.");
+        }
+        if (myRequest.getStatus() == MatchRequest.MatchStatus.WAITING) {
+            matchRequestRepository.delete(myRequest);
+            return MatchDecisionResponseDto.builder()
+                    .decision(MatchDecisionResponseDto.Decision.DECLINED)
+                    .message("대기열에서 제외되었습니다.")
+                    .myRequestId(requestId)
+                    .build();
+        }
+
+        myRequest.setStatus(MatchRequest.MatchStatus.DECLINED);
+        matchRequestRepository.save(myRequest);
+
+        MatchRequest partnerRequest = findPartnerRequest(myRequest).orElse(null);
+        Room room = myRequest.getRoom();
+
+        if (partnerRequest != null) {
+            partnerRequest.setStatus(MatchRequest.MatchStatus.CANCELLED);
+            matchRequestRepository.save(partnerRequest);
+
+            sendMatchEvent(
+                    partnerRequest.getUser(),
+                    partnerRequest,
+                    myRequest,
+                    room,
+                    MatchEventMessage.EventType.PARTNER_DECLINED,
+                    "상대방이 매칭을 거절했습니다.",
+                    shouldCreateOffer(partnerRequest.getUser(), me)
+            );
+            sendMatchEvent(
+                    partnerRequest.getUser(),
+                    partnerRequest,
+                    myRequest,
+                    room,
+                    MatchEventMessage.EventType.MATCH_CANCELLED,
+                    "매칭이 취소되었습니다.",
+                    false
+            );
+        }
+
+        sendMatchEvent(me, myRequest, partnerRequest, room, MatchEventMessage.EventType.MATCH_CANCELLED, "매칭을 종료했습니다.", false);
+
+        return buildDeclineResponse(myRequest, partnerRequest, "매칭을 거절했습니다.");
+    }
+
+    private MatchDecisionResponseDto buildDeclineResponse(MatchRequest myRequest, MatchRequest partnerRequest, String message) {
+        return MatchDecisionResponseDto.builder()
+                .decision(MatchDecisionResponseDto.Decision.DECLINED)
+                .roomId(myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null)
+                .myRequestId(myRequest.getRequestId())
+                .partnerRequestId(partnerRequest != null ? partnerRequest.getRequestId() : null)
+                .myStatus(myRequest.getStatus())
+                .partnerStatus(partnerRequest != null ? partnerRequest.getStatus() : MatchRequest.MatchStatus.CANCELLED)
+                .bothAccepted(false)
+                .message(message)
+                .build();
+    }
+
+    private MatchStartResponseDto buildMatchStartResponse(
+            MatchStartResponseDto.MatchState state,
+            MatchRequest myRequest,
+            MatchRequest partnerRequest,
+            Room room,
+            String message,
+            boolean shouldCreateOffer
+    ) {
+        return MatchStartResponseDto.builder()
+                .state(state)
+                .myRequestId(myRequest != null ? myRequest.getRequestId() : null)
+                .partnerRequestId(partnerRequest != null ? partnerRequest.getRequestId() : null)
+                .roomId(room != null ? room.getRoomId() : null)
+                .partnerLoginId(partnerRequest != null ? partnerRequest.getUser().getLoginId() : null)
+                .partnerNickName(partnerRequest != null ? partnerRequest.getUser().getNickName() : null)
+                .message(message)
+                .shouldCreateOffer(shouldCreateOffer)
+                .build();
+    }
+
+    private MatchRequest findLatestByStatuses(User user, List<MatchRequest.MatchStatus> statuses) {
+        for (MatchRequest.MatchStatus status : statuses) {
+            Optional<MatchRequest> request = matchRequestRepository.findTopByUserAndStatusOrderByRequestedAtDesc(user, status);
+            if (request.isPresent()) {
+                return request.get();
+            }
+        }
+        return null;
+    }
+
+    private Optional<MatchRequest> findPartnerRequest(MatchRequest request) {
+        Room room = request.getRoom();
+        if (room == null) {
+            return Optional.empty();
+        }
+        return matchRequestRepository.findFirstByRoomAndUserNot(room, request.getUser());
+    }
+
+    private Optional<MatchRequest> findCompatibleWaitingRequest(User me, MatchRequestDto requestDto) {
         List<MatchRequest> potentialMatches = matchRequestRepository.findPotentialMatches(
                 me.getUserPid(),
                 MatchRequest.MatchStatus.WAITING
         );
 
-        // 3. Java 코드로 최종 매칭 상대 결정 (역방향 검증)
-        MatchRequest matchedOpponentRequest = null;
+        long myAge = ChronoUnit.YEARS.between(me.getBirthDate(), LocalDate.now());
+
         for (MatchRequest opponentRequest : potentialMatches) {
             User opponent = opponentRequest.getUser();
-            long myAge = ChronoUnit.YEARS.between(me.getBirthDate(), LocalDate.now());
+            long opponentAge = ChronoUnit.YEARS.between(opponent.getBirthDate(), LocalDate.now());
 
-            // 상대방의 희망 성별이 '모두(A)'이거나 '나의 성별'과 일치하는지 확인
-            boolean isGenderMatch = opponentRequest.getChoiceGender() == MatchRequest.Gender.A ||
-                    opponentRequest.getChoiceGender().name().equals(me.getGender().toString());
+            boolean meetsOpponentGender = opponentRequest.getChoiceGender() == MatchRequest.Gender.A
+                    || opponentRequest.getChoiceGender().name().equalsIgnoreCase(String.valueOf(me.getGender()));
+            boolean meetsOpponentAge = myAge >= opponentRequest.getMinAge() && myAge <= opponentRequest.getMaxAge();
 
-            // 나의 나이가 상대방의 희망 나이 범위에 속하는지 확인
-            boolean isAgeMatch = myAge >= opponentRequest.getMinAge() && myAge <= opponentRequest.getMaxAge();
+            boolean meetsMyGender = "A".equalsIgnoreCase(requestDto.getChoiceGender())
+                    || requestDto.getChoiceGender().equalsIgnoreCase(String.valueOf(opponent.getGender()));
+            boolean meetsMyAge = opponentAge >= requestDto.getMinAge() && opponentAge <= requestDto.getMaxAge();
+            boolean meetsRegion = requestDto.getRegionCode().equalsIgnoreCase(opponentRequest.getRegionCode());
 
-            if (isGenderMatch && isAgeMatch) {
-                matchedOpponentRequest = opponentRequest;
-                break; // 첫 번째로 찾은 짝과 매칭
+            if (meetsOpponentGender && meetsOpponentAge && meetsMyGender && meetsMyAge && meetsRegion) {
+                return Optional.of(opponentRequest);
             }
         }
 
-        if (matchedOpponentRequest != null) {
-            // 4. 매칭 성공 처리
-            User opponent = matchedOpponentRequest.getUser();
-            log.info("Match found for user {}: {}", loginId, opponent.getLoginId());
+        return Optional.empty();
+    }
 
-            // 두 요청의 상태를 MATCHED로 변경
-            matchedOpponentRequest.setStatus(MatchRequest.MatchStatus.MATCHED);
+    private void sendMatchEvent(
+            User recipient,
+            MatchRequest recipientRequest,
+            MatchRequest partnerRequest,
+            Room room,
+            MatchEventMessage.EventType eventType,
+            String message,
+            boolean shouldCreateOffer
+    ) {
+        MatchEventMessage payload = MatchEventMessage.builder()
+                .eventType(eventType)
+                .roomId(room != null ? room.getRoomId() : null)
+                .myRequestId(recipientRequest != null ? recipientRequest.getRequestId() : null)
+                .partnerRequestId(partnerRequest != null ? partnerRequest.getRequestId() : null)
+                .partnerLoginId(partnerRequest != null ? partnerRequest.getUser().getLoginId() : null)
+                .partnerNickName(partnerRequest != null ? partnerRequest.getUser().getNickName() : null)
+                .shouldCreateOffer(shouldCreateOffer)
+                .message(message)
+                .build();
 
-            // [수정됨] 나의 매칭 요청도 'MATCHED' 상태로 생성하여 기록을 남김
-            MatchRequest myMatchedRequest = MatchRequest.builder()
-                    .user(me)
-                    .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
-                    .minAge(requestDto.getMinAge())
-                    .maxAge(requestDto.getMaxAge())
-                    .regionCode(requestDto.getRegionCode())
-                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
-                    .status(MatchRequest.MatchStatus.MATCHED) // 상태를 MATCHED로 설정
-                    .build();
-            matchRequestRepository.save(myMatchedRequest);
+        messagingTemplate.convertAndSendToUser(recipient.getLoginId(), "/queue/match-results", payload);
+    }
 
-            // 1:1 채팅방 생성
-            Room privateRoom = chatService.createPrivateRoom(me, opponent);
-
-            // 양쪽 사용자에게 매칭 성공 알림 전송 (웹소켓)
-            MatchFoundResponseDto myResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), opponent.getNickName());
-            MatchFoundResponseDto opponentResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), me.getNickName());
-
-            messagingTemplate.convertAndSendToUser(me.getLoginId(), "/queue/match-results", myResponse);
-            messagingTemplate.convertAndSendToUser(opponent.getLoginId(), "/queue/match-results", opponentResponse);
-
-        } else {
-            // 5. 매칭 실패 -> 대기열에 등록
-            log.info("No match found for user {}. Adding to queue.", loginId);
-            MatchRequest newRequest = MatchRequest.builder()
-                    .user(me)
-                    .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
-                    .minAge(requestDto.getMinAge())
-                    .maxAge(requestDto.getMaxAge())
-                    .regionCode(requestDto.getRegionCode())
-                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
-                    .status(MatchRequest.MatchStatus.WAITING)
-                    .build();
-            matchRequestRepository.save(newRequest);
+    private void validateOwnership(User me, MatchRequest myRequest) {
+        if (!myRequest.getUser().getUserPid().equals(me.getUserPid())) {
+            throw new IllegalArgumentException("본인의 매칭 요청만 처리할 수 있습니다.");
         }
+    }
+
+    private boolean shouldCreateOffer(User current, User partner) {
+        return current.getLoginId().compareToIgnoreCase(partner.getLoginId()) <= 0;
     }
 }

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -10,8 +10,14 @@ const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api'
 const origin = apiBase.replace(/\/api\/?$/, '')
 
 export function createStompClient(token) {
+    const baseOrigin = origin || (typeof window !== 'undefined' ? window.location.origin : '')
+    const wsUrl = new URL(WS_PATH, baseOrigin)
+    if (token) {
+        wsUrl.searchParams.set('access_token', token)
+    }
+
     const client = new Client({
-        webSocketFactory: () => new SockJS(origin + WS_PATH),
+        webSocketFactory: () => new SockJS(wsUrl.toString()),
         connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
         reconnectDelay: 3000,
         debug: () => {} // 필요 시 콘솔 출력


### PR DESCRIPTION
## Summary
- add a dedicated login response that includes the issued JWT and switch the auth service/controller to return it
- harden the security chain with a JWT entry point/filter and require authentication for match REST and websocket endpoints
- realign the match controller/service to serve the expected DTOs, handle accept/decline, broadcast MatchEventMessage events, and send access tokens with websocket handshakes

## Testing
- `./gradlew test` *(fails: Java 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caae6d12808325ba80c9a93872d09b