### PR TITLE
Implement follow system, saved words, and chat file sharing

### DIFF
--- a/First_sql.sql
+++ b/First_sql.sql
@@ -110,15 +110,18 @@ CREATE TABLE match_requests
     max_age        INT         NOT NULL,                                                                   -- 최대 나이
     region_code    VARCHAR(10) NOT NULL,                                                                   -- 희망 지역
     interests_json JSON        NOT NULL,                                                                   -- 관심사 배열(JSON)
+    room_id        BIGINT NULL,                                                                            -- 생성된 방 FK
     status         VARCHAR(10) NOT NULL DEFAULT 'WAITING'                                                  -- 대기/매칭/취소
-        CHECK (status IN ('WAITING', 'MATCHED', 'CANCELLED')),
+        CHECK (status IN ('WAITING', 'MATCHED', 'CONFIRMED', 'DECLINED', 'CANCELLED')),
     requested_at   TIMESTAMP            DEFAULT CURRENT_TIMESTAMP,                                         -- 요청시각
     CONSTRAINT fk_mr_user FOREIGN KEY (user_pid) REFERENCES users (user_pid) ON DELETE CASCADE,
+    CONSTRAINT fk_mr_room FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE SET NULL,
     CONSTRAINT ck_mr_age_range CHECK (max_age >= min_age),
 
     -- 인덱스(매칭 스캔)
     INDEX          idx_mr_match_scan (status, choice_gender, region_code, min_age, max_age, requested_at), -- 조건+FIFO
