### PR TITLE
Enable default HTTPS dev server with bundled cert

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -25,6 +25,7 @@ VITE_DEV_HMR_PORT=5173
 VITE_DEV_HMR_PROTOCOL=wss
 
 # 개발용 HTTPS 인증서 경로 (선택 사항)
-# mkcert 등으로 발급한 key/cert 파일 경로를 지정하세요.
-VITE_DEV_HTTPS_KEY=/dev-key.pem
-VITE_DEV_HTTPS_CERT=/dev-cert.pem
+# 기본 제공된 dev-key.pem/dev-cert.pem을 사용하려면 비워 두세요.
+# mkcert 등으로 발급한 key/cert 파일 경로를 지정하려면 아래 예시처럼 작성하세요.
+# VITE_DEV_HTTPS_KEY=./certs/dev-key.pem
+# VITE_DEV_HTTPS_CERT=./certs/dev-cert.pem

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,7 +19,7 @@ Vue 3 + Vite + Vuetify 3 프런트엔드입니다. 제공된 SQL 스키마를 �
    기본 포트는 `5173`이며 `VITE_DEV_ALLOWED_HOST`와 HTTPS 설정을 통해 동일 네트워크의 다른 기기에서도 접속할 수 있습니다.
 
 ## HTTPS 개발 서버 설정
-로컬/LAN 환경에서 WebRTC를 사용하려면 브라우저 보안 정책상 **HTTPS**가 필수입니다. 아래 절차에 따라 개발용 인증서를 발급하고 Vite 개발 서버에 적용하세요.
+로컬/LAN 환경에서 WebRTC를 사용하려면 브라우저 보안 정책상 **HTTPS**가 필수입니다. 기본적으로 본 레포지터리에는 `frontend/dev-key.pem`, `frontend/dev-cert.pem`이 포함되어 있으며, 별도 설정이 없으면 Vite 개발 서버가 해당 파일을 이용해 HTTPS로 기동됩니다. 처음 접속하는 기기에서는 이 인증서를 신뢰하도록 승인해야 합니다. 필요에 따라 아래 절차에 따라 자체 인증서를 발급하고 교체할 수 있습니다.
 
 ### 1. mkcert로 로컬 인증서 발급 (권장)
 1. [mkcert](https://github.com/FiloSottile/mkcert)를 설치합니다.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,18 +1,32 @@
 import fs from 'fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
+
+const frontendRoot = fileURLToPath(new URL('.', import.meta.url))
+
+const resolvePath = (p) => {
+  if (!p) return ''
+  return path.isAbsolute(p) ? p : path.resolve(frontendRoot, p)
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const backendOrigin = env.VITE_DEV_BACKEND_ORIGIN ?? 'http://localhost:8080'
   const lanHost = (env.VITE_DEV_ALLOWED_HOST || '').trim()
-  const keyPath = (env.VITE_DEV_HTTPS_KEY || '').trim()
-  const certPath = (env.VITE_DEV_HTTPS_CERT || '').trim()
+  const keyEnv = (env.VITE_DEV_HTTPS_KEY || '').trim()
+  const certEnv = (env.VITE_DEV_HTTPS_CERT || '').trim()
+  const keyPath = resolvePath(keyEnv)
+  const certPath = resolvePath(certEnv)
   const devHost = (env.VITE_DEV_SERVER_HOST || '0.0.0.0').trim() || '0.0.0.0'
   const devPort = Number.parseInt(env.VITE_DEV_SERVER_PORT || '5173', 10)
   const hmrHost = (env.VITE_DEV_HMR_HOST || '').trim()
   const hmrPort = env.VITE_DEV_HMR_PORT ? Number.parseInt(env.VITE_DEV_HMR_PORT, 10) : undefined
   const hmrProtocol = (env.VITE_DEV_HMR_PROTOCOL || '').trim()
+  const fallbackKeyPath = resolvePath('dev-key.pem')
+  const fallbackCertPath = resolvePath('dev-cert.pem')
 
   const allowedHosts = ['.ngrok-free.app']
   if (lanHost) {
@@ -27,10 +41,19 @@ export default defineConfig(({ mode }) => {
         cert: fs.readFileSync(certPath),
       }
     } else {
-      console.warn('[vite] 제공된 HTTPS 인증서 경로를 찾을 수 없습니다.', { keyPath, certPath })
+      console.warn('[vite] 제공된 HTTPS 인증서 경로를 찾을 수 없습니다.', {
+        keyPath,
+        certPath,
+      })
     }
-  } else if (keyPath || certPath) {
+  } else if (keyEnv || certEnv) {
     console.warn('[vite] HTTPS 개발 서버를 위해서는 VITE_DEV_HTTPS_KEY와 VITE_DEV_HTTPS_CERT를 모두 지정해야 합니다.')
+  } else if (fs.existsSync(fallbackKeyPath) && fs.existsSync(fallbackCertPath)) {
+    httpsConfig = {
+      key: fs.readFileSync(fallbackKeyPath),
+      cert: fs.readFileSync(fallbackCertPath),
+    }
+    console.info('[vite] 개발용 기본 HTTPS 인증서를 사용합니다. 필요 시 VITE_DEV_HTTPS_KEY/VITE_DEV_HTTPS_CERT로 덮어쓸 수 있습니다.')
   }
 
   return {


### PR DESCRIPTION
## Summary
- make the Vite dev server automatically load the bundled development TLS certificate so local LAN sessions start over HTTPS by default
- document the default HTTPS behaviour and clarify how to override it via environment variables

## Testing
- npm run build *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/Matcha-Talk/frontend/node_modules/vite/dist/node/chunks/dep-D_zLpgQd.js')*


------
https://chatgpt.com/codex/tasks/task_e_68d252824fac832598c594b0cb60a535