### PR TITLE
Add follow request schema and adjust JWT validation

### DIFF
--- a/First_sql.sql
+++ b/First_sql.sql
@@ -154,6 +154,23 @@ CREATE TABLE follow_list (
   INDEX idx_fl_follow_id (follow_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
+CREATE TABLE follow_requests (
+  follow_request_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  room_id           BIGINT NOT NULL,
+  requester_pid     BIGINT NOT NULL,
+  receiver_pid      BIGINT NOT NULL,
+  status            VARCHAR(10) NOT NULL CHECK (status IN ('PENDING','ACCEPTED','DECLINED')),
+  created_at        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  responded_at      TIMESTAMP NULL,
+  CONSTRAINT fk_fr_room      FOREIGN KEY (room_id)       REFERENCES rooms(room_id)      ON DELETE CASCADE,
+  CONSTRAINT fk_fr_requester FOREIGN KEY (requester_pid) REFERENCES users(user_pid)     ON DELETE CASCADE,
+  CONSTRAINT fk_fr_receiver  FOREIGN KEY (receiver_pid)  REFERENCES users(user_pid)     ON DELETE CASCADE,
+  CONSTRAINT uq_fr_room_participants UNIQUE (room_id, requester_pid, receiver_pid),
+  INDEX idx_fr_room_created (room_id, created_at),
+  INDEX idx_fr_requester_status (requester_pid, status, created_at),
+  INDEX idx_fr_receiver_status (receiver_pid, status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 /* =========================================================
  * 4) 랜덤 매칭(대기큐/핸드셰이크)
  *  - rooms를 선행 생성했으므로 FK OK

--- a/backend/src/main/java/net/datasa/project01/util/JwtUtil.java
+++ b/backend/src/main/java/net/datasa/project01/util/JwtUtil.java
@@ -15,8 +15,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.Key;
 import java.util.Date;
 
-import org.slf4j.Logger; 
-import org.slf4j.LoggerFactory; 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JWT -> 사용자가 아이디와 비밀번호로 로그인에 성공했을 때 발급하는 토큰(신분증과 비슷함)
@@ -41,15 +41,12 @@ public class JwtUtil {
 
     private Key key;
 
-    private Date serverStartTime;
-
     @PostConstruct
     public void init() {
         if (SECRET_KEY.length() < 32) {
             throw new IllegalArgumentException("JWT secret key must be at least 32 characters long");
         }
         key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
-        serverStartTime = new Date();
         logger.info("JwtUtil initialized with expiration time: {} ms", EXPIRATION_TIME);
     }
 
@@ -91,17 +88,6 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-
-            Date issuedAt = claims.getIssuedAt();
-            if (issuedAt == null) {
-                logger.warn("JWT token missing issuedAt claim");
-                return false;
-            }
-
-            if (issuedAt.before(serverStartTime)) {
-                logger.info("Rejecting JWT issued at {} because server started at {}", issuedAt, serverStartTime);
-                return false;
-            }
 
             // TODO: 추가 유효성 검사 (블랙리스트 체크 등)
             return true;


### PR DESCRIPTION
## Summary
- add the missing `follow_requests` table definition to the initialization SQL so follow APIs have the required storage
- simplify JWT validation so tokens remain valid across server restarts while keeping expiration enforcement in place

## Testing
- `./gradlew test` *(fails: dependency downloads blocked by 403 responses from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d492f84eb88325b4e0a822beedd723