### PR TITLE
Force JWT reauthentication after backend restart

### DIFF
--- a/backend/src/main/java/net/datasa/project01/util/JwtUtil.java
+++ b/backend/src/main/java/net/datasa/project01/util/JwtUtil.java
@@ -41,12 +41,15 @@ public class JwtUtil {
 
     private Key key;
 
+    private Date serverStartTime;
+
     @PostConstruct
     public void init() {
         if (SECRET_KEY.length() < 32) {
             throw new IllegalArgumentException("JWT secret key must be at least 32 characters long");
         }
         key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        serverStartTime = new Date();
         logger.info("JwtUtil initialized with expiration time: {} ms", EXPIRATION_TIME);
     }
 
@@ -88,7 +91,18 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-            
+
+            Date issuedAt = claims.getIssuedAt();
+            if (issuedAt == null) {
+                logger.warn("JWT token missing issuedAt claim");
+                return false;
+            }
+
+            if (issuedAt.before(serverStartTime)) {
+                logger.info("Rejecting JWT issued at {} because server started at {}", issuedAt, serverStartTime);
+                return false;
+            }
+
             // TODO: 추가 유효성 검사 (블랙리스트 체크 등)
             return true;
         } catch (SignatureException e) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import { camelizeKeys, snakifyKeys, isTransformable } from '../utils/case'
 import { API_BASE_URL } from './endpoints'
+import router from '../router'
+import { useAuthStore } from '../stores/auth'
 
 const api = axios.create({
   baseURL: API_BASE_URL,
@@ -41,6 +43,16 @@ api.interceptors.response.use(
   (error) => {
     if (error?.response?.data && isTransformable(error.response.data)) {
       error.response.data = camelizeKeys(error.response.data)
+    }
+
+    if (error?.response?.status === 401) {
+      const auth = useAuthStore()
+      if (auth.isAuthenticated || auth.hasUserSnapshot) {
+        auth.logout()
+        if (router.currentRoute.value.name !== 'login') {
+          router.push({ name: 'login', query: { expired: '1' } }).catch(() => {})
+        }
+      }
     }
     return Promise.reject(error)
   }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -6,8 +6,8 @@ export const useAuthStore = defineStore('auth', {
     user: JSON.parse(localStorage.getItem('user') || 'null'),
   }),
   getters: {
-    // ✅ 토큰 또는 사용자 요약 중 하나만 있어도 로그인된 것으로 간주
-    isAuthenticated: (s) => !!(s.token || s.user),
+    isAuthenticated: (s) => Boolean(s.token),
+    hasUserSnapshot: (s) => Boolean(s.user),
   },
   actions: {
     login({ token, user }) {


### PR DESCRIPTION
## Summary
- reject JWTs that were issued before the current server boot so that restarting the backend forces a new login
- require a stored token for Pinia authentication state and expose a snapshot flag for cached profiles
- auto-logout and redirect to the login screen whenever a 401 response is received by the shared Axios client

## Testing
- `./backend/gradlew -p backend test` *(fails: Maven Central returned HTTP 403 so dependencies could not be downloaded in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d489aadfc88325ab3592b01075f16a