### PR TITLE
Improve same-origin fallback for tunneled frontend

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://192.168.0.165:8080/api
+VITE_API_BASE_URL=/api
 VITE_WS_PATH=/ws-stomp

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,10 +1,15 @@
-#VITE_API_BASE_URL= https://*.ngrok-free.app/api
+# VITE_API_BASE_URL을 비우거나 /api로 두면 프런트엔드가 제공되는 도메인의 /api 경로를 사용합니다.
+# ngrok 등으로 프런트만 외부에 공개할 때 반드시 /api 형태를 유지해야 프록시를 통해 백엔드에 도달합니다.
+VITE_API_BASE_URL=/api
 
-# 프런트엔드에서 호출할 백엔드 REST API 기본 경로
-VITE_API_BASE_URL=http://192.168.0.165:8080/api
+# 백엔드를 별도 도메인이나 IP로 직접 호출하고 싶다면 아래 줄의 주석을 풀어 절대 URL을 지정합니다.
+# 예시) VITE_API_BASE_URL=http://localhost:8080/api
 
-# LAN 개발 환경에서 백엔드 게이트웨이 주소 (Vite 프록시 및 WebSocket용)
-VITE_DEV_BACKEND_ORIGIN=http://192.168.0.165:8080
+# Vite 개발 서버의 프록시가 전달할 백엔드 호스트(기본값: http://localhost:8080)
+VITE_DEV_BACKEND_ORIGIN=http://localhost:8080
 
-# 외부 기기에서 Vite 개발 서버에 접속할 때 사용할 호스트(IP)
-VITE_DEV_ALLOWED_HOST=192.168.0.165
+# 외부 기기(LAN, 터널 등)에서 개발 서버에 접근할 때 추가로 허용할 호스트/IP
+# 예시) VITE_DEV_ALLOWED_HOST=192.168.0.10
+
+# WebSocket/STOMP 엔드포인트 경로
+VITE_WS_PATH=/ws-stomp

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://192.168.0.165:8080/api
+VITE_API_BASE_URL=/api
 VITE_WS_PATH=/ws-stomp

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,9 @@
 import axios from 'axios'
 import { camelizeKeys, snakifyKeys, isTransformable } from '../utils/case'
+import { API_BASE_URL } from './endpoints'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
+  baseURL: API_BASE_URL,
   withCredentials: true,
 })
 

