### PR TITLE
Add TURN server support with Metered credentials

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -29,3 +29,12 @@ VITE_DEV_HMR_PROTOCOL=wss
 # mkcert 등으로 발급한 key/cert 파일 경로를 지정하려면 아래 예시처럼 작성하세요.
 # VITE_DEV_HTTPS_KEY=./certs/dev-key.pem
 # VITE_DEV_HTTPS_CERT=./certs/dev-cert.pem
+
+# TURN/STUN 서버 설정 (선택 사항)
+# 정적 자격 증명을 사용할 경우:
+# VITE_TURN_URLS=turn:seoul.relay.metered.ca:80,turn:seoul.relay.metered.ca:443
+# VITE_TURN_USERNAME=example-username
+# VITE_TURN_CREDENTIAL=example-password
+# Metered 등에서 제공하는 REST API로 동적 자격 증명을 가져올 경우:
+# VITE_TURN_CREDENTIALS_URL=https://matchatalk.metered.live/api/v1/turn/credentials
+# VITE_TURN_API_KEY=your-metered-api-key

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,30 @@ VITE_DEV_ALLOWED_HOST=192.168.0.165
 ### 4. 브라우저 신뢰 저장소 업데이트
 사설 인증서를 사용한다면 각 기기 브라우저/OS 신뢰 저장소에 루트 인증서를 등록해야 합니다. 등록이 완료되어야 카메라·마이크 권한 요청이 정상적으로 표시됩니다.
 
