### PR TITLE
Add match status fallback polling

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -90,6 +90,22 @@ public class MatchController {
         }
     }
 
+    @GetMapping("/requests/{requestId}")
+    public ResponseEntity<?> getMatchStatus(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long requestId) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body("인증 정보가 필요합니다.");
+        }
+        try {
+            MatchStartResponseDto response = matchService.getMatchStatus(userDetails.getUsername(), requestId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Match status lookup failed for user {} and request {}: {}", userDetails.getUsername(), requestId, e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
     @PostMapping("/requests/{requestId}/accept")
     public ResponseEntity<?> acceptMatch(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -177,6 +177,61 @@ public class MatchService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public MatchStartResponseDto getMatchStatus(String loginId, Long requestId) {
+        MatchRequest myRequest = matchRequestRepository.findByRequestIdAndUser_LoginId(requestId, loginId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        MatchRequest.MatchStatus status = myRequest.getStatus();
+
+        if (status == MatchRequest.MatchStatus.WAITING) {
+            long waitingCount = matchRequestRepository.countByStatusExcludingUser(MatchRequest.MatchStatus.WAITING, myRequest.getUser());
+            String message = waitingCount > 0 ? "다른 사용자를 찾고 있습니다." : "현재 대기 중인 사용자가 없습니다.";
+
+            return MatchStartResponseDto.builder()
+                    .state(MatchStartResponseDto.MatchState.WAITING)
+                    .myRequestId(myRequest.getRequestId())
+                    .waitingCount(waitingCount)
+                    .message(message)
+                    .shouldCreateOffer(false)
+                    .build();
+        }
+
+        if (status == MatchRequest.MatchStatus.MATCHED || status == MatchRequest.MatchStatus.CONFIRMED) {
+            MatchRequest opponent = findOpponentRequest(myRequest.getRoom(), myRequest.getRequestId());
+
+            boolean shouldCreateOffer = false;
+            if (opponent == null) {
+                shouldCreateOffer = true;
+            } else if (myRequest.getRequestedAt() != null && opponent.getRequestedAt() != null) {
+                shouldCreateOffer = myRequest.getRequestedAt().isAfter(opponent.getRequestedAt());
+            }
+
+            return MatchStartResponseDto.builder()
+                    .state(MatchStartResponseDto.MatchState.MATCHED)
+                    .myRequestId(myRequest.getRequestId())
+                    .partnerRequestId(opponent != null ? opponent.getRequestId() : null)
+                    .roomId(myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null)
+                    .partnerLoginId(opponent != null ? opponent.getUser().getLoginId() : null)
+                    .partnerNickName(opponent != null ? opponent.getUser().getNickName() : null)
+                    .message("매칭이 성사되었습니다.")
+                    .shouldCreateOffer(shouldCreateOffer)
+                    .build();
+        }
+
+        String message = switch (status) {
+            case DECLINED, CANCELLED -> "매칭이 종료되었습니다.";
+            default -> "현재 매칭 상태를 확인할 수 없습니다.";
+        };
+
+        return MatchStartResponseDto.builder()
+                .state(MatchStartResponseDto.MatchState.WAITING)
+                .myRequestId(myRequest.getRequestId())
+                .message(message)
+                .shouldCreateOffer(false)
+                .build();
+    }
+
     public MatchDecisionResponseDto respondToMatch(String loginId, Long requestId, boolean accept) {
         MatchRequest myRequest = matchRequestRepository.findByRequestIdAndUser_LoginId(requestId, loginId)
                 .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -145,9 +145,56 @@ let pc = null
 const offerCreated = ref(false)
 let chatRoute = null
 let chatRoomId = null
+const STATUS_POLL_INTERVAL = 2500
+let statusPollTimer = null
 
 if (!shouldInitialize.value) {
   router.replace('/match')
+}
+
+function stopStatusPolling() {
+  if (statusPollTimer) {
+    clearInterval(statusPollTimer)
+    statusPollTimer = null
+  }
+}
+
+async function requestStatusRefresh() {
+  if (!matchStore.requestId || isMatched.value || matchStore.sessionClosed) {
+    return
+  }
+  try {
+    const { data } = await api.get(`/match/requests/${matchStore.requestId}`)
+    if (data) {
+      matchStore.setFromStartResponse(data)
+      if (data.state === 'MATCHED') {
+        stopStatusPolling()
+        ensureChatRoute()
+        void ensurePeerConnection()
+      }
+    }
+  } catch (error) {
+    console.error('매칭 상태 조회 실패', error)
+  }
+}
+
+function ensureStatusPolling(immediate = false) {
+  if (!matchStore.requestId || isMatched.value || matchStore.sessionClosed) {
+    stopStatusPolling()
+    return
+  }
+  if (!statusPollTimer) {
+    statusPollTimer = setInterval(() => {
+      if (!matchStore.requestId || isMatched.value || matchStore.sessionClosed) {
+        stopStatusPolling()
+        return
+      }
+      void requestStatusRefresh()
+    }, STATUS_POLL_INTERVAL)
+  }
+  if (immediate) {
+    void requestStatusRefresh()
+  }
 }
 
 async function initLocalMedia() {
@@ -171,6 +218,21 @@ watch(localVideo, (element) => {
   }
 })
 
+watch(
+  () => [matchStore.requestId, matchStore.state, matchStore.sessionClosed],
+  ([requestId, state, sessionClosed], previous) => {
+    if (!requestId || sessionClosed || state === 'MATCHED') {
+      stopStatusPolling()
+      return
+    }
+    const prevRequestId = previous ? previous[0] : null
+    const prevState = previous ? previous[1] : null
+    const immediate = !previous || requestId !== prevRequestId || prevState === 'MATCHED'
+    ensureStatusPolling(immediate)
+  },
+  { immediate: true }
+)
+
 function handleMatchMessage(frame) {
   try {
     const payload = JSON.parse(frame.body)
@@ -185,6 +247,7 @@ function handleMatchMessage(frame) {
       hasRemoteStream.value = false
     }
     if (payload.eventType === 'MATCH_FOUND') {
+      stopStatusPolling()
       offerCreated.value = false
       hasRemoteStream.value = false
       chatMessages.value = []
@@ -481,6 +544,7 @@ watch(
   () => matchStore.sessionClosed,
   (closed) => {
     if (closed) {
+      stopStatusPolling()
       teardownPeerConnection()
       teardownChatRoute()
       chatMessages.value = []
@@ -535,6 +599,10 @@ onMounted(async () => {
   }
   client.value.activate()
 
+  if (!isMatched.value) {
+    ensureStatusPolling(true)
+  }
+
   if (isMatched.value) {
     ensureChatRoute()
     void ensurePeerConnection()
@@ -542,6 +610,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  stopStatusPolling()
   matchSubscription?.unsubscribe()
   matchSubscription = null
   if (signalRoute?.sub) {


### PR DESCRIPTION
## Summary
- add a GET /api/match/requests/{requestId} endpoint so authenticated clients can fetch their latest match status
- implement service logic that returns waiting counts or partner details for the fallback lookup and preserves the offer role
- add polling on the matching result screen to re-sync state when the websocket event is missed and stop polling after a match is found

## Testing
- ./gradlew test *(fails: Gradle toolchain cannot download Java 17 in the container environment)*
- npm run build *(fails: Vite CLI cannot resolve dep-D_zLpgQd.js even after reinstalling node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d1596a5fd48325974fae366114da79