-    INDEX          idx_mr_user (user_pid)                                                                  -- 사용자별 최신 요청 조회
+    INDEX          idx_mr_user (user_pid),                                                                 -- 사용자별 최신 요청 조회
+    INDEX          idx_mr_room (room_id)
 );
 
 /* =========================================

--- a/backend/First_sql.sql
+++ b/backend/First_sql.sql
@@ -110,15 +110,18 @@ CREATE TABLE match_requests
     max_age        INT         NOT NULL,                                                                   -- 최대 나이
     region_code    VARCHAR(10) NOT NULL,                                                                   -- 희망 지역
     interests_json JSON        NOT NULL,                                                                   -- 관심사 배열(JSON)
+    room_id        BIGINT NULL,                                                                            -- 생성된 방 FK
     status         VARCHAR(10) NOT NULL DEFAULT 'WAITING'                                                  -- 대기/매칭/취소
-        CHECK (status IN ('WAITING', 'MATCHED', 'CANCELLED')),
+        CHECK (status IN ('WAITING', 'MATCHED', 'CONFIRMED', 'DECLINED', 'CANCELLED')),
     requested_at   TIMESTAMP            DEFAULT CURRENT_TIMESTAMP,                                         -- 요청시각
     CONSTRAINT fk_mr_user FOREIGN KEY (user_pid) REFERENCES users (user_pid) ON DELETE CASCADE,
+    CONSTRAINT fk_mr_room FOREIGN KEY (room_id) REFERENCES rooms (room_id) ON DELETE SET NULL,
     CONSTRAINT ck_mr_age_range CHECK (max_age >= min_age),
 
     -- 인덱스(매칭 스캔)
     INDEX          idx_mr_match_scan (status, choice_gender, region_code, min_age, max_age, requested_at), -- 조건+FIFO
-    INDEX          idx_mr_user (user_pid)                                                                  -- 사용자별 최신 요청 조회
+    INDEX          idx_mr_user (user_pid),                                                                 -- 사용자별 최신 요청 조회
+    INDEX          idx_mr_room (room_id)
 );
 
 /* =========================================

--- a/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -2,12 +2,24 @@ package net.datasa.project01.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.ChatMessageRequestDto;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.dto.RoomCreateResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.service.ChatService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/api/rooms")
@@ -31,5 +43,59 @@ public class ChatController {
             log.error("Error creating group room", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @PostMapping("/{roomId}/messages")
+    public ResponseEntity<ChatMessageResponseDto> sendTextMessage(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestBody ChatMessageRequestDto requestDto
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        requestDto.setRoomId(roomId);
+        ChatMessageResponseDto response = chatService.processMessage(requestDto, userDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping(value = "/{roomId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageResponseDto> uploadFile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        ChatMessageResponseDto response = chatService.processFileMessage(roomId, file, userDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{roomId}/files/{messageId}")
+    public ResponseEntity<Resource> downloadFile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId,
+            @PathVariable Long messageId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        ChatService.FileDownload fileDownload = chatService.getFileForDownload(roomId, messageId, userDetails.getUsername());
+
+        MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        if (fileDownload.mimeType() != null && !fileDownload.mimeType().isBlank()) {
+            try {
+                mediaType = MediaType.parseMediaType(fileDownload.mimeType());
+            } catch (InvalidMediaTypeException e) {
+                log.warn("Invalid mime type {} for message {}", fileDownload.mimeType(), messageId);
+            }
+        }
+
+        String encodedFileName = UriUtils.encode(fileDownload.fileName(), StandardCharsets.UTF_8);
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedFileName)
+                .body(fileDownload.resource());
     }
 }

--- a/backend/src/main/java/net/datasa/project01/controller/FollowController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/FollowController.java
@@ -1,0 +1,94 @@
+package net.datasa.project01.controller;
+
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.FollowListItemDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.service.FollowService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follows")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/{targetPid}")
+    public ResponseEntity<FollowResponseDto> requestFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long targetPid
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        FollowResponseDto response = followService.requestFollow(userDetails.getUsername(), targetPid);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{followId}/accept")
+    public ResponseEntity<FollowResponseDto> acceptFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long followId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        FollowResponseDto response = followService.approveFollow(userDetails.getUsername(), followId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{followId}/reject")
+    public ResponseEntity<FollowResponseDto> rejectFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long followId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        FollowResponseDto response = followService.rejectFollow(userDetails.getUsername(), followId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{followId}")
+    public ResponseEntity<Void> removeFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long followId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        followService.removeFollow(userDetails.getUsername(), followId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/followings")
+    public ResponseEntity<List<FollowListItemDto>> getFollowings(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(value = "status", required = false) Follow.Status status
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<FollowListItemDto> items = followService.getFollowings(userDetails.getUsername(), status);
+        return ResponseEntity.ok(items);
+    }
+
+    @GetMapping("/followers")
+    public ResponseEntity<List<FollowListItemDto>> getFollowers(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(value = "status", required = false) Follow.Status status
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<FollowListItemDto> items = followService.getFollowers(userDetails.getUsername(), status);
+        return ResponseEntity.ok(items);
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/controller/SavedWordController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/SavedWordController.java
@@ -1,0 +1,57 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.SavedWordRequestDto;
+import net.datasa.project01.domain.dto.SavedWordResponseDto;
+import net.datasa.project01.service.SavedWordService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/words")
+public class SavedWordController {
+
+    private final SavedWordService savedWordService;
+
+    @PostMapping
+    public ResponseEntity<SavedWordResponseDto> saveWord(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody SavedWordRequestDto requestDto
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        SavedWordResponseDto response = savedWordService.saveWord(userDetails.getUsername(), requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SavedWordResponseDto>> getSavedWords(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<SavedWordResponseDto> words = savedWordService.getSavedWords(userDetails.getUsername());
+        return ResponseEntity.ok(words);
+    }
+
+    @DeleteMapping("/{wordId}")
+    public ResponseEntity<Void> deleteWord(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long wordId
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        savedWordService.deleteWord(userDetails.getUsername(), wordId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/controller/TranslationController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/TranslationController.java
@@ -1,0 +1,36 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.TranslationRequestDto;
+import net.datasa.project01.domain.dto.TranslationResponseDto;
+import net.datasa.project01.service.TranslationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/translation")
+public class TranslationController {
+
+    private final TranslationService translationService;
+
+    @PostMapping
+    public ResponseEntity<TranslationResponseDto> translate(@Valid @RequestBody TranslationRequestDto requestDto) {
+        String translated = translationService.translate(
+                requestDto.getText(),
+                requestDto.getSourceLang(),
+                requestDto.getTargetLang()
+        );
+        TranslationResponseDto response = TranslationResponseDto.builder()
+                .originalText(requestDto.getText())
+                .translatedText(translated)
+                .sourceLang(requestDto.getSourceLang())
+                .targetLang(requestDto.getTargetLang())
+                .build();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -3,6 +3,7 @@ package net.datasa.project01.domain.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import net.datasa.project01.domain.entity.RoomMessage;
 
 import java.time.LocalDateTime;
 
@@ -10,9 +11,15 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class ChatMessageResponseDto {
+    private final Long messageId;
     private final Long roomId;
+    private final RoomMessage.ContentType contentType;
     private final String senderNickName;
     private final String content;
-    private final String translatedContent; // 번역된 메시지를 담을 필드
+    private final String translatedContent;
+    private final String fileName;
+    private final String fileUrl;
+    private final String mimeType;
+    private final Long fileSize;
     private final LocalDateTime sentAt;
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowListItemDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowListItemDto.java
@@ -1,0 +1,23 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.FollowList;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FollowListItemDto {
+    private final Long followId;
+    private final Long userPid;
+    private final String loginId;
+    private final String nickName;
+    private final Follow.Status status;
+    private final FollowList.Direction direction;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
@@ -1,0 +1,20 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import net.datasa.project01.domain.entity.Follow;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FollowResponseDto {
+    private final Long followId;
+    private final Long followerPid;
+    private final String followerLoginId;
+    private final String followerNickName;
+    private final Long followeePid;
+    private final String followeeLoginId;
+    private final String followeeNickName;
+    private final Follow.Status status;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/SavedWordRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/SavedWordRequestDto.java
@@ -1,0 +1,23 @@
+package net.datasa.project01.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SavedWordRequestDto {
+    @NotBlank
+    private String sourceText;
+
+    @NotBlank
+    private String translatedText;
+
+    @NotBlank
+    private String sourceLang;
+
+    @NotBlank
+    private String targetLang;
+
+    private String context;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/SavedWordResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/SavedWordResponseDto.java
@@ -1,0 +1,20 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SavedWordResponseDto {
+    private final Long wordId;
+    private final String sourceText;
+    private final String translatedText;
+    private final String sourceLang;
+    private final String targetLang;
+    private final String context;
+    private final LocalDateTime createdAt;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/TranslationRequestDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/TranslationRequestDto.java
@@ -1,0 +1,18 @@
+package net.datasa.project01.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TranslationRequestDto {
+    @NotBlank
+    private String text;
+
+    @NotBlank
+    private String sourceLang;
+
+    @NotBlank
+    private String targetLang;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
@@ -1,0 +1,15 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TranslationResponseDto {
+    private final String originalText;
+    private final String translatedText;
+    private final String sourceLang;
+    private final String targetLang;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/Follow.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/Follow.java
@@ -1,0 +1,50 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "follows")
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow")
+    private Long followId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "followee_id", nullable = false)
+    private User followee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 10, nullable = false)
+    @Builder.Default
+    private Status status = Status.PENDING;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        REJECTED
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/FollowList.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/FollowList.java
@@ -1,0 +1,56 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "follow_list")
+public class FollowList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "list_id")
+    private Long listId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follow_id", nullable = false)
+    private Follow follow;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_pid", nullable = false)
+    private User owner;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_pid", nullable = false)
+    private User target;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", length = 10, nullable = false)
+    private Direction direction;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Follow.Status status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Direction {
+        FOLLOWING,
+        FOLLOWER
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/SavedWord.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/SavedWord.java
@@ -1,0 +1,45 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "saved_words")
+public class SavedWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "word_id")
+    private Long wordId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_pid", nullable = false)
+    private User user;
+
+    @Column(name = "source_text", length = 500, nullable = false)
+    private String sourceText;
+
+    @Column(name = "translated_text", length = 500, nullable = false)
+    private String translatedText;
+
+    @Column(name = "source_lang", length = 2, nullable = false)
+    private String sourceLang;
+
+    @Column(name = "target_lang", length = 2, nullable = false)
+    private String targetLang;
+
+    @Column(name = "context", length = 500)
+    private String context;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/net/datasa/project01/repository/FollowListRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/FollowListRepository.java
@@ -1,0 +1,20 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.FollowList;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowListRepository extends JpaRepository<FollowList, Long> {
+    List<FollowList> findByFollow(Follow follow);
+
+    List<FollowList> findByOwnerAndDirectionOrderByCreatedAtDesc(User owner, FollowList.Direction direction);
+
+    List<FollowList> findByOwnerAndDirectionAndStatusOrderByCreatedAtDesc(
+            User owner,
+            FollowList.Direction direction,
+            Follow.Status status
+    );
+}

--- a/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
@@ -1,0 +1,16 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
+
+    List<Follow> findByFollowerAndStatus(User follower, Follow.Status status);
+
+    List<Follow> findByFolloweeAndStatus(User followee, Follow.Status status);
+}

--- a/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 // JpaRepository의 두 번째 제네릭 타입으로 엔티티의 ID 클래스인 'RoomMemberId'를 지정
 public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemberId> {
-    // 예시: 특정 방의 모든 참여자를 찾는 커스텀 메소드
-    // List<RoomMember> findByRoom(Room room);
+
+    boolean existsByRoom_RoomIdAndUser_UserPidAndLeftAtIsNull(Long roomId, Long userPid);
 }

--- a/backend/src/main/java/net/datasa/project01/repository/SavedWordRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/SavedWordRepository.java
@@ -1,0 +1,14 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.SavedWord;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
+    List<SavedWord> findByUserOrderByCreatedAtDesc(User user);
+
+    Optional<SavedWord> findByWordIdAndUser(Long wordId, User user);
+}

--- a/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -1,27 +1,26 @@
 package net.datasa.project01.service;
 
 import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.ChatMessageRequestDto;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.RoomMember;
+import net.datasa.project01.domain.entity.RoomMessage;
 import net.datasa.project01.domain.entity.User;
-
 import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.RoomMessageRepository;
 import net.datasa.project01.repository.RoomRepository;
 import net.datasa.project01.repository.UserRepository;
-import net.datasa.project01.domain.dto.ChatMessageRequestDto;
-import net.datasa.project01.domain.dto.ChatMessageResponseDto;
-import net.datasa.project01.domain.entity.RoomMessage;
-
+import org.springframework.core.io.Resource;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import net.datasa.project01.service.TranslationService;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -32,13 +31,7 @@ public class ChatService {
     private final UserRepository userRepository;
     private final RoomMessageRepository roomMessageRepository;
     private final TranslationService translationService;
-
-    // TODO: 알림 서비스 추가 (Push Notification)
-    // private final NotificationService notificationService;
-    // TODO: 파일 업로드 서비스 추가
-    // private final FileUploadService fileUploadService;
-    // TODO: 커비너 세션 및 캐시 관리
-    // private final RedisTemplate<String, Object> redisTemplate;
+    private final FileStorageService fileStorageService;
 
     @Transactional
     public Room createGroupRoom() {
@@ -51,34 +44,34 @@ public class ChatService {
         User creator = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 2. 새로운 Room 엔티티를 생성하고 데이터베이스에 저장
         Room newRoom = Room.builder()
-                .roomType(Room.RoomType.GROUP) // Enum 타입 직접 사용
-                .capacity(4) // 그룹방의 최대 인원은 4명으로 고정
+                .roomType(Room.RoomType.GROUP)
+                .capacity(4)
                 .build();
         roomRepository.save(newRoom);
 
-        // 3. 방을 만든 사람을 해당 방의 첫 멤버이자 방장(HOST)으로 추가
         RoomMember newMember = RoomMember.builder()
                 .room(newRoom)
                 .user(creator)
-                .role("HOST") // DB 스키마에 정의된 enum 값
+                .role("HOST")
                 .build();
         roomMemberRepository.save(newMember);
 
-        // TODO: 방 생성 알림 전송
-        // TODO: 방 생성 로그 기록
         return newRoom;
     }
 
     @Transactional
     public ChatMessageResponseDto processMessage(ChatMessageRequestDto requestDto, String loginId) {
+        if (requestDto.getRoomId() == null) {
+            throw new IllegalArgumentException("대상 채팅방 정보가 필요합니다.");
+        }
         User sender = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         Room room = roomRepository.findById(requestDto.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
 
-        // 1. 원본 메시지를 DB에 저장
+        assertRoomMembership(room.getRoomId(), sender.getUserPid());
+
         RoomMessage savedMessage = roomMessageRepository.saveAndFlush(RoomMessage.builder()
                 .room(room)
                 .sender(sender)
@@ -86,11 +79,11 @@ public class ChatService {
                 .textContent(requestDto.getContent())
                 .build());
 
-        String originalText = savedMessage.getTextContent();
+        String originalText = Objects.requireNonNullElse(savedMessage.getTextContent(), "");
         String sourceLang = sender.getLanguageCode();
         String translatedText = originalText;
 
-        if (originalText != null && !originalText.isBlank() && sourceLang != null) {
+        if (!originalText.isBlank() && sourceLang != null) {
             if ("ko".equalsIgnoreCase(sourceLang)) {
                 translatedText = translationService.translate(originalText, "ko", "ja");
             } else if ("ja".equalsIgnoreCase(sourceLang)) {
@@ -98,29 +91,88 @@ public class ChatService {
             }
         }
 
-        LocalDateTime sentAt = savedMessage.getCreatedAt();
-        if (sentAt == null) {
-            sentAt = LocalDateTime.now();
-        }
+        LocalDateTime sentAt = Objects.requireNonNullElseGet(savedMessage.getCreatedAt(), LocalDateTime::now);
 
         return ChatMessageResponseDto.builder()
+                .messageId(savedMessage.getMessageId())
                 .roomId(room.getRoomId())
+                .contentType(savedMessage.getContentType())
                 .senderNickName(sender.getNickName())
                 .content(savedMessage.getTextContent())
                 .translatedContent(translatedText)
                 .sentAt(sentAt)
                 .build();
     }
+
+    @Transactional
+    public ChatMessageResponseDto processFileMessage(Long roomId, MultipartFile multipartFile, String loginId) {
+        if (roomId == null) {
+            throw new IllegalArgumentException("대상 채팅방 정보가 필요합니다.");
+        }
+        User sender = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        assertRoomMembership(room.getRoomId(), sender.getUserPid());
+
+        FileStorageService.StoredFile storedFile = fileStorageService.store(multipartFile, "room-" + room.getRoomId());
+        RoomMessage.ContentType contentType = determineContentType(storedFile.getContentType());
+
+        RoomMessage savedMessage = roomMessageRepository.saveAndFlush(RoomMessage.builder()
+                .room(room)
+                .sender(sender)
+                .contentType(contentType)
+                .fileName(storedFile.getOriginalFileName())
+                .filePath(storedFile.getRelativePath())
+                .mimeType(storedFile.getContentType())
+                .sizeBytes(storedFile.getSize())
+                .build());
+
+        LocalDateTime sentAt = Objects.requireNonNullElseGet(savedMessage.getCreatedAt(), LocalDateTime::now);
+
+        return ChatMessageResponseDto.builder()
+                .messageId(savedMessage.getMessageId())
+                .roomId(room.getRoomId())
+                .contentType(savedMessage.getContentType())
+                .senderNickName(sender.getNickName())
+                .fileName(savedMessage.getFileName())
+                .fileUrl(buildFileUrl(room.getRoomId(), savedMessage.getMessageId()))
+                .mimeType(savedMessage.getMimeType())
+                .fileSize(savedMessage.getSizeBytes())
+                .sentAt(sentAt)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public FileDownload getFileForDownload(Long roomId, Long messageId, String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        RoomMessage message = roomMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+
+        if (!message.getRoom().getRoomId().equals(roomId)) {
+            throw new IllegalArgumentException("파일이 요청된 방에 존재하지 않습니다.");
+        }
+        assertRoomMembership(roomId, user.getUserPid());
+
+        if (message.getFilePath() == null) {
+            throw new IllegalStateException("파일이 첨부된 메시지가 아닙니다.");
+        }
+
+        Resource resource = fileStorageService.loadAsResource(message.getFilePath());
+        String fileName = message.getFileName() != null ? message.getFileName() : "download";
+        return new FileDownload(resource, fileName, message.getMimeType());
+    }
+
     @Transactional
     public Room createPrivateRoom(User user1, User user2) {
-        // 1. 새로운 PRIVATE 타입의 방 생성
         Room newRoom = Room.builder()
                 .roomType(Room.RoomType.PRIVATE)
                 .capacity(2)
                 .build();
         roomRepository.save(newRoom);
 
-        // 2. 두 명의 사용자를 멤버로 추가
         RoomMember member1 = RoomMember.builder()
                 .room(newRoom)
                 .user(user1)
@@ -133,21 +185,28 @@ public class ChatService {
                 .role("MEMBER")
                 .build();
 
-        roomMemberRepository.saveAll(java.util.List.of(member1, member2)); // 두 멤버를 한 번에 저장
-
+        roomMemberRepository.saveAll(java.util.List.of(member1, member2));
         return newRoom;
     }
 
-    // TODO: 추가 필요한 메서드들
-    // public void joinRoom(Long roomId, String loginId) { }
-    // public void leaveRoom(Long roomId, String loginId) { }
-    // public List<RoomResponseDto> getUserRooms(String loginId) { }
-    // public List<ChatMessageResponseDto> getMessageHistory(Long roomId, int page, int size) { }
-    // public void deleteMessage(Long messageId, String loginId) { }
-    // public void updateMessage(Long messageId, String newContent, String loginId) { }
-    // public void uploadFile(Long roomId, MultipartFile file, String loginId) { }
-    // public void markMessageAsRead(Long messageId, String loginId) { }
-    // public int getUnreadMessageCount(String loginId) { }
-    // public void kickMember(Long roomId, String targetLoginId, String adminLoginId) { }
-    // public void updateRoomSettings(Long roomId, RoomSettingsDto settings, String loginId) { }
+    private void assertRoomMembership(Long roomId, Long userPid) {
+        boolean isMember = roomMemberRepository.existsByRoom_RoomIdAndUser_UserPidAndLeftAtIsNull(roomId, userPid);
+        if (!isMember) {
+            throw new IllegalStateException("채팅방에 참여 중인 사용자만 메시지를 전송하거나 파일에 접근할 수 있습니다.");
+        }
+    }
+
+    private RoomMessage.ContentType determineContentType(String mimeType) {
+        if (mimeType != null && mimeType.toLowerCase().startsWith("image/")) {
+            return RoomMessage.ContentType.IMAGE;
+        }
+        return RoomMessage.ContentType.FILE;
+    }
+
+    private String buildFileUrl(Long roomId, Long messageId) {
+        return String.format("/api/rooms/%d/files/%d", roomId, messageId);
+    }
+
+    public record FileDownload(Resource resource, String fileName, String mimeType) {
+    }
 }

--- a/backend/src/main/java/net/datasa/project01/service/FileStorageService.java
+++ b/backend/src/main/java/net/datasa/project01/service/FileStorageService.java
@@ -1,0 +1,119 @@
+package net.datasa.project01.service;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class FileStorageService {
+
+    private final Path storageLocation;
+
+    public FileStorageService(@Value("${chat.file-storage-path:uploads}") String storagePath) {
+        this.storageLocation = Paths.get(storagePath).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storageLocation);
+        } catch (IOException e) {
+            throw new IllegalStateException("파일 저장 디렉터리를 생성할 수 없습니다.", e);
+        }
+    }
+
+    public StoredFile store(MultipartFile multipartFile, String subDirectory) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 존재하지 않습니다.");
+        }
+
+        String originalFileName = StringUtils.cleanPath(
+                multipartFile.getOriginalFilename() != null ? multipartFile.getOriginalFilename() : "uploaded-file"
+        );
+
+        String extension = "";
+        int lastDot = originalFileName.lastIndexOf('.');
+        if (lastDot != -1) {
+            extension = originalFileName.substring(lastDot);
+        }
+
+        String storedFileName = UUID.randomUUID().toString().replaceAll("-", "") + extension;
+        Path targetDirectory = this.storageLocation;
+        if (subDirectory != null && !subDirectory.isBlank()) {
+            targetDirectory = this.storageLocation.resolve(subDirectory).normalize();
+            try {
+                Files.createDirectories(targetDirectory);
+            } catch (IOException e) {
+                throw new IllegalStateException("하위 디렉터리를 생성할 수 없습니다.", e);
+            }
+        }
+
+        Path targetLocation = targetDirectory.resolve(storedFileName).normalize();
+        if (!targetLocation.startsWith(this.storageLocation)) {
+            throw new IllegalArgumentException("잘못된 파일 경로입니다.");
+        }
+
+        try {
+            Files.copy(multipartFile.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException("파일을 저장할 수 없습니다.", e);
+        }
+
+        Path relativePath = this.storageLocation.relativize(targetLocation);
+        String normalizedRelativePath = relativePath.toString().replace('\\', '/');
+
+        return new StoredFile(
+                originalFileName,
+                storedFileName,
+                normalizedRelativePath,
+                multipartFile.getContentType(),
+                multipartFile.getSize()
+        );
+    }
+
+    public Resource loadAsResource(String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) {
+            throw new IllegalArgumentException("파일 경로가 비어 있습니다.");
+        }
+        Path filePath = this.storageLocation.resolve(relativePath).normalize();
+        if (!filePath.startsWith(this.storageLocation)) {
+            throw new IllegalArgumentException("잘못된 파일 경로입니다.");
+        }
+        try {
+            Resource resource = new UrlResource(filePath.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            }
+            throw new IllegalArgumentException("파일을 읽을 수 없습니다.");
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("잘못된 파일 경로입니다.", e);
+        }
+    }
+
+    @Getter
+    public static class StoredFile {
+        private final String originalFileName;
+        private final String storedFileName;
+        private final String relativePath;
+        private final String contentType;
+        private final long size;
+
+        public StoredFile(String originalFileName, String storedFileName, String relativePath, String contentType, long size) {
+            this.originalFileName = originalFileName;
+            this.storedFileName = storedFileName;
+            this.relativePath = relativePath;
+            this.contentType = contentType;
+            this.size = size;
+        }
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/service/FollowService.java
+++ b/backend/src/main/java/net/datasa/project01/service/FollowService.java
@@ -1,0 +1,190 @@
+package net.datasa.project01.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.FollowListItemDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.FollowList;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.FollowListRepository;
+import net.datasa.project01.repository.FollowRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FollowService {
+
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final FollowListRepository followListRepository;
+
+    public FollowResponseDto requestFollow(String loginId, Long targetPid) {
+        User follower = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        User followee = userRepository.findById(targetPid)
+                .orElseThrow(() -> new IllegalArgumentException("대상 사용자를 찾을 수 없습니다."));
+
+        if (follower.getUserPid().equals(followee.getUserPid())) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
+
+        Optional<Follow> existing = followRepository.findByFollowerAndFollowee(follower, followee);
+
+        Follow follow = existing.map(value -> {
+                    if (value.getStatus() == Follow.Status.PENDING) {
+                        throw new IllegalStateException("이미 팔로우 요청이 진행 중입니다.");
+                    }
+                    if (value.getStatus() == Follow.Status.ACCEPTED) {
+                        throw new IllegalStateException("이미 상대를 팔로우하고 있습니다.");
+                    }
+                    value.setStatus(Follow.Status.PENDING);
+                    syncFollowListEntries(value);
+                    log.info("Re-requested follow from {} to {}", loginId, followee.getLoginId());
+                    return value;
+                })
+                .orElseGet(() -> {
+                    Follow created = followRepository.save(Follow.builder()
+                            .follower(follower)
+                            .followee(followee)
+                            .status(Follow.Status.PENDING)
+                            .build());
+                    createFollowListEntries(created);
+                    log.info("Created follow request from {} to {}", loginId, followee.getLoginId());
+                    return created;
+                });
+
+        return toResponseDto(follow);
+    }
+
+    public FollowResponseDto approveFollow(String loginId, Long followId) {
+        Follow follow = followRepository.findById(followId)
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 요청을 찾을 수 없습니다."));
+
+        if (!follow.getFollowee().getLoginId().equals(loginId)) {
+            throw new IllegalStateException("승인 권한이 없습니다.");
+        }
+
+        follow.setStatus(Follow.Status.ACCEPTED);
+        syncFollowListEntries(follow);
+        log.info("Follow request {} approved by {}", followId, loginId);
+        return toResponseDto(follow);
+    }
+
+    public FollowResponseDto rejectFollow(String loginId, Long followId) {
+        Follow follow = followRepository.findById(followId)
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 요청을 찾을 수 없습니다."));
+
+        if (!follow.getFollowee().getLoginId().equals(loginId)) {
+            throw new IllegalStateException("거절 권한이 없습니다.");
+        }
+
+        follow.setStatus(Follow.Status.REJECTED);
+        syncFollowListEntries(follow);
+        log.info("Follow request {} rejected by {}", followId, loginId);
+        return toResponseDto(follow);
+    }
+
+    public void removeFollow(String loginId, Long followId) {
+        Follow follow = followRepository.findById(followId)
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 요청을 찾을 수 없습니다."));
+
+        String followerLogin = follow.getFollower().getLoginId();
+        String followeeLogin = follow.getFollowee().getLoginId();
+
+        if (!followerLogin.equals(loginId) && !followeeLogin.equals(loginId)) {
+            throw new IllegalStateException("삭제 권한이 없습니다.");
+        }
+
+        followRepository.delete(follow);
+        log.info("Follow relationship {} removed by {}", followId, loginId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FollowListItemDto> getFollowings(String loginId, Follow.Status status) {
+        User owner = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        List<FollowList> entries = fetchEntries(owner, FollowList.Direction.FOLLOWING, status);
+        return entries.stream().map(this::toListDto).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<FollowListItemDto> getFollowers(String loginId, Follow.Status status) {
+        User owner = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        List<FollowList> entries = fetchEntries(owner, FollowList.Direction.FOLLOWER, status);
+        return entries.stream().map(this::toListDto).collect(Collectors.toList());
+    }
+
+    private List<FollowList> fetchEntries(User owner, FollowList.Direction direction, Follow.Status status) {
+        if (status == null) {
+            return followListRepository.findByOwnerAndDirectionOrderByCreatedAtDesc(owner, direction);
+        }
+        return followListRepository.findByOwnerAndDirectionAndStatusOrderByCreatedAtDesc(owner, direction, status);
+    }
+
+    private void createFollowListEntries(Follow follow) {
+        FollowList followerEntry = FollowList.builder()
+                .follow(follow)
+                .owner(follow.getFollower())
+                .target(follow.getFollowee())
+                .direction(FollowList.Direction.FOLLOWING)
+                .status(follow.getStatus())
+                .build();
+
+        FollowList followeeEntry = FollowList.builder()
+                .follow(follow)
+                .owner(follow.getFollowee())
+                .target(follow.getFollower())
+                .direction(FollowList.Direction.FOLLOWER)
+                .status(follow.getStatus())
+                .build();
+
+        followListRepository.save(followerEntry);
+        followListRepository.save(followeeEntry);
+    }
+
+    private void syncFollowListEntries(Follow follow) {
+        List<FollowList> lists = followListRepository.findByFollow(follow);
+        if (lists.isEmpty()) {
+            createFollowListEntries(follow);
+            return;
+        }
+        lists.forEach(entry -> entry.setStatus(follow.getStatus()));
+    }
+
+    private FollowResponseDto toResponseDto(Follow follow) {
+        return FollowResponseDto.builder()
+                .followId(follow.getFollowId())
+                .followerPid(follow.getFollower().getUserPid())
+                .followerLoginId(follow.getFollower().getLoginId())
+                .followerNickName(follow.getFollower().getNickName())
+                .followeePid(follow.getFollowee().getUserPid())
+                .followeeLoginId(follow.getFollowee().getLoginId())
+                .followeeNickName(follow.getFollowee().getNickName())
+                .status(follow.getStatus())
+                .build();
+    }
+
+    private FollowListItemDto toListDto(FollowList followList) {
+        User target = followList.getTarget();
+        return FollowListItemDto.builder()
+                .followId(followList.getFollow().getFollowId())
+                .userPid(target.getUserPid())
+                .loginId(target.getLoginId())
+                .nickName(target.getNickName())
+                .status(followList.getStatus())
+                .direction(followList.getDirection())
+                .createdAt(followList.getCreatedAt())
+                .updatedAt(followList.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/service/SavedWordService.java
+++ b/backend/src/main/java/net/datasa/project01/service/SavedWordService.java
@@ -1,0 +1,76 @@
+package net.datasa.project01.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.SavedWordRequestDto;
+import net.datasa.project01.domain.dto.SavedWordResponseDto;
+import net.datasa.project01.domain.entity.SavedWord;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.SavedWordRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class SavedWordService {
+
+    private final SavedWordRepository savedWordRepository;
+    private final UserRepository userRepository;
+
+    public SavedWordResponseDto saveWord(String loginId, SavedWordRequestDto requestDto) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        SavedWord savedWord = savedWordRepository.save(SavedWord.builder()
+                .user(user)
+                .sourceText(requestDto.getSourceText())
+                .translatedText(requestDto.getTranslatedText())
+                .sourceLang(requestDto.getSourceLang())
+                .targetLang(requestDto.getTargetLang())
+                .context(requestDto.getContext())
+                .build());
+
+        log.info("Saved translated word for user {}", loginId);
+        return toResponse(savedWord);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavedWordResponseDto> getSavedWords(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return savedWordRepository.findByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteWord(String loginId, Long wordId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        SavedWord savedWord = savedWordRepository.findByWordIdAndUser(wordId, user)
+                .orElseThrow(() -> new IllegalArgumentException("단어를 찾을 수 없습니다."));
+
+        savedWordRepository.delete(savedWord);
+        log.info("Deleted saved word {} for user {}", wordId, loginId);
+    }
+
+    private SavedWordResponseDto toResponse(SavedWord savedWord) {
+        return SavedWordResponseDto.builder()
+                .wordId(savedWord.getWordId())
+                .sourceText(savedWord.getSourceText())
+                .translatedText(savedWord.getTranslatedText())
+                .sourceLang(savedWord.getSourceLang())
+                .targetLang(savedWord.getTargetLang())
+                .context(savedWord.getContext())
+                .createdAt(savedWord.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Align the `match_requests` DDL with the application state model by adding the `room_id` foreign key and supporting all match status values.
- Implement server-side follow management including persistence, service logic, and REST endpoints for requesting, accepting, rejecting, listing, and removing follows.
- Add saved-word vocabulary storage and a translation REST endpoint to back Papago-based features along with DTOs and repositories.
- Enhance chat messaging with file upload/download support through a file storage service, enriched response payloads, and HTTP endpoints gated by room membership checks.

## Testing
- ⚠️ `./gradlew test` *(fails: missing configured Java toolchain in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ed3dfecc8325aba0a77eb424783f