+## TURN 서버 설정
+기본 구성은 구글 STUN 서버만 포함하고 있어, 대칭 NAT나 이동통신망 등의 환경에서는 WebRTC 연결이 실패할 수 있습니다. `MatchSession.vue`는 환경 변수 또는 외부 API에서 TURN 정보를 불러와 `RTCPeerConnection`에 주입하도록 수정되어 있으므로, 아래 방법 중 하나를 통해 ICE 서버 구성을 준비하세요.
+
+### 1. Metered Open Relay (동적 자격 증명)
+1. [Metered](https://www.metered.ca) 콘솔에서 프로젝트를 생성하고 Open Relay를 활성화합니다. 무료 티어는 월 500MB까지 TURN 트래픽을 제공합니다.
+2. 콘솔의 TURN Credentials API 엔드포인트(예: `https://matchatalk.metered.live/api/v1/turn/credentials`)와 API Key를 확인합니다.
+3. 프런트엔드 `.env`에 다음 값을 추가합니다.
+   ```bash
+   VITE_TURN_CREDENTIALS_URL=https://matchatalk.metered.live/api/v1/turn/credentials
+   VITE_TURN_API_KEY=<Metered_API_Key>
+   ```
+4. 애플리케이션이 로드되면 `getIceServers()`가 위 엔드포인트를 호출해 임시 TURN 자격 증명을 받아 `RTCPeerConnection`에 적용합니다.
+
+### 2. 정적 TURN 자격 증명 사용
+Metered가 발급한 고정 Username/Password를 직접 사용하거나, 다른 TURN 서버(coturn 등)를 운영 중이라면 다음 변수를 설정합니다.
+```bash
+VITE_TURN_URLS=turn:seoul.relay.metered.ca:80,turn:seoul.relay.metered.ca:443?transport=tcp,turns:seoul.relay.metered.ca:443
+VITE_TURN_USERNAME=<TURN_Username>
+VITE_TURN_CREDENTIAL=<TURN_Password>
+```
+여러 URL은 쉼표로 구분하며, UDP/TCP/TLS를 모두 포함해 두면 다양한 네트워크 환경에서 성공 확률이 높아집니다.
+
+> ⚠️ TURN API 키나 자격 증명은 민감 정보이므로 `.env.local`, `.env.production` 등 git에 커밋되지 않는 파일에서 관리하세요.
+
 ## 운영 환경 배포 체크리스트
 - Nginx, Apache, CloudFront 등 프록시/로드밸런서에 TLS 인증서를 설치하고 443 포트를 개방합니다.
 - `/ws-stomp` 경로(WebSocket 업그레이드 요청)를 포함해 모든 트래픽이 HTTPS로 서비스되도록 설정합니다.

--- a/frontend/src/services/turn.js
+++ b/frontend/src/services/turn.js
@@ -1,0 +1,209 @@
+const DEFAULT_ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }]
+
+let cachedIceServers = null
+let pendingIceServersPromise = null
+
+function normalizeIceServer(entry) {
+  if (!entry) {
+    return null
+  }
+
+  if (typeof entry === 'string') {
+    const url = entry.trim()
+    return url ? { urls: url } : null
+  }
+
+  if (typeof entry !== 'object') {
+    return null
+  }
+
+  const rawUrls = entry.urls ?? entry.url
+  const urls = []
+
+  if (Array.isArray(rawUrls)) {
+    for (const item of rawUrls) {
+      if (typeof item === 'string') {
+        const trimmed = item.trim()
+        if (trimmed) {
+          urls.push(trimmed)
+        }
+      }
+    }
+  } else if (typeof rawUrls === 'string') {
+    for (const item of rawUrls.split(',')) {
+      const trimmed = item.trim()
+      if (trimmed) {
+        urls.push(trimmed)
+      }
+    }
+  }
+
+  if (!urls.length) {
+    return null
+  }
+
+  const credential = entry.credential ?? entry.password ?? null
+  const server = {
+    urls: urls.length === 1 ? urls[0] : urls,
+  }
+
+  if (entry.username) {
+    server.username = entry.username
+  }
+  if (credential) {
+    server.credential = credential
+  }
+
+  return server
+}
+
+function dedupeIceServers(servers) {
+  const seen = new Set()
+  const result = []
+
+  for (const server of servers) {
+    const normalized = normalizeIceServer(server)
+    if (!normalized) {
+      continue
+    }
+
+    const urlsArray = Array.isArray(normalized.urls) ? normalized.urls : [normalized.urls]
+    if (!urlsArray.length) {
+      continue
+    }
+    const key = `${urlsArray.join('|')}|${normalized.username || ''}|${normalized.credential || ''}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    result.push(normalized)
+  }
+
+  return result
+}
+
+function parseStaticIceServersFromEnv() {
+  const urlsEnv = import.meta.env.VITE_TURN_URLS
+  if (!urlsEnv) {
+    return []
+  }
+
+  const username = import.meta.env.VITE_TURN_USERNAME
+  const credential = import.meta.env.VITE_TURN_CREDENTIAL
+  const urls = urlsEnv
+    .split(',')
+    .map((url) => url.trim())
+    .filter((url) => url.length > 0)
+
+  if (!urls.length) {
+    return []
+  }
+
+  if (username || credential) {
+    return dedupeIceServers([{ urls, username: username || undefined, credential: credential || undefined }])
+  }
+
+  return dedupeIceServers(urls.map((url) => ({ urls: url })))
+}
+
+function buildCredentialsRequestUrl() {
+  const baseUrl = import.meta.env.VITE_TURN_CREDENTIALS_URL
+  if (!baseUrl) {
+    return null
+  }
+
+  let requestUrl = baseUrl.trim()
+  if (!requestUrl) {
+    return null
+  }
+
+  const apiKey = import.meta.env.VITE_TURN_API_KEY
+  if (!apiKey) {
+    return requestUrl
+  }
+
+  if (requestUrl.includes('{{API_KEY}}')) {
+    return requestUrl.replace(/\{\{API_KEY\}\}/g, encodeURIComponent(apiKey))
+  }
+
+  if (requestUrl.includes('{API_KEY}')) {
+    return requestUrl.replace(/\{API_KEY\}/g, encodeURIComponent(apiKey))
+  }
+
+  if (!/[?&]apiKey=/.test(requestUrl)) {
+    const separator = requestUrl.includes('?') ? '&' : '?'
+    requestUrl += `${separator}apiKey=${encodeURIComponent(apiKey)}`
+  }
+
+  return requestUrl
+}
+
+async function fetchIceServersFromApi() {
+  const requestUrl = buildCredentialsRequestUrl()
+  if (!requestUrl) {
+    return []
+  }
+
+  try {
+    const response = await fetch(requestUrl, { cache: 'no-store' })
+    if (!response.ok) {
+      console.warn(`TURN credentials 요청이 실패했습니다. status=${response.status}`)
+      return []
+    }
+
+    const body = await response.json()
+    const candidates = Array.isArray(body?.iceServers) ? body.iceServers : Array.isArray(body) ? body : []
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      console.warn('TURN credentials 응답 형식이 예상과 다릅니다.', body)
+      return []
+    }
+
+    return dedupeIceServers(candidates)
+  } catch (error) {
+    console.error('TURN credentials를 가져오는 중 오류가 발생했습니다.', error)
+    return []
+  }
+}
+
+export async function getIceServers() {
+  if (cachedIceServers) {
+    return cachedIceServers
+  }
+  if (pendingIceServersPromise) {
+    return pendingIceServersPromise
+  }
+
+  pendingIceServersPromise = (async () => {
+    const staticServers = parseStaticIceServersFromEnv()
+    const dynamicServers = await fetchIceServersFromApi()
+
+    const combined = dedupeIceServers([
+      ...DEFAULT_ICE_SERVERS.map((server) => ({ ...server })),
+      ...staticServers,
+      ...dynamicServers,
+    ])
+
+    if (!combined.length) {
+      return DEFAULT_ICE_SERVERS.map((server) => ({ ...server }))
+    }
+
+    return combined
+  })()
+
+  try {
+    cachedIceServers = await pendingIceServersPromise
+  } catch (error) {
+    console.error('ICE 서버 구성을 불러오는 중 오류가 발생했습니다.', error)
+    cachedIceServers = DEFAULT_ICE_SERVERS.map((server) => ({ ...server }))
+  } finally {
+    pendingIceServersPromise = null
+  }
+
+  return cachedIceServers
+}
+
+export function resetIceServerCache() {
+  cachedIceServers = null
+  pendingIceServersPromise = null
+}

--- a/frontend/src/views/MatchSession.vue
+++ b/frontend/src/views/MatchSession.vue
@@ -112,6 +112,7 @@ import defaultAvatar from '../assets/default-avatar.svg'
 import { createStompClient } from '../services/ws'
 import { setupSignalRoutes } from '../services/signaling'
 import { setupChat } from '../services/chat'
+import { getIceServers } from '../services/turn'
 import api from '../services/api'
 import { useAuthStore } from '../stores/auth'
 import { useMatchStore } from '../stores/match'
@@ -382,31 +383,38 @@ async function ensurePeerConnection() {
   }
 
   if (!pc) {
-    pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] })
-    pc.ontrack = (event) => {
-      const [stream] = event.streams
-      if (stream && remoteVideo.value) {
-        remoteVideo.value.srcObject = stream
-        hasRemoteStream.value = true
-        Promise.resolve()
+    const iceServers = await getIceServers()
+
+    if (pc) {
+      // 다른 비동기 ensurePeerConnection 호출이 이미 RTCPeerConnection을 준비했습니다.
+      // 아래 로직은 기존 연결에 대해 계속 진행합니다.
+    } else {
+      pc = new RTCPeerConnection({ iceServers })
+      pc.ontrack = (event) => {
+        const [stream] = event.streams
+        if (stream && remoteVideo.value) {
+          remoteVideo.value.srcObject = stream
+          hasRemoteStream.value = true
+          Promise.resolve()
           .then(() => remoteVideo.value?.play?.())
           .catch((error) => {
             console.warn('원격 영상 자동 재생 실패', error)
           })
       }
     }
-    pc.onicecandidate = (event) => {
-      if (event.candidate && signalRoute) {
-        signalRoute.sendSignal({
-          type: 'ice-candidate',
-          receiverLoginId: matchStore.partnerLoginId,
-          data: event.candidate,
-        })
+      pc.onicecandidate = (event) => {
+        if (event.candidate && signalRoute) {
+          signalRoute.sendSignal({
+            type: 'ice-candidate',
+            receiverLoginId: matchStore.partnerLoginId,
+            data: event.candidate,
+          })
+        }
       }
-    }
-    pc.onconnectionstatechange = () => {
-      if (pc && ['disconnected', 'failed', 'closed'].includes(pc.connectionState)) {
-        hasRemoteStream.value = false
+      pc.onconnectionstatechange = () => {
+        if (pc && ['disconnected', 'failed', 'closed'].includes(pc.connectionState)) {
+          hasRemoteStream.value = false
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add a reusable TURN configuration loader that supports static env values and Metered credential API tokens
- update the WebRTC session to consume the resolved ICE servers instead of the hardcoded Google STUN entry
- document the new environment variables and TURN setup process in the frontend readme and example env file

## Testing
- npm run build *(fails: Vite CLI throws ERR_MODULE_NOT_FOUND for chunks/dep-D_zLpgQd.js in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d29284e50c83258c2655c0a8fea4f5