### PR TITLE
Implement realtime chat messaging with file support

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/ChatMessageController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/ChatMessageController.java
@@ -1,0 +1,87 @@
+package net.datasa.project01.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.ChatFileResource;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
+import net.datasa.project01.service.ChatService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageController {
+
+    private final ChatService chatService;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @PostMapping(value = "/rooms/{roomId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageResponseDto> uploadFile(
+            @PathVariable("roomId") Long roomId,
+            @RequestPart("file") MultipartFile file,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        try {
+            ChatMessageResponseDto response = chatService.storeFileMessage(roomId, file, principal.getName());
+            messagingTemplate.convertAndSend("/topic/rooms/" + roomId, response);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("파일 업로드 요청이 거부되었습니다: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            log.error("채팅 파일 업로드 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/files/{messageId}")
+    public ResponseEntity<Resource> downloadFile(@PathVariable("messageId") Long messageId) {
+        try {
+            ChatFileResource fileResource = chatService.loadFileResource(messageId);
+            Resource resource = fileResource.resource();
+            String filename = fileResource.fileName() != null ? fileResource.fileName() : "attachment";
+            String encodedFileName = UriUtils.encode(filename, StandardCharsets.UTF_8);
+
+            MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+            if (fileResource.mimeType() != null) {
+                try {
+                    mediaType = MediaType.parseMediaType(fileResource.mimeType());
+                } catch (IllegalArgumentException parseException) {
+                    log.debug("지원되지 않는 MIME 타입 형식: {}", fileResource.mimeType());
+                }
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(mediaType)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encodedFileName + "\"")
+                    .body(resource);
+        } catch (IllegalArgumentException e) {
+            log.warn("파일 다운로드 실패: {}", e.getMessage());
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            log.error("파일 다운로드 처리 중 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatFileResource.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatFileResource.java
@@ -1,0 +1,9 @@
+package net.datasa.project01.domain.dto;
+
+import org.springframework.core.io.Resource;
+
+/**
+ * 채팅 파일 다운로드 시 응답에 필요한 리소스와 메타데이터를 묶어 반환하기 위한 DTO.
+ */
+public record ChatFileResource(Resource resource, String fileName, String mimeType) {
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -14,5 +14,10 @@ public class ChatMessageResponseDto {
     private final String senderNickName;
     private final String content;
     private final String translatedContent; // 번역된 메시지를 담을 필드
+    private final String contentType;
+    private final String fileName;
+    private final String fileUrl;
+    private final String mimeType;
+    private final Long sizeBytes;
     private final LocalDateTime sentAt;
 }

--- a/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -1,27 +1,37 @@
 package net.datasa.project01.service;
 
 import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.ChatFileResource;
+import net.datasa.project01.domain.dto.ChatMessageRequestDto;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.RoomMember;
+import net.datasa.project01.domain.entity.RoomMessage;
 import net.datasa.project01.domain.entity.User;
-
 import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.RoomMessageRepository;
 import net.datasa.project01.repository.RoomRepository;
 import net.datasa.project01.repository.UserRepository;
-import net.datasa.project01.domain.dto.ChatMessageRequestDto;
-import net.datasa.project01.domain.dto.ChatMessageResponseDto;
-import net.datasa.project01.domain.entity.RoomMessage;
-
+import net.datasa.project01.service.TranslationService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
-import net.datasa.project01.service.TranslationService;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +42,9 @@ public class ChatService {
     private final UserRepository userRepository;
     private final RoomMessageRepository roomMessageRepository;
     private final TranslationService translationService;
+
+    @Value("${chat.storage-dir:uploads/chat}")
+    private String chatStorageDir;
 
     // TODO: 알림 서비스 추가 (Push Notification)
     // private final NotificationService notificationService;
@@ -98,18 +111,64 @@ public class ChatService {
             }
         }
 
-        LocalDateTime sentAt = savedMessage.getCreatedAt();
-        if (sentAt == null) {
-            sentAt = LocalDateTime.now();
+        return buildResponse(savedMessage, translatedText);
+    }
+
+    @Transactional
+    public ChatMessageResponseDto storeFileMessage(Long roomId, MultipartFile multipartFile, String loginId) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 존재하지 않습니다.");
         }
 
-        return ChatMessageResponseDto.builder()
-                .roomId(room.getRoomId())
-                .senderNickName(sender.getNickName())
-                .content(savedMessage.getTextContent())
-                .translatedContent(translatedText)
-                .sentAt(sentAt)
-                .build();
+        User sender = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        String originalFilename = StringUtils.cleanPath(multipartFile.getOriginalFilename() == null
+                ? "file"
+                : multipartFile.getOriginalFilename());
+        String mimeType = multipartFile.getContentType() != null
+                ? multipartFile.getContentType()
+                : "application/octet-stream";
+        RoomMessage.ContentType contentType = mimeType.toLowerCase().startsWith("image/")
+                ? RoomMessage.ContentType.IMAGE
+                : RoomMessage.ContentType.FILE;
+
+        Path storedPath = storeFileOnDisk(roomId, multipartFile, originalFilename);
+
+        RoomMessage savedMessage = roomMessageRepository.saveAndFlush(RoomMessage.builder()
+                .room(room)
+                .sender(sender)
+                .contentType(contentType)
+                .fileName(originalFilename)
+                .filePath(buildRelativePath(roomId, storedPath.getFileName().toString()))
+                .mimeType(mimeType)
+                .sizeBytes(multipartFile.getSize())
+                .build());
+
+        return buildResponse(savedMessage, null);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatFileResource loadFileResource(Long messageId) {
+        RoomMessage message = roomMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+
+        if (message.getFilePath() == null) {
+            throw new IllegalArgumentException("파일이 첨부된 메시지가 아닙니다.");
+        }
+
+        try {
+            Path filePath = Paths.get(chatStorageDir).resolve(message.getFilePath()).normalize();
+            Resource resource = new UrlResource(filePath.toUri());
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new IllegalArgumentException("파일을 찾을 수 없거나 읽을 수 없습니다.");
+            }
+            return new ChatFileResource(resource, message.getFileName(), message.getMimeType());
+        } catch (IOException e) {
+            throw new IllegalStateException("파일을 불러오는 중 오류가 발생했습니다.", e);
+        }
     }
     @Transactional
     public Room createPrivateRoom(User user1, User user2) {
@@ -136,6 +195,61 @@ public class ChatService {
         roomMemberRepository.saveAll(java.util.List.of(member1, member2)); // 두 멤버를 한 번에 저장
 
         return newRoom;
+    }
+
+    private ChatMessageResponseDto buildResponse(RoomMessage message, String translatedText) {
+        LocalDateTime sentAt = message.getCreatedAt();
+        if (sentAt == null) {
+            sentAt = LocalDateTime.now();
+        }
+
+        String fileUrl = null;
+        if (message.getMessageId() != null && message.getFilePath() != null) {
+            fileUrl = "/api/chat/files/" + message.getMessageId();
+        }
+
+        return ChatMessageResponseDto.builder()
+                .roomId(message.getRoom().getRoomId())
+                .senderNickName(message.getSender() != null ? message.getSender().getNickName() : null)
+                .content(message.getTextContent())
+                .translatedContent(translatedText)
+                .contentType(message.getContentType() != null ? message.getContentType().name() : null)
+                .fileName(message.getFileName())
+                .fileUrl(fileUrl)
+                .mimeType(message.getMimeType())
+                .sizeBytes(message.getSizeBytes())
+                .sentAt(sentAt)
+                .build();
+    }
+
+    private Path storeFileOnDisk(Long roomId, MultipartFile multipartFile, String originalFilename) {
+        try {
+            Path root = Paths.get(chatStorageDir).toAbsolutePath().normalize();
+            Files.createDirectories(root);
+
+            Path roomDirectory = root.resolve(String.valueOf(roomId));
+            Files.createDirectories(roomDirectory);
+
+            String extension = "";
+            int lastDot = originalFilename.lastIndexOf('.');
+            if (lastDot >= 0) {
+                extension = originalFilename.substring(lastDot);
+            }
+            String storedFileName = UUID.randomUUID() + extension;
+            Path destination = roomDirectory.resolve(storedFileName);
+
+            try (InputStream inputStream = multipartFile.getInputStream()) {
+                Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            return destination;
+        } catch (IOException e) {
+            throw new IllegalStateException("파일을 저장하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private String buildRelativePath(Long roomId, String storedFileName) {
+        return roomId + "/" + storedFileName;
     }
 
     // TODO: 추가 필요한 메서드들

--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -1,133 +1,312 @@
 <template>
   <div class="d-flex flex-column h-100">
     <div class="d-flex justify-end mb-1">
-      <v-btn size="small" variant="outlined" @click="addFriend">친구 추가</v-btn>
+      <v-btn size="small" variant="outlined" @click="addFriend" :disabled="!partner">
+        친구 추가
+      </v-btn>
     </div>
+
+    <v-alert
+      v-if="errorMessage"
+      type="error"
+      density="compact"
+      class="mb-2"
+      variant="tonal"
+      closable
+      @click:close="errorMessage = ''"
+    >
+      {{ errorMessage }}
+    </v-alert>
+
     <div class="flex-grow-1 overflow-y-auto pe-2" ref="messagesContainer">
       <div
-        v-for="(msg, index) in messages"
-        :key="index"
-        class="my-1"
+        v-if="!computedMessages.length"
+        class="text-caption text-medium-emphasis text-center mt-4"
       >
-        <template v-if="msg.fileUrl">
-          <div v-if="msg.isImage">
-            <img :src="msg.fileUrl" :alt="msg.original" class="max-w-100" />
+        아직 메시지가 없습니다. 인사를 건네보세요!
+      </div>
+
+      <div
+        v-for="msg in computedMessages"
+        :key="msg.key"
+        class="mb-3 d-flex"
+        :class="msg.fromMe ? 'justify-end' : 'justify-start'"
+      >
+        <div :class="['message-bubble', msg.fromMe ? 'from-me' : 'from-partner']">
+          <div class="d-flex justify-space-between align-center text-caption message-meta">
+            <span class="fw-medium">{{ msg.senderNickName || '알 수 없음' }}</span>
+            <span class="ms-2">{{ msg.timeLabel }}</span>
           </div>
-          <div v-else>
-            <a :href="msg.fileUrl" :download="msg.original">{{ msg.original }}</a>
-          </div>
-        </template>
-        <template v-else>
-          <div class="text-body-2">{{ msg.original }}</div>
-          <div v-if="msg.translated" class="text-caption text-grey">
-            {{ msg.translated }}
-            <v-icon size="small" class="ms-1 cursor-pointer" @click="saveWord(msg)">mdi-content-save</v-icon>
-          </div>
-        </template>
+
+          <template v-if="msg.fileUrl">
+            <div class="mt-2">
+              <div class="d-flex align-center">
+                <v-icon size="18" class="me-1">
+                  {{ msg.isImage ? 'mdi-image' : 'mdi-file-download' }}
+                </v-icon>
+                <a
+                  :href="msg.fileUrl"
+                  target="_blank"
+                  rel="noopener"
+                  class="text-body-2 text-decoration-none"
+                >
+                  {{ msg.fileName || '첨부파일' }}
+                </a>
+              </div>
+              <div v-if="msg.sizeLabel" class="text-caption text-medium-emphasis">
+                {{ msg.sizeLabel }}
+              </div>
+              <img v-if="msg.isImage" :src="msg.fileUrl" class="attached-image mt-2" />
+            </div>
+          </template>
+          <template v-else>
+            <div class="message-content text-body-2 mt-2">
+              {{ msg.content }}
+            </div>
+            <div
+              v-if="showTranslation && msg.translatedContent"
+              class="text-caption text-medium-emphasis mt-2 d-flex align-center"
+            >
+              {{ msg.translatedContent }}
+              <v-icon
+                size="16"
+                class="ms-1 cursor-pointer"
+                @click="saveWord(msg)"
+              >
+                mdi-content-save
+              </v-icon>
+            </div>
+          </template>
+        </div>
       </div>
     </div>
+
     <v-file-input
+      v-if="hasFileUpload"
       v-model="file"
       prepend-icon="mdi-paperclip"
       hide-details
       density="compact"
       accept="image/*,application/*"
       @change="sendFile"
+      :disabled="isUploading"
+      :loading="isUploading"
+      clearable
+      class="mt-2"
     />
+
     <v-text-field
       v-model="newMessage"
       @keyup.enter="send"
       placeholder="메시지를 입력하세요"
       density="compact"
       hide-details
+      :disabled="isSending"
     >
       <template #append-inner>
-        <v-icon @click="toggleTranslate" :color="useTranslate ? 'primary' : undefined" class="me-1 cursor-pointer">mdi-translate</v-icon>
-        <v-icon @click="send" class="cursor-pointer">mdi-send</v-icon>
+        <v-icon
+          @click="toggleTranslate"
+          :color="showTranslation ? 'primary' : undefined"
+          class="me-1 cursor-pointer"
+        >
+          mdi-translate
+        </v-icon>
+        <v-icon
+          @click="send"
+          class="cursor-pointer"
+          :class="{ 'text-disabled': isSending }"
+        >
+          mdi-send
+        </v-icon>
       </template>
     </v-text-field>
   </div>
 </template>
 
 <script setup>
-import { ref, nextTick, onMounted } from 'vue';
-import { translate } from '../services/translator';
-import { useVocabularyStore } from '../stores/vocabulary';
-import { useFriendsStore } from '../stores/friends';
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { useVocabularyStore } from '../stores/vocabulary'
+import { useFriendsStore } from '../stores/friends'
 
 const props = defineProps({
-  partner: { type: String, default: '' }
+  partner: { type: String, default: '' },
+  messages: { type: Array, default: () => [] },
+  sending: { type: Boolean, default: false },
+  uploading: { type: Boolean, default: false },
+  onSend: { type: Function, required: true },
+  onSendFile: { type: Function, default: null },
 })
 
-const messages = ref([
-  { original: '안녕하세요!', translated: '' },
-  { original: '테스트 메시지', translated: '' }
-]);
-const newMessage = ref('');
-const file = ref(null);
-const messagesContainer = ref(null);
-const useTranslate = ref(false);
-const vocab = useVocabularyStore();
-const friends = useFriendsStore();
+const vocab = useVocabularyStore()
+const friends = useFriendsStore()
+
+const errorMessage = ref('')
+const newMessage = ref('')
+const file = ref(null)
+const messagesContainer = ref(null)
+const showTranslation = ref(false)
+const internalSending = ref(false)
+const internalUploading = ref(false)
+
+const isSending = computed(() => props.sending || internalSending.value)
+const isUploading = computed(() => props.uploading || internalUploading.value)
+const hasFileUpload = computed(() => typeof props.onSendFile === 'function')
+
+const timeFormatter = new Intl.DateTimeFormat('ko-KR', {
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+const computedMessages = computed(() =>
+  props.messages.map((msg, index) => {
+    const sentAt = msg.sentAt ? new Date(msg.sentAt) : null
+    const contentType = (msg.contentType || '').toString().toUpperCase()
+    const mimeType = msg.mimeType || ''
+    const isImage = contentType === 'IMAGE' || mimeType.startsWith('image/')
+
+    return {
+      ...msg,
+      key: msg.id ?? `${index}-${sentAt ? sentAt.getTime() : Date.now()}`,
+      timeLabel: sentAt ? timeFormatter.format(sentAt) : '',
+      isImage,
+      sizeLabel: formatBytes(msg.sizeBytes),
+    }
+  })
+)
+
+watch(
+  () => props.messages.length,
+  () => {
+    nextTick(scrollToBottom)
+  }
+)
+
+onMounted(() => {
+  scrollToBottom()
+})
 
 function scrollToBottom() {
-  nextTick(() => {
-    const el = messagesContainer.value;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-    }
-  });
+  const el = messagesContainer.value
+  if (el) {
+    el.scrollTop = el.scrollHeight
+  }
 }
 
-async function send() {
-  const text = newMessage.value.trim();
-  if (text) {
-    let translated = '';
-    if (useTranslate.value) {
-      translated = await translate(text);
-    }
-    messages.value.push({ original: text, translated });
-    newMessage.value = '';
-    scrollToBottom();
+function formatBytes(size) {
+  if (typeof size !== 'number' || Number.isNaN(size) || size < 0) {
+    return ''
   }
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = size
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  const fixed = value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1)
+  return `${fixed} ${units[unitIndex]}`
 }
 
 function toggleTranslate() {
-  useTranslate.value = !useTranslate.value;
+  showTranslation.value = !showTranslation.value
 }
 
 function saveWord(msg) {
-  if (msg.translated) {
-    vocab.addWord(msg.original, msg.translated);
+  if (msg.translatedContent) {
+    vocab.addWord(msg.content, msg.translatedContent)
   }
 }
 
-function sendFile() {
-  const f = file.value;
-  if (!f) return;
-  const reader = new FileReader();
-  reader.onload = () => {
-    messages.value.push({
-      original: f.name,
-      fileUrl: reader.result,
-      isImage: f.type.startsWith('image/')
-    });
-    file.value = null;
-    scrollToBottom();
-  };
-  reader.readAsDataURL(f);
+async function send() {
+  const text = newMessage.value.trim()
+  if (!text || isSending.value || typeof props.onSend !== 'function') {
+    return
+  }
+
+  try {
+    internalSending.value = true
+    await props.onSend(text)
+    newMessage.value = ''
+  } catch (error) {
+    console.error('채팅 메시지 전송 실패', error)
+    displayError(error)
+  } finally {
+    internalSending.value = false
+  }
+}
+
+async function sendFile() {
+  const selected = file.value
+  if (!selected || !hasFileUpload.value || isUploading.value) {
+    return
+  }
+
+  try {
+    internalUploading.value = true
+    await props.onSendFile(selected)
+    file.value = null
+  } catch (error) {
+    console.error('파일 업로드 실패', error)
+    displayError(error)
+  } finally {
+    internalUploading.value = false
+  }
+}
+
+function displayError(error) {
+  if (!error) {
+    return
+  }
+  const message =
+    typeof error === 'string'
+      ? error
+      : error?.response?.data?.message || error?.message || '요청 처리 중 오류가 발생했습니다.'
+  errorMessage.value = message
+  window.setTimeout(() => {
+    if (errorMessage.value === message) {
+      errorMessage.value = ''
+    }
+  }, 5000)
 }
 
 function addFriend() {
-  friends.add(props.partner);
+  if (props.partner) {
+    friends.add(props.partner)
+  }
 }
-
-onMounted(scrollToBottom);
 
 </script>
 
 <style scoped>
-.max-w-100 {
+.message-bubble {
   max-width: 100%;
+  min-width: 40%;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background-color: #f5f5f5;
+}
+
+.message-bubble.from-me {
+  background-color: #f8bbd0;
+  color: #2d2d2d;
+}
+
+.message-bubble.from-partner {
+  background-color: #ffffff;
+  border: 1px solid #f5f5f5;
+}
+
+.message-meta {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.attached-image {
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+.message-content {
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>

--- a/frontend/src/services/chat.js
+++ b/frontend/src/services/chat.js
@@ -1,13 +1,36 @@
 // src/services/chat.js
-export function setupChat(client, roomId, { onChat }) {
-    const sub = client.subscribe(`/topic/chat/${roomId}`, (msg) => {
-        onChat(JSON.parse(msg.body))
-    })
-    function sendChat(dto) {
-        client.publish({
-            destination: `/app/chat/${roomId}`,
-            body: JSON.stringify(dto) // { message: "...", sender: "...", ... }
-        })
+export function setupChat(client, roomId, { onChat } = {}) {
+  if (!client) {
+    throw new Error('STOMP 클라이언트가 필요합니다.')
+  }
+  if (!roomId) {
+    throw new Error('roomId가 필요합니다.')
+  }
+
+  const subscription = client.subscribe(`/topic/rooms/${roomId}`, (frame) => {
+    if (typeof onChat !== 'function') {
+      return
     }
-    return { sub, sendChat }
+    try {
+      const payload = JSON.parse(frame.body)
+      onChat(payload)
+    } catch (error) {
+      console.error('채팅 메시지 파싱 실패', error)
+    }
+  })
+
+  return {
+    roomId,
+    subscription,
+    sendChat(payload = {}) {
+      const body = JSON.stringify({ roomId, ...payload })
+      client.publish({
+        destination: `/app/chat.sendMessage/${roomId}`,
+        body,
+      })
+    },
+    unsubscribe() {
+      subscription?.unsubscribe?.()
+    },
+  }
 }

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -35,7 +35,15 @@
             </v-col>
             <v-col cols="12" md="3">
               <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
-                <ChatPanel class="flex-grow-1" :partner="partnerNameDisplay" />
+                <ChatPanel
+                  class="flex-grow-1"
+                  :partner="partnerNameDisplay"
+                  :messages="chatMessages"
+                  :sending="isSendingChat"
+                  :uploading="isUploadingFile"
+                  :on-send="handleSendChatMessage"
+                  :on-send-file="handleUploadFile"
+                />
               </v-card>
             </v-col>
           </v-row>
@@ -78,6 +86,7 @@ import { useRouter } from 'vue-router'
 import ChatPanel from '../components/ChatPanel.vue'
 import { createStompClient } from '../services/ws'
 import { setupSignalRoutes } from '../services/signaling'
+import { setupChat } from '../services/chat'
 import { useAuthStore } from '../stores/auth'
 import { useMatchStore } from '../stores/match'
 import api from '../services/api'
@@ -90,11 +99,15 @@ const localVideo = ref(null)
 const remoteVideo = ref(null)
 const localStream = ref(null)
 const hasRemoteStream = ref(false)
+const chatMessages = ref([])
+const isSendingChat = ref(false)
+const isUploadingFile = ref(false)
 const actionLoading = reactive({ accept: false, decline: false })
 
 const partnerAvatarFallback = 'https://via.placeholder.com/96?text=User'
 
 const meLoginId = computed(() => auth.user?.loginId || auth.user?.login_id || auth.user?.loginID || null)
+const myNickname = computed(() => auth.user?.nickname || auth.user?.nickName || auth.user?.nick_name || '')
 const partnerNameDisplay = computed(() => matchStore.partnerNickName || '상대 대기 중')
 const isMatched = computed(() => matchStore.isMatched)
 const waitingStatusText = computed(() =>
@@ -130,6 +143,8 @@ let matchSubscription = null
 let signalRoute = null
 let pc = null
 const offerCreated = ref(false)
+let chatRoute = null
+let chatRoomId = null
 
 if (!shouldInitialize.value) {
   router.replace('/match')
@@ -172,12 +187,82 @@ function handleMatchMessage(frame) {
     if (payload.eventType === 'MATCH_FOUND') {
       offerCreated.value = false
       hasRemoteStream.value = false
+      chatMessages.value = []
     }
     matchStore.applyMatchEvent(payload)
+    ensureChatRoute()
     void ensurePeerConnection()
   } catch (error) {
     console.error('매칭 이벤트 처리 실패', error)
   }
+}
+
+function handleIncomingChatMessage(payload) {
+  if (!payload) {
+    return
+  }
+  try {
+    const sentAt = payload.sentAt ? new Date(payload.sentAt) : new Date()
+    let sizeValue = null
+    if (typeof payload.sizeBytes === 'number') {
+      sizeValue = payload.sizeBytes
+    } else if (payload.sizeBytes !== null && payload.sizeBytes !== undefined) {
+      const parsed = Number(payload.sizeBytes)
+      if (Number.isFinite(parsed)) {
+        sizeValue = parsed
+      }
+    }
+    chatMessages.value.push({
+      id: `${payload.roomId ?? ''}-${sentAt.getTime()}-${Math.random().toString(36).slice(2, 8)}`,
+      roomId: payload.roomId,
+      senderNickName: payload.senderNickName,
+      content: payload.content ?? '',
+      translatedContent: payload.translatedContent ?? '',
+      contentType: payload.contentType ?? 'TEXT',
+      fileName: payload.fileName ?? '',
+      fileUrl: payload.fileUrl ?? '',
+      mimeType: payload.mimeType ?? '',
+      sizeBytes: Number.isFinite(sizeValue) ? sizeValue : null,
+      sentAt,
+      fromMe: !!payload.senderNickName && payload.senderNickName === myNickname.value,
+    })
+  } catch (error) {
+    console.error('채팅 메시지 처리 실패', error)
+  }
+}
+
+function ensureChatRoute() {
+  if (!connected.value || !client.value || !matchStore.roomId || !isMatched.value) {
+    if (!matchStore.roomId) {
+      chatMessages.value = []
+    }
+    teardownChatRoute()
+    return
+  }
+
+  if (chatRoute && chatRoomId === matchStore.roomId) {
+    return
+  }
+
+  const shouldReset = chatRoomId !== matchStore.roomId
+  teardownChatRoute()
+  if (shouldReset) {
+    chatMessages.value = []
+  }
+  chatRoute = setupChat(client.value, matchStore.roomId, {
+    onChat: handleIncomingChatMessage,
+  })
+  chatRoomId = matchStore.roomId
+}
+
+function teardownChatRoute() {
+  if (chatRoute?.unsubscribe) {
+    chatRoute.unsubscribe()
+  } else if (chatRoute?.subscription?.unsubscribe) {
+    chatRoute.subscription.unsubscribe()
+  }
+  chatRoute = null
+  chatRoomId = null
 }
 
 async function ensurePeerConnection() {
@@ -295,6 +380,56 @@ function teardownPeerConnection() {
   hasRemoteStream.value = false
 }
 
+async function handleSendChatMessage(text) {
+  if (!text) {
+    return
+  }
+  if (!client.value || !connected.value || !matchStore.roomId) {
+    throw new Error('채팅방이 아직 준비되지 않았습니다.')
+  }
+
+  try {
+    isSendingChat.value = true
+    if (chatRoute?.sendChat) {
+      chatRoute.sendChat({ content: text })
+    } else {
+      client.value.publish({
+        destination: `/app/chat.sendMessage/${matchStore.roomId}`,
+        body: JSON.stringify({ roomId: matchStore.roomId, content: text }),
+      })
+    }
+  } catch (error) {
+    console.error('채팅 메시지 전송 실패', error)
+    throw error instanceof Error ? error : new Error('채팅 메시지 전송에 실패했습니다.')
+  } finally {
+    isSendingChat.value = false
+  }
+}
+
+async function handleUploadFile(file) {
+  if (!file) {
+    return
+  }
+  if (!matchStore.roomId) {
+    throw new Error('채팅방이 아직 준비되지 않았습니다.')
+  }
+
+  const formData = new FormData()
+  formData.append('file', file)
+
+  try {
+    isUploadingFile.value = true
+    await api.post(`/chat/rooms/${matchStore.roomId}/files`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  } catch (error) {
+    console.error('파일 업로드 실패', error)
+    throw error instanceof Error ? error : new Error('파일 업로드 중 오류가 발생했습니다.')
+  } finally {
+    isUploadingFile.value = false
+  }
+}
+
 async function acceptMatch() {
   if (acceptDisabled.value) {
     return
@@ -347,6 +482,32 @@ watch(
   (closed) => {
     if (closed) {
       teardownPeerConnection()
+      teardownChatRoute()
+      chatMessages.value = []
+    }
+  }
+)
+
+watch(
+  () => [connected.value, matchStore.roomId],
+  () => {
+    if (!connected.value || !matchStore.roomId) {
+      if (!matchStore.roomId) {
+        chatMessages.value = []
+      }
+      teardownChatRoute()
+      return
+    }
+    ensureChatRoute()
+  }
+)
+
+watch(
+  () => matchStore.state,
+  (state) => {
+    if (state !== 'MATCHED') {
+      teardownChatRoute()
+      chatMessages.value = []
     }
   }
 )
@@ -362,6 +523,7 @@ onMounted(async () => {
   client.value.onConnect = () => {
     connected.value = true
     matchSubscription = client.value.subscribe('/user/queue/match-results', handleMatchMessage)
+    ensureChatRoute()
     void ensurePeerConnection()
   }
   client.value.onDisconnect = () => {
@@ -369,10 +531,12 @@ onMounted(async () => {
     matchSubscription?.unsubscribe()
     matchSubscription = null
     teardownPeerConnection()
+    teardownChatRoute()
   }
   client.value.activate()
 
   if (isMatched.value) {
+    ensureChatRoute()
     void ensurePeerConnection()
   }
 })
@@ -386,6 +550,7 @@ onBeforeUnmount(() => {
   signalRoute = null
   client.value?.deactivate?.()
   teardownPeerConnection()
+  teardownChatRoute()
   if (localStream.value) {
     localStream.value.getTracks().forEach((track) => track.stop())
   }


### PR DESCRIPTION
## Summary
- add REST endpoints and storage utilities that save chat attachments, broadcast them via STOMP, and expose secure download URLs
- extend chat message DTOs and service logic to include content metadata while persisting files on disk with translation support
- wire the matching chat panel to the backend STOMP topic, display translations, and upload files through the new API with improved UI feedback

## Testing
- ./gradlew test *(fails: Java 17 toolchain is unavailable in the execution environment)*
- npm run build *(fails: local Vite CLI cannot resolve generated chunk dep-D_zLpgQd.js inside node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d101c1b91083259334ff8fe638306f