--- a/frontend/src/services/endpoints.js
+++ b/frontend/src/services/endpoints.js
@@ -1,0 +1,192 @@
+const DEFAULT_API_PATH = '/api'
+const DEFAULT_WS_PATH = '/ws-stomp'
+
+const rawApiBase = (import.meta.env.VITE_API_BASE_URL || '').trim()
+const rawWsPath = (import.meta.env.VITE_WS_PATH || DEFAULT_WS_PATH).trim()
+
+export const WS_PATH = normalizeWsPath(rawWsPath)
+export const API_BASE_URL = resolveApiBase(rawApiBase)
+export const SOCK_JS_URL = resolveSockJsUrl(API_BASE_URL, WS_PATH)
+
+function resolveApiBase(rawBase) {
+  if (!rawBase) {
+    return DEFAULT_API_PATH
+  }
+
+  if (!isAbsoluteHttpUrl(rawBase)) {
+    return normalizeRelativePath(rawBase) || DEFAULT_API_PATH
+  }
+
+  try {
+    const parsed = new URL(rawBase)
+
+    if (shouldPreferRelativePath(parsed)) {
+      return normalizeRelativePath(parsed.pathname) || DEFAULT_API_PATH
+    }
+
+    return parsed.toString()
+  } catch (error) {
+    return DEFAULT_API_PATH
+  }
+}
+
+function shouldPreferRelativePath(url) {
+  if (typeof window === 'undefined' || !window.location) {
+    return false
+  }
+
+  const { hostname: currentHost, protocol: currentProtocol } = window.location
+  if (!currentHost) {
+    return false
+  }
+
+  const configuredHost = url.hostname
+  if (!configuredHost) {
+    return false
+  }
+
+  const configuredProtocol = url.protocol || 'http:'
+  const configuredHostIsLocal = isLocalLikeHostname(configuredHost)
+  const currentHostIsLocal = isLocalLikeHostname(currentHost)
+
+  if (configuredHost === currentHost) {
+    if (configuredHostIsLocal && hasMixedContentConflict(currentProtocol, configuredProtocol)) {
+      return true
+    }
+    return false
+  }
+
+  if (configuredHostIsLocal && !currentHostIsLocal) {
+    return true
+  }
+
+  if (configuredHostIsLocal && hasMixedContentConflict(currentProtocol, configuredProtocol)) {
+    return true
+  }
+
+  return false
+}
+
+function hasMixedContentConflict(currentProtocol, configuredProtocol) {
+  return currentProtocol === 'https:' && configuredProtocol !== 'https:'
+}
+
+function isLocalLikeHostname(hostname) {
+  if (!hostname) {
+    return false
+  }
+
+  const normalized = hostname.toLowerCase()
+
+  if (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '0.0.0.0' ||
+    normalized === '::1' ||
+    normalized === '[::1]'
+  ) {
+    return true
+  }
+
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(normalized)) {
+    const [a, b] = normalized.split('.').map(Number)
+    if (a === 10 || a === 127) {
+      return true
+    }
+    if (a === 192 && b === 168) {
+      return true
+    }
+    if (a === 169 && b === 254) {
+      return true
+    }
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true
+    }
+    if (a === 100 && b >= 64 && b <= 127) {
+      return true
+    }
+    if (a === 198 && (b === 18 || b === 19)) {
+      return true
+    }
+    return false
+  }
+
+  return false
+}
+
+function isAbsoluteHttpUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+function normalizeRelativePath(path) {
+  if (!path) {
+    return ''
+  }
+
+  const trimmed = path.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  const withoutTrailing = withLeading.replace(/\/+$/, '')
+
+  if (!withoutTrailing || withoutTrailing === '/') {
+    return ''
+  }
+
+  return withoutTrailing
+}
+
+function normalizeWsPath(path) {
+  const value = path || DEFAULT_WS_PATH
+  const trimmed = value.trim()
+  const normalized = trimmed ? trimmed : DEFAULT_WS_PATH
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}
+
+function resolveSockJsUrl(baseUrl, wsPath) {
+  if (isAbsoluteHttpUrl(baseUrl)) {
+    const url = new URL(baseUrl)
+    const basePath = stripApiSuffix(url.pathname)
+    url.pathname = joinPaths(basePath, wsPath)
+    return url.toString()
+  }
+
+  const basePath = stripApiSuffix(baseUrl)
+  if (!basePath) {
+    return wsPath
+  }
+
+  const normalizedBase = basePath.startsWith('/') ? basePath : `/${basePath}`
+  return joinPaths(normalizedBase, wsPath)
+}
+
+function stripApiSuffix(pathname = '') {
+  if (!pathname) {
+    return ''
+  }
+
+  if (/\/api\/?$/i.test(pathname)) {
+    return pathname.replace(/\/api\/?$/i, '')
+  }
+
+  if (/^api\/?$/i.test(pathname)) {
+    return ''
+  }
+
+  return pathname
+}
+
+function joinPaths(basePath, wsPath) {
+  const normalizedBase = basePath.replace(/\/+$/, '')
+  const normalizedWs = wsPath.startsWith('/') ? wsPath : `/${wsPath}`
+
+  if (!normalizedBase) {
+    return normalizedWs
+  }
+
+  return `${normalizedBase}${normalizedWs}`
+}
+
+export { resolveSockJsUrl }

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -1,20 +1,13 @@
 import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client'
-
-// 백엔드 WebSocket 엔드포인트는 WebSocketConfig.java의 registry.addEndpoint("...") 값을 확인해 넣으세요.
-// 흔한 예: /ws-stomp  (정확한 path를 WebSocketConfig에서 확인 필요)
-const WS_PATH = import.meta.env.VITE_WS_PATH || '/ws-stomp'
-
-// axios baseURL에서 호스트 추출
-const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api'
-const origin = apiBase.replace(/\/api\/?$/, '')
+import { SOCK_JS_URL } from './endpoints'
 
 export function createStompClient(token) {
-    const client = new Client({
-        webSocketFactory: () => new SockJS(origin + WS_PATH),
-        connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
-        reconnectDelay: 3000,
-        debug: () => {} // 필요 시 콘솔 출력
-    })
-    return client
+  const client = new Client({
+    webSocketFactory: () => new SockJS(SOCK_JS_URL),
+    connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+    reconnectDelay: 3000,
+    debug: () => {}, // 필요 시 콘솔 출력
+  })
+  return client
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,7 +10,7 @@ import vue from '@vitejs/plugin-vue'
     export default defineConfig(({mode}) => {
         const env = loadEnv(mode, process.cwd(), '')
         const backendOrigin = env.VITE_DEV_BACKEND_ORIGIN ?? 'http://localhost:8080'
-        const lanHost = env.VITE_DEV_ALLOWED_HOST ?? '192.168.0.165'
+        const lanHost = (env.VITE_DEV_ALLOWED_HOST || '').trim()
         const allowedHosts = ['.ngrok-free.app']
         if (lanHost) {
             allowedHosts.push(lanHost)


### PR DESCRIPTION
## Summary
- centralize REST and SockJS endpoint resolution with logic that falls back to same-origin paths whenever a private host is configured or an HTTPS tunnel would downgrade to a local HTTP address
- point the axios service and STOMP client to the normalized endpoints so REST and WebSocket traffic share the same adaptive base URLs
- default the development/example env files to `/api` with guidance so tunneled frontends keep proxying through the dev server unless an explicit absolute backend URL is required

## Testing
- npm run build *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/Matcha-Talk/frontend/node_modules/vite/dist/node/chunks/dep-D_zLpgQd.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d1342fd7bc8325a30a8f7273eb5a34