### PR TITLE
Fix WebRTC signaling setup and integrate match flow

### DIFF
--- a/frontend/src/views/MatchingSetup.vue
+++ b/frontend/src/views/MatchingSetup.vue
@@ -106,8 +106,10 @@
 import { ref, computed } from 'vue'
 import api from '../services/api'
 import { useRouter } from 'vue-router'
+import { useMatchStore } from '../stores/match'
 
 const router = useRouter()
+const matchStore = useMatchStore()
 const ageRange = ref([20, 30])
 const gender = ref('A')
 const regions = [
@@ -132,6 +134,7 @@ const isValid = computed(() => !!gender.value && !!region.value && interests.val
 async function startMatch(){
   if (!isValid.value) return
   loading.value = true
+  matchStore.reset()
   const payload = {
     choice_gender: gender.value,
     min_age: ageRange.value[0],
@@ -140,8 +143,9 @@ async function startMatch(){
     interests: interests.value,
   }
   try{
-    await api.post('/match/requests', payload)
-    router.push('/match/result')
+    const { data } = await api.post('/match/requests', payload)
+    matchStore.setFromStartResponse(data)
+    router.push({ name: 'match-result' })
   }catch(e){
     alert('매칭 실패: ' + (e?.response?.data?.message || e.message))
   }finally{


### PR DESCRIPTION
## Summary
- reset and hydrate the match store when starting a match so the result view knows both participants
- rework the matching result view to read login data from the stores, subscribe to the correct STOMP queues, and run the WebRTC negotiation only when ready
- implement accept/decline API calls, show live video placeholders, and clean up peer connections when the session ends

## Testing
- npm run build *(fails: missing vite chunk because dependencies cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac58cd80c83259681af326ce8976d