### PR TITLE
Add follow request workflow and sync chat list

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/FollowController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/FollowController.java
@@ -1,0 +1,104 @@
+package net.datasa.project01.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.FollowRequestCreateDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.domain.dto.FollowSummaryDto;
+import net.datasa.project01.service.FollowService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+@Slf4j
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping
+    public ResponseEntity<?> createFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody FollowRequestCreateDto requestDto) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증 정보가 필요합니다."));
+        }
+        try {
+            FollowResponseDto response = followService.requestFollow(userDetails.getUsername(), requestDto);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("Follow request failed for user {}: {}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/rooms/{roomId}")
+    public ResponseEntity<?> getFollowStatus(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long roomId) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증 정보가 필요합니다."));
+        }
+        try {
+            FollowResponseDto response = followService.getFollowStatus(userDetails.getUsername(), roomId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Follow status lookup failed for user {} and room {}: {}", userDetails.getUsername(), roomId, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{followRequestId}/accept")
+    public ResponseEntity<?> acceptFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long followRequestId) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증 정보가 필요합니다."));
+        }
+        try {
+            FollowResponseDto response = followService.respondToFollow(followRequestId, userDetails.getUsername(), true);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("Follow accept failed for user {}: {}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{followRequestId}/decline")
+    public ResponseEntity<?> declineFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long followRequestId) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증 정보가 필요합니다."));
+        }
+        try {
+            FollowResponseDto response = followService.respondToFollow(followRequestId, userDetails.getUsername(), false);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("Follow decline failed for user {}: {}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/accepted")
+    public ResponseEntity<?> getAcceptedFollows(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증 정보가 필요합니다."));
+        }
+        try {
+            List<FollowSummaryDto> summaries = followService.getAcceptedFollows(userDetails.getUsername());
+            return ResponseEntity.ok(summaries);
+        } catch (IllegalArgumentException e) {
+            log.warn("Accepted follow lookup failed for user {}: {}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -10,7 +10,9 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class ChatMessageResponseDto {
+    private final Long messageId;
     private final Long roomId;
+    private final String senderLoginId;
     private final String senderNickName;
     private final String content;
     private final String translatedContent; // 번역된 메시지를 담을 필드

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowEventMessage.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowEventMessage.java
@@ -1,0 +1,24 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowEventMessage {
+
+    public enum EventType {
+        REQUESTED,
+        ACCEPTED,
+        DECLINED,
+        CANCELLED
+    }
+
+    private EventType eventType;
+    private FollowResponseDto follow;
+    private String message;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowRequestCreateDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowRequestCreateDto.java
@@ -1,0 +1,13 @@
+package net.datasa.project01.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowRequestCreateDto {
+
+    @NotNull
+    private Long roomId;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowResponseDto.java
@@ -1,0 +1,84 @@
+package net.datasa.project01.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.datasa.project01.domain.entity.FollowRequest;
+import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.domain.entity.User;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FollowResponseDto {
+
+    private Long followRequestId;
+    private Long roomId;
+    private String status;
+    private String direction;
+    private boolean actionable;
+    private boolean accepted;
+    private String partnerLoginId;
+    private String partnerNickName;
+    private LocalDateTime createdAt;
+    private LocalDateTime respondedAt;
+    private String message;
+
+    public static FollowResponseDto from(FollowRequest request, User viewer) {
+        return from(request, viewer, null);
+    }
+
+    public static FollowResponseDto from(FollowRequest request, User viewer, String message) {
+        if (request == null || viewer == null) {
+            return FollowResponseDto.builder()
+                    .status("NONE")
+                    .actionable(false)
+                    .accepted(false)
+                    .message(message)
+                    .build();
+        }
+
+        boolean viewerIsRequester = request.getRequester() != null
+                && request.getRequester().getUserPid() != null
+                && request.getRequester().getUserPid().equals(viewer.getUserPid());
+
+        User partner = viewerIsRequester ? request.getReceiver() : request.getRequester();
+        FollowRequest.Status status = request.getStatus();
+
+        return FollowResponseDto.builder()
+                .followRequestId(request.getFollowRequestId())
+                .roomId(request.getRoom() != null ? request.getRoom().getRoomId() : null)
+                .status(status != null ? status.name() : "NONE")
+                .direction(viewerIsRequester ? "OUTGOING" : "INCOMING")
+                .actionable(status == FollowRequest.Status.PENDING && !viewerIsRequester)
+                .accepted(status == FollowRequest.Status.ACCEPTED)
+                .partnerLoginId(partner != null ? partner.getLoginId() : null)
+                .partnerNickName(partner != null ? partner.getNickName() : null)
+                .createdAt(request.getCreatedAt())
+                .respondedAt(request.getRespondedAt())
+                .message(message)
+                .build();
+    }
+
+    public static FollowResponseDto none(Room room, User viewer, User partner) {
+        return FollowResponseDto.builder()
+                .followRequestId(null)
+                .roomId(room != null ? room.getRoomId() : null)
+                .status("NONE")
+                .direction(null)
+                .actionable(false)
+                .accepted(false)
+                .partnerLoginId(partner != null ? partner.getLoginId() : null)
+                .partnerNickName(partner != null ? partner.getNickName() : null)
+                .createdAt(null)
+                .respondedAt(null)
+                .message(null)
+                .build();
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/domain/dto/FollowSummaryDto.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/FollowSummaryDto.java
@@ -1,0 +1,22 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowSummaryDto {
+    private Long followRequestId;
+    private Long roomId;
+    private String partnerLoginId;
+    private String partnerNickName;
+    private LocalDateTime acceptedAt;
+    private List<ChatMessageResponseDto> recentMessages;
+}

--- a/backend/src/main/java/net/datasa/project01/domain/entity/FollowRequest.java
+++ b/backend/src/main/java/net/datasa/project01/domain/entity/FollowRequest.java
@@ -1,0 +1,63 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "follow_requests")
+public class FollowRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_request_id")
+    private Long followRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_pid", nullable = false)
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_pid", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 10, nullable = false)
+    private Status status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
+
+    public boolean involves(User user) {
+        if (user == null) {
+            return false;
+        }
+        Long userPid = user.getUserPid();
+        if (userPid == null) {
+            return false;
+        }
+        return (requester != null && userPid.equals(requester.getUserPid()))
+                || (receiver != null && userPid.equals(receiver.getUserPid()));
+    }
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        DECLINED
+    }
+}

--- a/backend/src/main/java/net/datasa/project01/repository/FollowRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/FollowRequestRepository.java
@@ -1,0 +1,29 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.FollowRequest;
+import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRequestRepository extends JpaRepository<FollowRequest, Long> {
+
+    Optional<FollowRequest> findTopByRoomOrderByCreatedAtDesc(Room room);
+
+    Optional<FollowRequest> findTopByRoomAndStatusOrderByCreatedAtDesc(Room room, FollowRequest.Status status);
+
+    Optional<FollowRequest> findByFollowRequestIdAndReceiver_LoginId(Long followRequestId, String loginId);
+
+    @Query("select fr from FollowRequest fr " +
+            "join fetch fr.room r " +
+            "join fetch fr.requester req " +
+            "join fetch fr.receiver rec " +
+            "where fr.status = :status and (req = :user or rec = :user) " +
+            "order by fr.respondedAt desc nulls last, fr.createdAt desc")
+    List<FollowRequest> findByUserAndStatus(@Param("user") User user,
+                                            @Param("status") FollowRequest.Status status);
+}

--- a/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
@@ -1,11 +1,16 @@
 package net.datasa.project01.repository;
 
+import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.RoomMember;
 import net.datasa.project01.domain.entity.RoomMemberId;
+import net.datasa.project01.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // JpaRepository의 두 번째 제네릭 타입으로 엔티티의 ID 클래스인 'RoomMemberId'를 지정
 public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemberId> {
-    // 예시: 특정 방의 모든 참여자를 찾는 커스텀 메소드
-    // List<RoomMember> findByRoom(Room room);
+    java.util.List<RoomMember> findByRoom(Room room);
+
+    java.util.Optional<RoomMember> findByRoomAndUser(Room room, User user);
+
+    java.util.Optional<RoomMember> findByRoom_RoomIdAndUser_LoginId(Long roomId, String loginId);
 }

--- a/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -209,7 +209,9 @@ public class ChatService {
         }
 
         return ChatMessageResponseDto.builder()
+                .messageId(message.getMessageId())
                 .roomId(message.getRoom().getRoomId())
+                .senderLoginId(message.getSender() != null ? message.getSender().getLoginId() : null)
                 .senderNickName(message.getSender() != null ? message.getSender().getNickName() : null)
                 .content(message.getTextContent())
                 .translatedContent(translatedText)

--- a/backend/src/main/java/net/datasa/project01/service/FollowService.java
+++ b/backend/src/main/java/net/datasa/project01/service/FollowService.java
@@ -1,0 +1,299 @@
+package net.datasa.project01.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
+import net.datasa.project01.domain.dto.FollowEventMessage;
+import net.datasa.project01.domain.dto.FollowRequestCreateDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
+import net.datasa.project01.domain.dto.FollowSummaryDto;
+import net.datasa.project01.domain.entity.FollowRequest;
+import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.domain.entity.RoomMember;
+import net.datasa.project01.domain.entity.RoomMessage;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.FollowRequestRepository;
+import net.datasa.project01.repository.RoomMemberRepository;
+import net.datasa.project01.repository.RoomMessageRepository;
+import net.datasa.project01.repository.RoomRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FollowService {
+
+    private static final int RECENT_MESSAGE_LIMIT = 50;
+
+    private final FollowRequestRepository followRequestRepository;
+    private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomMessageRepository roomMessageRepository;
+    private final UserRepository userRepository;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    public FollowResponseDto requestFollow(String loginId, FollowRequestCreateDto dto) {
+        if (dto == null || dto.getRoomId() == null) {
+            throw new IllegalArgumentException("팔로우를 요청할 채팅방을 선택해 주세요.");
+        }
+        User requester = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Room room = roomRepository.findById(dto.getRoomId())
+                .orElseThrow(() -> new IllegalArgumentException("채팅방 정보를 확인할 수 없습니다."));
+
+        if (room.getRoomType() != Room.RoomType.PRIVATE) {
+            throw new IllegalArgumentException("팔로우는 1:1 매칭 채팅에서만 신청할 수 있습니다.");
+        }
+
+        Participants participants = resolveParticipants(room, requester);
+        User receiver = participants.partner();
+
+        Optional<FollowRequest> latestOptional = followRequestRepository.findTopByRoomOrderByCreatedAtDesc(room);
+        if (latestOptional.isPresent()) {
+            FollowRequest latest = latestOptional.get();
+            if (latest.getStatus() == FollowRequest.Status.PENDING) {
+                String message = latest.getRequester().getUserPid().equals(requester.getUserPid())
+                        ? "이미 팔로우 요청을 보냈습니다."
+                        : String.format("%s님이 팔로우 요청을 보냈습니다.", latest.getRequester().getNickName());
+                FollowResponseDto response = FollowResponseDto.from(latest, requester, message);
+                if (!latest.getRequester().getUserPid().equals(requester.getUserPid())) {
+                    // 상대 요청 대기 중임을 알리기 위해 이벤트만 재전송
+                    sendFollowEvent(requester, FollowEventMessage.EventType.REQUESTED, latest, message);
+                }
+                return response;
+            }
+            if (latest.getStatus() == FollowRequest.Status.ACCEPTED) {
+                String message = "이미 서로 팔로우 관계입니다.";
+                return FollowResponseDto.from(latest, requester, message);
+            }
+        }
+
+        FollowRequest newRequest = followRequestRepository.save(FollowRequest.builder()
+                .room(room)
+                .requester(requester)
+                .receiver(receiver)
+                .status(FollowRequest.Status.PENDING)
+                .build());
+
+        String requesterMessage = "팔로우 요청을 보냈습니다.";
+        String receiverMessage = String.format("%s님이 팔로우를 요청했습니다.", requester.getNickName());
+
+        sendFollowEvent(requester, FollowEventMessage.EventType.REQUESTED, newRequest, requesterMessage);
+        sendFollowEvent(receiver, FollowEventMessage.EventType.REQUESTED, newRequest, receiverMessage);
+
+        return FollowResponseDto.from(newRequest, requester, requesterMessage);
+    }
+
+    public FollowResponseDto respondToFollow(Long followRequestId, String loginId, boolean accept) {
+        FollowRequest request = followRequestRepository.findById(followRequestId)
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 요청을 찾을 수 없습니다."));
+
+        if (request.getStatus() != FollowRequest.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 팔로우 요청입니다.");
+        }
+
+        if (!request.getReceiver().getLoginId().equals(loginId)) {
+            throw new IllegalArgumentException("해당 팔로우 요청에 응답할 권한이 없습니다.");
+        }
+
+        User receiver = request.getReceiver();
+        User requester = request.getRequester();
+
+        request.setStatus(accept ? FollowRequest.Status.ACCEPTED : FollowRequest.Status.DECLINED);
+        request.setRespondedAt(LocalDateTime.now());
+
+        String receiverMessage = accept ? "팔로우를 수락했습니다." : "팔로우 요청을 거절했습니다.";
+        String requesterMessage = accept
+                ? String.format("%s님이 팔로우를 수락했습니다.", receiver.getNickName())
+                : String.format("%s님이 팔로우 요청을 거절했습니다.", receiver.getNickName());
+
+        FollowEventMessage.EventType eventType = accept
+                ? FollowEventMessage.EventType.ACCEPTED
+                : FollowEventMessage.EventType.DECLINED;
+
+        sendFollowEvent(receiver, eventType, request, receiverMessage);
+        sendFollowEvent(requester, eventType, request, requesterMessage);
+
+        return FollowResponseDto.from(request, receiver, receiverMessage);
+    }
+
+    @Transactional(readOnly = true)
+    public FollowResponseDto getFollowStatus(String loginId, Long roomId) {
+        User viewer = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방 정보를 확인할 수 없습니다."));
+
+        Participants participants = resolveParticipants(room, viewer);
+        Optional<FollowRequest> latestOptional = followRequestRepository.findTopByRoomOrderByCreatedAtDesc(room);
+
+        if (latestOptional.isEmpty()) {
+            return FollowResponseDto.none(room, viewer, participants.partner());
+        }
+
+        FollowRequest latest = latestOptional.get();
+        if (!latest.involves(viewer)) {
+            throw new IllegalArgumentException("팔로우 요청 정보를 확인할 수 없습니다.");
+        }
+        return FollowResponseDto.from(latest, viewer);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FollowSummaryDto> getAcceptedFollows(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<FollowRequest> accepted = followRequestRepository.findByUserAndStatus(user, FollowRequest.Status.ACCEPTED);
+        Map<Long, FollowRequest> latestByRoom = new LinkedHashMap<>();
+        for (FollowRequest request : accepted) {
+            Room room = request.getRoom();
+            if (room == null) {
+                continue;
+            }
+            Long roomId = room.getRoomId();
+            if (roomId == null) {
+                continue;
+            }
+            latestByRoom.putIfAbsent(roomId, request);
+        }
+
+        List<FollowSummaryDto> summaries = new ArrayList<>();
+        for (FollowRequest request : latestByRoom.values()) {
+            Room room = request.getRoom();
+            if (room == null) {
+                continue;
+            }
+            boolean viewerIsRequester = request.getRequester() != null
+                    && request.getRequester().getUserPid() != null
+                    && request.getRequester().getUserPid().equals(user.getUserPid());
+            User partner = viewerIsRequester ? request.getReceiver() : request.getRequester();
+
+            List<ChatMessageResponseDto> messages = fetchRecentMessages(room);
+
+            FollowSummaryDto summary = FollowSummaryDto.builder()
+                    .followRequestId(request.getFollowRequestId())
+                    .roomId(room.getRoomId())
+                    .partnerLoginId(partner != null ? partner.getLoginId() : null)
+                    .partnerNickName(partner != null ? partner.getNickName() : null)
+                    .acceptedAt(request.getRespondedAt())
+                    .recentMessages(messages)
+                    .build();
+            summaries.add(summary);
+        }
+        return summaries;
+    }
+
+    private List<ChatMessageResponseDto> fetchRecentMessages(Room room) {
+        return roomMessageRepository.findByRoomOrderByCreatedAtDesc(
+                        room,
+                        PageRequest.of(0, RECENT_MESSAGE_LIMIT, Sort.by(Sort.Direction.DESC, "createdAt")))
+                .stream()
+                .map(this::toChatMessageDto)
+                .filter(dto -> dto != null)
+                .sorted((a, b) -> {
+                    LocalDateTime left = a.getSentAt();
+                    LocalDateTime right = b.getSentAt();
+                    if (left == null && right == null) {
+                        return 0;
+                    }
+                    if (left == null) {
+                        return -1;
+                    }
+                    if (right == null) {
+                        return 1;
+                    }
+                    return left.compareTo(right);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private ChatMessageResponseDto toChatMessageDto(RoomMessage message) {
+        if (message == null) {
+            return null;
+        }
+        String fileUrl = null;
+        if (message.getMessageId() != null && message.getFilePath() != null) {
+            fileUrl = "/api/chat/files/" + message.getMessageId();
+        }
+        return ChatMessageResponseDto.builder()
+                .messageId(message.getMessageId())
+                .roomId(message.getRoom() != null ? message.getRoom().getRoomId() : null)
+                .senderLoginId(message.getSender() != null ? message.getSender().getLoginId() : null)
+                .senderNickName(message.getSender() != null ? message.getSender().getNickName() : null)
+                .content(message.getTextContent())
+                .translatedContent(null)
+                .contentType(message.getContentType() != null ? message.getContentType().name() : null)
+                .fileName(message.getFileName())
+                .fileUrl(fileUrl)
+                .mimeType(message.getMimeType())
+                .sizeBytes(message.getSizeBytes())
+                .sentAt(message.getCreatedAt())
+                .build();
+    }
+
+    private Participants resolveParticipants(Room room, User viewer) {
+        List<RoomMember> members = roomMemberRepository.findByRoom(room);
+        if (members == null || members.isEmpty()) {
+            throw new IllegalArgumentException("채팅방 참여자 정보를 찾을 수 없습니다.");
+        }
+
+        RoomMember viewerMember = members.stream()
+                .filter(member -> member.getUser() != null
+                        && member.getUser().getUserPid() != null
+                        && member.getUser().getUserPid().equals(viewer.getUserPid()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방 참여자가 아닙니다."));
+
+        RoomMember partnerMember = members.stream()
+                .filter(member -> member.getUser() != null
+                        && !member.getUser().getUserPid().equals(viewer.getUserPid()))
+                .filter(member -> member.getLeftAt() == null)
+                .findFirst()
+                .orElse(null);
+
+        if (partnerMember == null) {
+            partnerMember = members.stream()
+                    .filter(member -> member.getUser() != null
+                            && !member.getUser().getUserPid().equals(viewer.getUserPid()))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (partnerMember == null || partnerMember.getUser() == null) {
+            throw new IllegalStateException("상대방 정보를 찾을 수 없습니다.");
+        }
+
+        return new Participants(viewerMember.getUser(), partnerMember.getUser());
+    }
+
+    private void sendFollowEvent(User target, FollowEventMessage.EventType eventType,
+                                 FollowRequest request, String message) {
+        if (target == null) {
+            return;
+        }
+        FollowResponseDto payload = FollowResponseDto.from(request, target, message);
+        FollowEventMessage event = FollowEventMessage.builder()
+                .eventType(eventType)
+                .follow(payload)
+                .message(message)
+                .build();
+        messagingTemplate.convertAndSendToUser(target.getLoginId(), "/queue/follow-events", event);
+    }
+
+    private record Participants(User viewer, User partner) {
+    }
+}

--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -271,7 +271,7 @@ function displayError(error) {
 
 function addFriend() {
   if (props.partner) {
-    friends.add(props.partner)
+    friends.upsert({ partnerNickName: props.partner })
   }
 }
 

--- a/frontend/src/stores/friends.js
+++ b/frontend/src/stores/friends.js
@@ -1,19 +1,214 @@
 import { defineStore } from 'pinia'
+import api from '../services/api'
+
+const STORAGE_KEY = 'friends'
+
+function normalizeMessage(raw = {}) {
+  const messageId = raw.messageId ?? raw.id ?? null
+  const sentAt = raw.sentAt ?? null
+  const sizeValue = raw.sizeBytes ?? raw.size_bytes
+  let normalizedSize = null
+  if (typeof sizeValue === 'number') {
+    normalizedSize = Number.isFinite(sizeValue) ? sizeValue : null
+  } else if (sizeValue != null) {
+    const parsed = Number(sizeValue)
+    normalizedSize = Number.isFinite(parsed) ? parsed : null
+  }
+
+  const base = {
+    id:
+      messageId ??
+      `${raw.roomId ?? ''}-${sentAt ?? Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    messageId: messageId,
+    roomId: raw.roomId ?? null,
+    senderLoginId: raw.senderLoginId ?? raw.sender_login_id ?? null,
+    senderNickName: raw.senderNickName ?? raw.sender_nick_name ?? raw.sender ?? '',
+    content: raw.content ?? raw.text ?? '',
+    translatedContent: raw.translatedContent ?? raw.translated_content ?? '',
+    contentType: (raw.contentType ?? raw.content_type ?? (raw.fileUrl ? 'FILE' : 'TEXT') ?? 'TEXT').toString().toUpperCase(),
+    fileName: raw.fileName ?? raw.file_name ?? '',
+    fileUrl: raw.fileUrl ?? raw.file_url ?? '',
+    mimeType: raw.mimeType ?? raw.mime_type ?? '',
+    sizeBytes: normalizedSize,
+    sentAt,
+  }
+
+  return base
+}
+
+function normalizeFriend(raw = {}) {
+  if (typeof raw === 'string') {
+    return normalizeFriend({ partnerNickName: raw })
+  }
+
+  const messages = Array.isArray(raw.messages) ? raw.messages.map(normalizeMessage) : []
+  messages.sort((a, b) => {
+    const left = a.sentAt ? new Date(a.sentAt).getTime() : 0
+    const right = b.sentAt ? new Date(b.sentAt).getTime() : 0
+    return left - right
+  })
+
+  const partnerNickName = raw.partnerNickName ?? raw.partner_nick_name ?? raw.name ?? ''
+  const partnerLoginId = raw.partnerLoginId ?? raw.partner_login_id ?? null
+  const roomId = raw.roomId ?? raw.room_id ?? null
+
+  let identifier = raw.id ?? roomId ?? partnerLoginId
+  if (!identifier || (typeof identifier === 'string' && !identifier.trim())) {
+    identifier = partnerNickName && partnerNickName.trim()
+      ? partnerNickName
+      : `friend-${Math.random().toString(36).slice(2, 10)}`
+  }
+
+  return {
+    id: identifier,
+    followRequestId: raw.followRequestId ?? raw.follow_request_id ?? null,
+    roomId,
+    partnerLoginId,
+    partnerNickName,
+    acceptedAt: raw.acceptedAt ?? raw.accepted_at ?? null,
+    messages,
+  }
+}
+
+function summaryToFriend(summary = {}) {
+  const friend = {
+    followRequestId: summary.followRequestId ?? null,
+    roomId: summary.roomId ?? null,
+    partnerLoginId: summary.partnerLoginId ?? null,
+    partnerNickName: summary.partnerNickName ?? summary.partnerNickname ?? '',
+    acceptedAt: summary.acceptedAt ?? null,
+    messages: Array.isArray(summary.recentMessages) ? summary.recentMessages : [],
+  }
+  return normalizeFriend(friend)
+}
+
+function loadInitialState() {
+  if (typeof localStorage === 'undefined') {
+    return []
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) {
+      return []
+    }
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    return parsed.map(normalizeFriend)
+  } catch (error) {
+    console.warn('친구 목록 복원 실패', error)
+    return []
+  }
+}
+
+function persist(list) {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list))
+  } catch (error) {
+    console.warn('친구 목록 저장 실패', error)
+  }
+}
 
 export const useFriendsStore = defineStore('friends', {
   state: () => ({
-    list: JSON.parse(localStorage.getItem('friends') || '[]')
+    list: loadInitialState(),
+    loading: false,
   }),
+  getters: {
+    byRoomId: (state) =>
+      state.list.reduce((acc, friend) => {
+        if (friend.roomId != null) {
+          acc[friend.roomId] = friend
+        }
+        return acc
+      }, {}),
+  },
   actions: {
-    add(name) {
-      if (name && !this.list.includes(name)) {
-        this.list.push(name)
-        localStorage.setItem('friends', JSON.stringify(this.list))
+    setAll(friends = []) {
+      this.list = friends.map(normalizeFriend)
+      persist(this.list)
+    },
+    upsert(friend) {
+      const normalized = normalizeFriend(friend)
+      const index = this.list.findIndex((item) => {
+        if (normalized.roomId != null && item.roomId != null) {
+          return item.roomId === normalized.roomId
+        }
+        if (normalized.partnerLoginId && item.partnerLoginId) {
+          return item.partnerLoginId === normalized.partnerLoginId
+        }
+        if (normalized.partnerNickName && item.partnerNickName) {
+          return item.partnerNickName === normalized.partnerNickName
+        }
+        return false
+      })
+      if (index >= 0) {
+        const existing = this.list[index]
+        const mergedMessages = normalized.messages.length ? normalized.messages : existing.messages
+        this.list.splice(index, 1, {
+          ...existing,
+          ...normalized,
+          messages: mergedMessages,
+        })
+      } else {
+        this.list.push(normalized)
+      }
+      persist(this.list)
+    },
+    add(friend) {
+      this.upsert(friend)
+    },
+    remove(identifier) {
+      if (!identifier) {
+        return
+      }
+      if (typeof identifier === 'object') {
+        const { roomId, partnerLoginId, partnerNickName } = identifier
+        this.list = this.list.filter((item) => {
+          if (roomId != null && item.roomId === roomId) {
+            return false
+          }
+          if (partnerLoginId && item.partnerLoginId === partnerLoginId) {
+            return false
+          }
+          if (partnerNickName && item.partnerNickName === partnerNickName) {
+            return false
+          }
+          return true
+        })
+      } else {
+        this.list = this.list.filter((item) => item.partnerNickName !== identifier)
+      }
+      persist(this.list)
+    },
+    removeByRoom(roomId) {
+      if (roomId == null) {
+        return
+      }
+      this.list = this.list.filter((item) => item.roomId !== roomId)
+      persist(this.list)
+    },
+    clear() {
+      this.list = []
+      persist(this.list)
+    },
+    async refreshFromServer() {
+      try {
+        this.loading = true
+        const { data } = await api.get('/follows/accepted')
+        if (Array.isArray(data)) {
+          this.setAll(data.map(summaryToFriend))
+        }
+      } catch (error) {
+        console.error('친구 목록 갱신 실패', error)
+        throw error
+      } finally {
+        this.loading = false
       }
     },
-    remove(name) {
-      this.list = this.list.filter(f => f !== name)
-      localStorage.setItem('friends', JSON.stringify(this.list))
-    }
-  }
+  },
 })

--- a/frontend/src/stores/match.js
+++ b/frontend/src/stores/match.js
@@ -15,13 +15,20 @@ export const useMatchStore = defineStore('match', {
     partnerDecision: null,
     bothConfirmed: false,
     sessionClosed: false,
+    followRequestId: null,
+    followStatus: 'NONE',
+    followDirection: null,
+    followActionable: false,
+    followAccepted: false,
   }),
   getters: {
     isMatched: (state) => state.state === 'MATCHED',
     isWaiting: (state) => state.state === 'WAITING' || state.state === 'ALREADY_WAITING',
+    needsFollowAction: (state) => state.followStatus === 'PENDING' && state.followActionable,
   },
   actions: {
     setFromStartResponse(payload = {}) {
+      this.resetFollow()
       this.state = payload.state || null
       this.requestId = payload.myRequestId ?? null
       this.partnerRequestId = payload.partnerRequestId ?? null
@@ -104,6 +111,35 @@ export const useMatchStore = defineStore('match', {
           break
       }
     },
+    setFollowState(follow = {}) {
+      if (!follow) {
+        this.resetFollow()
+        return
+      }
+      this.followRequestId = follow.followRequestId ?? null
+      this.followStatus = follow.status || 'NONE'
+      this.followDirection = follow.direction || null
+      this.followActionable = !!follow.actionable
+      this.followAccepted = !!follow.accepted
+      if (typeof follow.message === 'string' && follow.message) {
+        this.statusMessage = follow.message
+      }
+    },
+    applyFollowEvent(event = {}) {
+      if (event.message) {
+        this.statusMessage = event.message
+      }
+      if (event.follow) {
+        this.setFollowState(event.follow)
+      }
+    },
+    resetFollow() {
+      this.followRequestId = null
+      this.followStatus = 'NONE'
+      this.followDirection = null
+      this.followActionable = false
+      this.followAccepted = false
+    },
     setMyDecision(decision, message = '', bothAccepted = false) {
       this.myDecision = decision
       if (message) {
@@ -134,6 +170,7 @@ export const useMatchStore = defineStore('match', {
       this.partnerDecision = null
       this.bothConfirmed = false
       this.sessionClosed = false
+      this.resetFollow()
     },
   },
 })

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -63,7 +63,7 @@
         <div class="chat-header d-flex align-center pa-4">
           <v-avatar size="40"><v-icon color="primary">mdi-account</v-icon></v-avatar>
           <div class="ml-3">
-            <div class="text-subtitle-1 font-weight-medium">{{ current.name }}</div>
+            <div class="text-subtitle-1 font-weight-medium">{{ currentName }}</div>
             <div class="text-caption text-grey" v-if="!isGroup">온라인</div>
             <div class="text-caption text-grey" v-else>{{ groupParticipants }}</div>
           </div>
@@ -76,10 +76,9 @@
         </div>
         <v-divider />
         <div class="chat-messages flex-grow-1 pa-4 overflow-y-auto" ref="chatMessagesContainer">
-          <div class="text-center my-4 text-caption text-grey">2023년 1월 18일</div>
           <div
             v-for="(m, i) in messages"
-            :key="i"
+            :key="m.id || i"
             class="d-flex mb-4"
             :class="{ 'justify-end': m.me }"
           >
@@ -121,16 +120,16 @@
 
 <script setup>
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
+import { useAuthStore } from '../stores/auth'
 import { useFriendsStore } from '../stores/friends'
 
 const query = ref('')
 const tab = ref('direct')
-const chats = ref([])
 const groups = ref([
-  { id: 3, name: '스터디 모임', last: '다음 주 모임 시간 안내', participants: ['김서연', '대학 동기'] }
+  { id: 3, type: 'group', name: '스터디 모임', last: '다음 주 모임 시간 안내', participants: ['김서연', '대학 동기'] }
 ])
 
-const current = ref({})
+const current = ref(null)
 const draft = ref('')
 const conversations = ref({
   3: []
@@ -139,38 +138,115 @@ const conversations = ref({
 const chatMessagesContainer = ref(null)
 
 const friendsStore = useFriendsStore()
+const auth = useAuthStore()
 
-onMounted(() => {
-  chats.value = friendsStore.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
-  current.value = chats.value[0] || groups.value[0]
-  scrollToBottom()
+const meLoginId = computed(() => auth.user?.loginId || auth.user?.login_id || auth.user?.loginID || null)
+const meNickName = computed(() => auth.user?.nickName || auth.user?.nickname || auth.user?.nick_name || '')
+
+const timeFormatter = new Intl.DateTimeFormat('ko-KR', {
+  hour: '2-digit',
+  minute: '2-digit',
 })
 
-friendsStore.$subscribe((_, state) => {
-  chats.value = state.list.map((name, idx) => ({ id: idx + 1, name, last: '' }))
+const directChats = computed(() =>
+  friendsStore.list.map((friend) => ({
+    id:
+      friend.id ??
+      friend.roomId ??
+      friend.partnerLoginId ??
+      friend.partnerNickName ??
+      `friend-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'direct',
+    name: friend.partnerNickName || friend.partnerLoginId || '알 수 없음',
+    last: summarizeLastMessage(friend),
+    friend,
+  }))
+)
+
+const filteredChats = computed(() => {
+  const keyword = query.value.trim()
+  if (!keyword) {
+    return directChats.value
+  }
+  return directChats.value.filter(
+    (chat) =>
+      (chat.name && chat.name.includes(keyword)) ||
+      (chat.last && chat.last.includes(keyword))
+  )
 })
 
-
-const filteredChats = computed(() =>
-  chats.value.filter(c =>
-    c.name.includes(query.value) || c.last?.includes(query.value)
+const filteredGroups = computed(() => {
+  const keyword = query.value.trim()
+  if (!keyword) {
+    return groups.value
+  }
+  return groups.value.filter(
+    (group) =>
+      (group.name && group.name.includes(keyword)) ||
+      (group.last && group.last.includes(keyword))
   )
-)
-const filteredGroups = computed(() =>
-  groups.value.filter(c =>
-    c.name.includes(query.value) || c.last?.includes(query.value)
-  )
-)
+})
 
-const isGroup = computed(() =>
-    groups.value.some(g => g.id === current.value.id)
-)
+const isGroup = computed(() => current.value?.type === 'group')
+
 const groupParticipants = computed(() => {
-  const g = groups.value.find(g => g.id === current.value.id)
-  return g ? g.participants.join(', ') : ''
+  if (!isGroup.value) {
+    return ''
+  }
+  const group = groups.value.find((g) => g.id === current.value?.id)
+  return group ? group.participants.join(', ') : ''
 })
 
-const messages = computed(() => conversations.value[current.value.id] || [])
+const currentName = computed(() => current.value?.name || '대화 상대 없음')
+
+const messages = computed(() => {
+  if (current.value?.type === 'group') {
+    return conversations.value[current.value.id] || []
+  }
+  if (current.value?.type === 'direct') {
+    return formatFriendMessages(current.value.friend?.messages || [])
+  }
+  return []
+})
+
+function summarizeLastMessage(friend) {
+  if (!friend || !Array.isArray(friend.messages) || friend.messages.length === 0) {
+    return ''
+  }
+  const last = friend.messages[friend.messages.length - 1]
+  const contentType = (last.contentType || '').toString().toUpperCase()
+  if (contentType === 'IMAGE') {
+    return '[이미지]'
+  }
+  if (contentType === 'FILE') {
+    return last.fileName ? `[파일] ${last.fileName}` : '[파일]'
+  }
+  return last.content || ''
+}
+
+function formatFriendMessages(items = []) {
+  return items.map((item) => {
+    const contentType = (item.contentType || '').toString().toUpperCase()
+    let text = item.content || ''
+    if (contentType === 'IMAGE') {
+      text = '[이미지]'
+    } else if (contentType === 'FILE') {
+      text = item.fileName ? `[파일] ${item.fileName}` : '[파일]'
+    }
+    const sentAt = item.sentAt ? new Date(item.sentAt) : null
+    const fromMe = item.senderLoginId
+      ? item.senderLoginId === meLoginId.value
+      : item.fromMe ?? (item.senderNickName && item.senderNickName === meNickName.value)
+
+    return {
+      text,
+      me: !!fromMe,
+      sender: item.senderNickName || '',
+      time: sentAt ? timeFormatter.format(sentAt) : '',
+      id: item.id ?? item.messageId ?? `${text}-${Math.random().toString(36).slice(2, 8)}`,
+    }
+  })
+}
 
 function scrollToBottom() {
   nextTick(() => {
@@ -182,13 +258,18 @@ function scrollToBottom() {
 }
 
 function openChat(item) {
+  if (!item) {
+    return
+  }
   current.value = item
-  if (!conversations.value[item.id]) conversations.value[item.id] = []
+  if (item.type === 'group' && !conversations.value[item.id]) {
+    conversations.value[item.id] = []
+  }
   scrollToBottom()
 }
 
 function inviteParticipant() {
-  const group = groups.value.find(g => g.id === current.value.id)
+  const group = groups.value.find((g) => g.id === current.value?.id)
   if (!group) return
   if (group.participants.length >= 4) {
     alert('최대 4명까지 초대할 수 있습니다.')
@@ -204,22 +285,86 @@ function startVideoCall() {
 
 function send() {
   if (!draft.value) return
+  if (current.value?.type !== 'group') {
+    draft.value = ''
+    return
+  }
   const formatted = new Date().toLocaleTimeString([], {
     hour: '2-digit',
-    minute: '2-digit'
+    minute: '2-digit',
   })
   const msg = { text: draft.value, time: formatted, me: true }
   conversations.value[current.value.id] = conversations.value[current.value.id] || []
   conversations.value[current.value.id].push(msg)
-  let chat = chats.value.find(c => c.id === current.value.id)
-  if (!chat) chat = groups.value.find(c => c.id === current.value.id)
-  if (chat) chat.last = draft.value
+  const group = groups.value.find((g) => g.id === current.value.id)
+  if (group) {
+    group.last = draft.value
+  }
 
   draft.value = ''
   scrollToBottom()
 }
 
 watch(messages, () => scrollToBottom())
+
+watch(
+  directChats,
+  (newChats) => {
+    if (tab.value !== 'direct') {
+      return
+    }
+    if (!newChats.length) {
+      if (groups.value.length) {
+        current.value = groups.value[0]
+        tab.value = 'group'
+      }
+      return
+    }
+    if (!current.value || current.value.type !== 'direct') {
+      current.value = newChats[0]
+      return
+    }
+    const exists = newChats.some((chat) => chat.id === current.value.id)
+    if (!exists) {
+      current.value = newChats[0]
+    }
+  },
+  { immediate: true }
+)
+
+watch(tab, (value) => {
+  if (value === 'direct') {
+    if (directChats.value.length) {
+      if (current.value?.type !== 'direct') {
+        current.value = directChats.value[0]
+      }
+    }
+  } else if (value === 'group') {
+    if (groups.value.length) {
+      if (current.value?.type !== 'group') {
+        current.value = groups.value[0]
+      }
+    }
+  }
+})
+
+onMounted(async () => {
+  try {
+    await friendsStore.refreshFromServer()
+  } catch (error) {
+    console.error('채팅 목록 초기화 실패', error)
+  }
+
+  if (directChats.value.length) {
+    current.value = directChats.value[0]
+    tab.value = 'direct'
+  } else if (groups.value.length) {
+    current.value = groups.value[0]
+    tab.value = 'group'
+  }
+
+  scrollToBottom()
+})
 </script>
 
 <style scoped>

--- a/frontend/src/views/MatchSession.vue
+++ b/frontend/src/views/MatchSession.vue
@@ -46,16 +46,44 @@
                   playsinline
                 ></video>
 
-                <v-btn
-                  class="follow-btn"
-                  color="success"
-                  variant="flat"
-                  prepend-icon="mdi-heart-outline"
-                  :loading="followLoading"
-                  @click="handleFollow"
-                >
-                  팔로우
-                </v-btn>
+                <div class="follow-action-group">
+                  <template v-if="followActionRequired">
+                    <v-btn
+                      class="follow-btn"
+                      color="success"
+                      variant="flat"
+                      prepend-icon="mdi-heart"
+                      :loading="followActionLoading && followActionType === 'accept'"
+                      :disabled="followActionLoading"
+                      @click="() => respondFollow(true)"
+                    >
+                      수락
+                    </v-btn>
+                    <v-btn
+                      class="follow-btn decline"
+                      color="grey"
+                      variant="outlined"
+                      prepend-icon="mdi-close"
+                      :loading="followActionLoading && followActionType === 'decline'"
+                      :disabled="followActionLoading"
+                      @click="() => respondFollow(false)"
+                    >
+                      거절
+                    </v-btn>
+                  </template>
+                  <v-btn
+                    v-else
+                    class="follow-btn"
+                    :color="followButtonColor"
+                    variant="flat"
+                    :prepend-icon="followButtonIcon"
+                    :loading="followLoading"
+                    :disabled="followButtonDisabled || followLoading"
+                    @click="handleFollow"
+                  >
+                    {{ followButtonLabel }}
+                  </v-btn>
+                </div>
               </div>
             </div>
 
@@ -115,12 +143,14 @@ import { setupChat } from '../services/chat'
 import { getIceServers } from '../services/turn'
 import api from '../services/api'
 import { useAuthStore } from '../stores/auth'
+import { useFriendsStore } from '../stores/friends'
 import { useMatchStore } from '../stores/match'
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 const matchStore = useMatchStore()
+const friendsStore = useFriendsStore()
 
 const localVideo = ref(null)
 const remoteVideo = ref(null)
@@ -131,6 +161,8 @@ const chatMessages = ref([])
 const isSendingChat = ref(false)
 const isUploadingFile = ref(false)
 const followLoading = ref(false)
+const followActionLoading = ref(false)
+const followActionType = ref(null)
 
 const client = ref(null)
 const connected = ref(false)
@@ -156,6 +188,7 @@ function logLocalState() {
   })
 }
 let matchSubscription = null
+let followSubscription = null
 let signalRoute = null
 let pc = null
 let audioTransceiver = null
@@ -182,6 +215,45 @@ const shouldInitialize = computed(
     !matchStore.sessionClosed
 )
 const meLoginId = computed(() => auth.user?.loginId || auth.user?.login_id || auth.user?.loginID || null)
+const meNickName = computed(() => auth.user?.nickName || auth.user?.nickname || auth.user?.nick_name || '')
+const followStatus = computed(() => matchStore.followStatus)
+const followDirection = computed(() => matchStore.followDirection)
+const followActionRequired = computed(() => matchStore.needsFollowAction)
+const followAccepted = computed(() => matchStore.followAccepted)
+const followButtonLabel = computed(() => {
+  if (followAccepted.value) {
+    return '팔로우 완료'
+  }
+  if (followStatus.value === 'PENDING') {
+    if (followDirection.value === 'OUTGOING') {
+      return '수락 대기중'
+    }
+    if (followDirection.value === 'INCOMING') {
+      return '팔로우 요청됨'
+    }
+    return '팔로우 대기중'
+  }
+  if (followStatus.value === 'DECLINED') {
+    return '다시 팔로우'
+  }
+  return '팔로우'
+})
+const followButtonDisabled = computed(() => {
+  if (followAccepted.value) {
+    return true
+  }
+  if (followStatus.value === 'PENDING') {
+    if (followDirection.value === 'OUTGOING') {
+      return true
+    }
+    if (followDirection.value === 'INCOMING') {
+      return true
+    }
+  }
+  return false
+})
+const followButtonIcon = computed(() => (followAccepted.value ? 'mdi-heart' : 'mdi-heart-outline'))
+const followButtonColor = computed(() => (followAccepted.value ? 'pink-darken-1' : 'success'))
 
 async function initializeSession() {
   if (initializing.value) {
@@ -581,6 +653,8 @@ function handleIncomingChatMessage(payload) {
   }
   try {
     const sentAt = payload.sentAt ? new Date(payload.sentAt) : new Date()
+    const messageId = payload.messageId ?? payload.message_id ?? null
+    const senderLoginId = payload.senderLoginId ?? payload.sender_login_id ?? null
     let sizeValue = null
     if (typeof payload.sizeBytes === 'number') {
       sizeValue = payload.sizeBytes
@@ -590,9 +664,16 @@ function handleIncomingChatMessage(payload) {
         sizeValue = parsed
       }
     }
+    const computedId =
+      messageId ?? `${payload.roomId ?? ''}-${sentAt.getTime()}-${Math.random().toString(36).slice(2, 8)}`
+    const isFromMe = senderLoginId
+      ? senderLoginId === meLoginId.value
+      : !!payload.senderNickName && payload.senderNickName === meNickName.value
     chatMessages.value.push({
-      id: `${payload.roomId ?? ''}-${sentAt.getTime()}-${Math.random().toString(36).slice(2, 8)}`,
+      id: computedId,
+      messageId,
       roomId: payload.roomId,
+      senderLoginId,
       senderNickName: payload.senderNickName,
       content: payload.content ?? '',
       translatedContent: payload.translatedContent ?? '',
@@ -602,7 +683,7 @@ function handleIncomingChatMessage(payload) {
       mimeType: payload.mimeType ?? '',
       sizeBytes: Number.isFinite(sizeValue) ? sizeValue : null,
       sentAt,
-      fromMe: !!payload.senderNickName && payload.senderNickName === (auth.user?.nickname || auth.user?.nickName || auth.user?.nick_name || ''),
+      fromMe: isFromMe,
     })
   } catch (error) {
     console.error('채팅 메시지 처리 실패', error)
@@ -621,6 +702,18 @@ function handleMatchMessage(frame) {
     void ensurePeerConnection()
   } catch (error) {
     console.error('매칭 이벤트 처리 실패', error)
+  }
+}
+
+function handleFollowMessage(frame) {
+  try {
+    const payload = JSON.parse(frame.body)
+    matchStore.applyFollowEvent(payload)
+    if (payload?.eventType === 'ACCEPTED' || payload?.follow?.accepted) {
+      void friendsStore.refreshFromServer().catch(() => {})
+    }
+  } catch (error) {
+    console.error('팔로우 이벤트 처리 실패', error)
   }
 }
 
@@ -655,13 +748,73 @@ function stopLocalStream() {
   }
 }
 
+async function loadFollowStatus() {
+  if (!matchStore.roomId) {
+    matchStore.resetFollow()
+    return
+  }
+  try {
+    const { data } = await api.get(`/follows/rooms/${matchStore.roomId}`)
+    if (data) {
+      matchStore.setFollowState(data)
+      if (data.accepted) {
+        await friendsStore.refreshFromServer().catch(() => {})
+      }
+    }
+  } catch (error) {
+    console.error('팔로우 상태 조회 실패', error)
+  }
+}
+
+async function respondFollow(accept) {
+  if (!matchStore.followRequestId) {
+    return
+  }
+  if (followActionLoading.value) {
+    return
+  }
+  followActionLoading.value = true
+  followActionType.value = accept ? 'accept' : 'decline'
+  try {
+    const endpoint = `/follows/${matchStore.followRequestId}/${accept ? 'accept' : 'decline'}`
+    const { data } = await api.post(endpoint)
+    if (data) {
+      matchStore.setFollowState(data)
+      if (data.accepted) {
+        await friendsStore.refreshFromServer().catch(() => {})
+      }
+    }
+  } catch (error) {
+    console.error('팔로우 응답 실패', error)
+    const message =
+      error?.response?.data?.message ||
+      error?.message ||
+      (accept ? '팔로우 수락에 실패했습니다.' : '팔로우 거절에 실패했습니다.')
+    window.alert(message)
+  } finally {
+    followActionLoading.value = false
+    followActionType.value = null
+  }
+}
+
 async function handleFollow() {
-  if (followLoading.value) {
+  if (followLoading.value || followButtonDisabled.value) {
+    return
+  }
+  if (!matchStore.roomId) {
+    window.alert('채팅방이 준비되지 않았습니다.')
     return
   }
   followLoading.value = true
   try {
-    window.alert('팔로우 기능은 준비 중입니다.')
+    const { data } = await api.post('/follows', { roomId: matchStore.roomId })
+    if (data) {
+      matchStore.setFollowState(data)
+    }
+  } catch (error) {
+    console.error('팔로우 요청 실패', error)
+    const message = error?.response?.data?.message || error?.message || '팔로우 요청에 실패했습니다.'
+    window.alert(message)
   } finally {
     followLoading.value = false
   }
@@ -717,18 +870,40 @@ watch(
   }
 )
 
+watch(
+  () => matchStore.roomId,
+  (roomId) => {
+    if (roomId && shouldInitialize.value) {
+      void loadFollowStatus()
+    } else if (!roomId) {
+      matchStore.resetFollow()
+    }
+  }
+)
+
+watch(
+  () => shouldInitialize.value,
+  (ready) => {
+    if (ready && matchStore.roomId) {
+      void loadFollowStatus()
+    }
+  }
+)
+
 onMounted(async () => {
   const ready = await initializeSession()
   if (!ready) {
     return
   }
 
+  await loadFollowStatus()
   await initLocalMedia()
 
   client.value = createStompClient(auth.token)
   client.value.onConnect = () => {
     connected.value = true
     matchSubscription = client.value.subscribe('/user/queue/match-results', handleMatchMessage)
+    followSubscription = client.value.subscribe('/user/queue/follow-events', handleFollowMessage)
     ensureChatRoute()
     void ensurePeerConnection()
   }
@@ -736,6 +911,8 @@ onMounted(async () => {
     connected.value = false
     matchSubscription?.unsubscribe()
     matchSubscription = null
+    followSubscription?.unsubscribe()
+    followSubscription = null
     teardownPeerConnection()
     teardownChatRoute()
   }
@@ -748,6 +925,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   matchSubscription?.unsubscribe()
   matchSubscription = null
+  followSubscription?.unsubscribe()
+  followSubscription = null
   if (signalRoute?.sub) {
     signalRoute.sub.unsubscribe()
   }
@@ -829,17 +1008,27 @@ onBeforeUnmount(() => {
   z-index: 3;
 }
 
-.follow-btn {
+.follow-action-group {
   position: absolute;
   left: 32px;
   bottom: 32px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  z-index: 3;
+}
+
+.follow-btn {
   border-radius: 999px;
   padding-inline: 22px;
   font-weight: 600;
-  background: #c6f7d6 !important;
-  color: #1b5e20 !important;
-  box-shadow: 0 18px 32px rgba(42, 157, 143, 0.25);
-  z-index: 3;
+  box-shadow: 0 18px 32px rgba(42, 157, 143, 0.18);
+}
+
+.follow-btn.decline {
+  color: #5f6368 !important;
+  background: #ffffff !important;
+  box-shadow: none;
 }
 
 .chat-column {


### PR DESCRIPTION
## Summary
- add FollowRequest entity, repository, service, controller and DTOs to handle follow submissions and notifications
- publish follow events over STOMP, expose REST APIs, and include recent messages in accepted follow summaries
- update MatchSession follow UI, friend store, and Chat view to call new APIs, manage follow state, and surface matched chats

## Testing
- npm run build
- ./gradlew test *(fails: Maven Central 403 in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3acc3236c8325b918c26963a20d11