### PR TITLE
Simplify match flow for real-time pairing

### DIFF
--- a/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -1,24 +1,21 @@
 package net.datasa.project01.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchDecisionResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
-import net.datasa.project01.domain.entity.MatchRequest;
-import net.datasa.project01.domain.entity.User;
-import net.datasa.project01.repository.MatchRequestRepository;
-import net.datasa.project01.repository.UserRepository;
 import net.datasa.project01.service.MatchService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/match")
@@ -27,65 +24,19 @@ import java.util.Map;
 public class MatchController {
 
     private final MatchService matchService;
-    private final MatchRequestRepository matchRequestRepository;
-    private final ObjectMapper objectMapper;
-    private final UserRepository userRepository;
 
-    /**
-     * 매칭 요청(단일 엔드포인트)
-     * - 인증 정보(@AuthenticationPrincipal)가 있으면 매칭 로직 실행
-     * - 인증 정보가 없고 X-USER-PID 헤더가 있으면 DB에 요청 레코드 저장
-     * - 둘 다 없으면 400
-     */
     @PostMapping("/requests")
-    public ResponseEntity<?> createOrStartMatch(
+    public ResponseEntity<?> startMatch(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestHeader(value = "X-USER-PID", required = false) Long userPid,
             @Valid @RequestBody MatchRequestDto dto) {
-
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body("인증 정보가 필요합니다.");
+        }
         try {
-            // 1) Spring Security 인증 기반 흐름
-            if (userDetails != null) {
-                String loginId = userDetails.getUsername();
-                log.info("Match request received from authenticated user: {}", loginId);
-
-                // 서비스 레이어에 매칭 시작/탐색 위임
-                MatchStartResponseDto response = matchService.startOrFindMatch(loginId, dto);
-                return ResponseEntity.ok(response);
-            }
-
-            // 2) 헤더 기반(비인증) 흐름: 요청 엔티티 저장 후 requestId 반환
-            if (userPid != null) {
-                User user = userRepository.findById(userPid)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
-                if (dto.getInterests() == null || dto.getInterests().isEmpty()) {
-                    throw new IllegalArgumentException("관심사는 최소 1개 이상 선택해야 합니다.");
-                }
-                MatchRequest saved = matchRequestRepository.save(
-                        MatchRequest.builder()
-                                .user(user)
-                                .choiceGender(MatchRequest.Gender.valueOf(dto.getChoiceGender()))
-                                .minAge(dto.getMinAge())
-                                .maxAge(dto.getMaxAge())
-                                .regionCode(dto.getRegionCode())
-                                .interestsJson(objectMapper.writeValueAsString(dto.getInterests()))
-                                .build()
-                );
-                return ResponseEntity.ok(Map.of("requestId", saved.getRequestId()));
-            }
-
-            // 3) 둘 다 없는 경우
-            return ResponseEntity.badRequest()
-                    .body("인증 정보가 없습니다. 로그인(@AuthenticationPrincipal) 또는 X-USER-PID 헤더 중 하나가 필요합니다.");
-
-        } catch (JsonProcessingException e) {
-            log.error("JSON processing error during match request. user={} / userPid={}",
-                    (userDetails != null ? userDetails.getUsername() : "null"), userPid, e);
-            return ResponseEntity.internalServerError().body("매칭 요청 처리 중 오류가 발생했습니다.");
+            MatchStartResponseDto response = matchService.startOrFindMatch(userDetails.getUsername(), dto);
+            return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
-            log.warn("Invalid match request. user={} / userPid={} / reason={}",
-                    (userDetails != null ? userDetails.getUsername() : "null"), userPid, e.getMessage());
+            log.warn("Invalid match request from {}: {}", userDetails.getUsername(), e.getMessage());
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
@@ -101,7 +52,8 @@ public class MatchController {
             MatchStartResponseDto response = matchService.getMatchStatus(userDetails.getUsername(), requestId);
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
-            log.warn("Match status lookup failed for user {} and request {}: {}", userDetails.getUsername(), requestId, e.getMessage());
+            log.warn("Match status lookup failed for user {} and request {}: {}",
+                    userDetails.getUsername(), requestId, e.getMessage());
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }

--- a/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -1,52 +1,22 @@
 package net.datasa.project01.repository;
 
-import jakarta.persistence.LockModeType;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
     Optional<MatchRequest> findByUserAndStatus(User user, MatchRequest.MatchStatus status);
 
-    Optional<MatchRequest> findFirstByUserAndStatusOrderByRequestedAtDesc(User user, MatchRequest.MatchStatus status);
-
     Optional<MatchRequest> findByRequestIdAndUser_LoginId(Long requestId, String loginId);
 
-    @Query("select count(mr) from MatchRequest mr where mr.status = :status and mr.user <> :user")
-    long countByStatusExcludingUser(@Param("status") MatchRequest.MatchStatus status,
-                                    @Param("user") User user);
+    Optional<MatchRequest> findFirstByStatusAndUserNotOrderByRequestedAtAsc(MatchRequest.MatchStatus status, User user);
+
+    long countByStatus(MatchRequest.MatchStatus status);
 
     List<MatchRequest> findByRoom(Room room);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select mr from MatchRequest mr where mr.room = :room order by mr.requestId asc")
-    List<MatchRequest> findAllByRoomForUpdate(@Param("room") Room room);
-
-    List<MatchRequest> findByRoom_RoomId(Long roomId);
-
-    // [수정됨] '나의 조건'에 맞는 잠재적 매칭 상대를 찾는 더 간단한 쿼리
-    @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user u " +
-            "WHERE mr.status = :status " +
-            "AND u.userPid <> :myPid " +
-            "AND (:myChoiceGender = 'A' OR u.gender = :myChoiceGender) " +
-            "AND mr.regionCode = :myRegionCode " +
-            "AND u.birthDate BETWEEN :oldestBirthDate AND :youngestBirthDate " +
-            "ORDER BY mr.requestedAt ASC")
-    List<MatchRequest> findPotentialMatches(
-            @Param("myPid") Long myPid,
-            @Param("myChoiceGender") String myChoiceGender,
-            @Param("myRegionCode") String myRegionCode,
-            @Param("oldestBirthDate") LocalDate oldestBirthDate,
-            @Param("youngestBirthDate") LocalDate youngestBirthDate,
-            @Param("status") MatchRequest.MatchStatus status
-    );
 }
 

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -1,15 +1,11 @@
 package net.datasa.project01.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchDecisionResponseDto;
 import net.datasa.project01.domain.dto.MatchEventMessage;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
@@ -19,12 +15,8 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Service
@@ -37,184 +29,86 @@ public class MatchService {
     private final UserRepository userRepository;
     private final ChatService chatService;
     private final SimpMessageSendingOperations messagingTemplate;
-    private final ObjectMapper objectMapper;
 
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    private static final Duration WAITING_TIMEOUT = Duration.ofMinutes(5);
-
-    /**
-     * 랜덤 매칭을 시작하거나 대기열에서 상대를 찾기
-     * @param loginId 요청한 사용자의 ID
-     * @param requestDto 매칭 조건
-     */
-    public MatchStartResponseDto startOrFindMatch(String loginId, MatchRequestDto requestDto) throws JsonProcessingException {
+    public MatchStartResponseDto startOrFindMatch(String loginId, MatchRequestDto requestDto) {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 1. 이미 대기열에 있는지 확인
-        LocalDateTime now = LocalDateTime.now();
-
-        Optional<MatchRequest> existingWaiting = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING);
-        if (existingWaiting.isPresent()) {
-            MatchRequest waitingRequest = existingWaiting.get();
-            if (isRequestExpired(waitingRequest, now)) {
-                cancelExpiredRequest(waitingRequest);
-            } else {
-                long waitingCount = matchRequestRepository.countByStatusExcludingUser(MatchRequest.MatchStatus.WAITING, me);
-                return MatchStartResponseDto.builder()
-                        .state(MatchStartResponseDto.MatchState.ALREADY_WAITING)
-                        .myRequestId(waitingRequest.getRequestId())
-                        .waitingCount(waitingCount)
-                        .message(waitingCount > 0 ? "다른 사용자를 찾고 있습니다." : "현재 대기 중인 사용자가 없습니다.")
-                        .shouldCreateOffer(false)
-                        .myStatus(waitingRequest.getStatus())
-                        .partnerStatus(null)
-                        .bothAccepted(false)
-                        .build();
-            }
+        MatchRequest existingWaiting = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING)
+                .orElse(null);
+        if (existingWaiting != null) {
+            log.debug("User {} is already waiting for a match", loginId);
+            return buildWaitingResponse(existingWaiting, true);
         }
 
-        // 2. 이미 매칭된 기록이 있는지 확인
-        Optional<MatchRequest> existingMatched = matchRequestRepository.findFirstByUserAndStatusOrderByRequestedAtDesc(me, MatchRequest.MatchStatus.MATCHED);
-        if (existingMatched.isPresent() && existingMatched.get().getRoom() != null) {
-            MatchRequest myMatched = existingMatched.get();
-            MatchRequest opponent = findOpponentRequest(myMatched.getRoom(), myMatched.getRequestId());
-            return MatchStartResponseDto.builder()
-                    .state(MatchStartResponseDto.MatchState.MATCHED)
-                    .myRequestId(myMatched.getRequestId())
-                    .partnerRequestId(opponent != null ? opponent.getRequestId() : null)
-                    .roomId(myMatched.getRoom().getRoomId())
-                    .partnerLoginId(opponent != null ? opponent.getUser().getLoginId() : null)
-                    .partnerNickName(opponent != null ? opponent.getUser().getNickName() : null)
-                    .message("이미 진행 중인 매칭이 있습니다.")
-                    .shouldCreateOffer(false)
-                    .myStatus(myMatched.getStatus())
-                    .partnerStatus(opponent != null ? opponent.getStatus() : null)
-                    .bothAccepted(opponent != null
-                            && myMatched.getStatus() == MatchRequest.MatchStatus.CONFIRMED
-                            && opponent.getStatus() == MatchRequest.MatchStatus.CONFIRMED)
-                    .build();
+        MatchRequest existingMatched = findActiveMatch(me);
+        if (existingMatched != null && existingMatched.getRoom() != null) {
+            MatchRequest partner = findPartner(existingMatched);
+            return buildMatchedResponse(existingMatched, partner, "이미 진행 중인 매칭이 있습니다.");
         }
 
-        MatchRequest.Gender myChoiceGender = MatchRequest.Gender.valueOf(requestDto.getChoiceGender());
-        Character myChoiceGenderChar = requestDto.getChoiceGender().charAt(0);
+        Optional<MatchRequest> opponentOptional = matchRequestRepository
+                .findFirstByStatusAndUserNotOrderByRequestedAtAsc(MatchRequest.MatchStatus.WAITING, me);
 
-        if (requestDto.getMinAge() > requestDto.getMaxAge()) {
-            throw new IllegalArgumentException("최소 나이는 최대 나이보다 클 수 없습니다.");
-        }
+        if (opponentOptional.isPresent()) {
+            MatchRequest opponent = opponentOptional.get();
+            User opponentUser = opponent.getUser();
+            Room room = chatService.createPrivateRoom(me, opponentUser);
 
-        LocalDate today = LocalDate.now();
-        LocalDate oldestBirthDate = today.minusYears(requestDto.getMaxAge());
-        LocalDate youngestBirthDate = today.minusYears(requestDto.getMinAge());
+            opponent.setStatus(MatchRequest.MatchStatus.MATCHED);
+            opponent.setRoom(room);
 
-        List<MatchRequest> potentialMatches = matchRequestRepository.findPotentialMatches(
-                me.getUserPid(),
-                requestDto.getChoiceGender(),
-                requestDto.getRegionCode(),
-                oldestBirthDate,
-                youngestBirthDate,
-                MatchRequest.MatchStatus.WAITING
-        );
-
-        List<MatchRequest> filteredPotentialMatches = new ArrayList<>();
-        for (MatchRequest potentialMatch : potentialMatches) {
-            if (isRequestExpired(potentialMatch, now)) {
-                cancelExpiredRequest(potentialMatch);
-                continue;
-            }
-            filteredPotentialMatches.add(potentialMatch);
-        }
-
-        MatchRequest matchedOpponentRequest = selectFinalOpponent(me, filteredPotentialMatches);
-
-        if (matchedOpponentRequest != null) {
-            // 4. 매칭 성공 처리
-            User opponent = matchedOpponentRequest.getUser();
-            log.info("Match found for user {}: {}", loginId, opponent.getLoginId());
-
-            matchedOpponentRequest.setStatus(MatchRequest.MatchStatus.MATCHED);
-
-            // 1:1 채팅방 생성 및 각 요청에 연결
-            Room privateRoom = chatService.createPrivateRoom(me, opponent);
-            matchedOpponentRequest.setRoom(privateRoom);
-
-            MatchRequest myMatchedRequest = matchRequestRepository.save(MatchRequest.builder()
+            MatchRequest myRequest = matchRequestRepository.save(MatchRequest.builder()
                     .user(me)
-                    .choiceGender(myChoiceGender)
+                    .choiceGender(parseChoiceGender(requestDto))
                     .minAge(requestDto.getMinAge())
                     .maxAge(requestDto.getMaxAge())
                     .regionCode(requestDto.getRegionCode())
-                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
+                    .interestsJson(toJsonArray(requestDto.getInterests()))
                     .status(MatchRequest.MatchStatus.MATCHED)
-                    .room(privateRoom)
+                    .room(room)
                     .build());
 
-            // 양쪽 사용자에게 매칭 성공 알림 전송 (웹소켓)
-            MatchEventMessage initiatorEvent = MatchEventMessage.builder()
+            MatchEventMessage myEvent = MatchEventMessage.builder()
                     .eventType(MatchEventMessage.EventType.MATCH_FOUND)
-                    .roomId(privateRoom.getRoomId())
-                    .myRequestId(myMatchedRequest.getRequestId())
-                    .partnerRequestId(matchedOpponentRequest.getRequestId())
-                    .partnerLoginId(opponent.getLoginId())
-                    .partnerNickName(opponent.getNickName())
-                    .message(String.format("%s님과 매칭되었습니다.", opponent.getNickName()))
-                    .shouldCreateOffer(true)
+                    .roomId(room.getRoomId())
+                    .myRequestId(myRequest.getRequestId())
+                    .partnerRequestId(opponent.getRequestId())
+                    .partnerLoginId(opponentUser.getLoginId())
+                    .partnerNickName(opponentUser.getNickName())
+                    .message(String.format("%s님과 매칭되었습니다.", opponentUser.getNickName()))
+                    .shouldCreateOffer(shouldCreateOffer(myRequest, opponent))
                     .build();
-            sendMatchEvent(me, initiatorEvent);
+            sendMatchEvent(me, myEvent);
 
-            MatchEventMessage opponentEvent = MatchEventMessage.builder()
+            MatchEventMessage partnerEvent = MatchEventMessage.builder()
                     .eventType(MatchEventMessage.EventType.MATCH_FOUND)
-                    .roomId(privateRoom.getRoomId())
-                    .myRequestId(matchedOpponentRequest.getRequestId())
-                    .partnerRequestId(myMatchedRequest.getRequestId())
+                    .roomId(room.getRoomId())
+                    .myRequestId(opponent.getRequestId())
+                    .partnerRequestId(myRequest.getRequestId())
                     .partnerLoginId(me.getLoginId())
                     .partnerNickName(me.getNickName())
                     .message(String.format("%s님과 매칭되었습니다.", me.getNickName()))
-                    .shouldCreateOffer(false)
+                    .shouldCreateOffer(shouldCreateOffer(opponent, myRequest))
                     .build();
-            sendMatchEvent(opponent, opponentEvent);
+            sendMatchEvent(opponentUser, partnerEvent);
 
-            return MatchStartResponseDto.builder()
-                    .state(MatchStartResponseDto.MatchState.MATCHED)
-                    .myRequestId(myMatchedRequest.getRequestId())
-                    .partnerRequestId(matchedOpponentRequest.getRequestId())
-                    .roomId(privateRoom.getRoomId())
-                    .partnerLoginId(opponent.getLoginId())
-                    .partnerNickName(opponent.getNickName())
-                    .message("매칭이 성사되었습니다.")
-                    .shouldCreateOffer(true)
-                    .myStatus(myMatchedRequest.getStatus())
-                    .partnerStatus(matchedOpponentRequest.getStatus())
-                    .bothAccepted(false)
-                    .build();
+            log.info("Match created between {} and {} in room {}", loginId, opponentUser.getLoginId(), room.getRoomId());
+            return buildMatchedResponse(myRequest, opponent, "매칭이 성사되었습니다.");
         }
 
-        // 5. 매칭 실패 -> 대기열에 등록
-        log.info("No match found for user {}. Adding to queue.", loginId);
-        MatchRequest newRequest = matchRequestRepository.save(MatchRequest.builder()
+        MatchRequest waiting = matchRequestRepository.save(MatchRequest.builder()
                 .user(me)
-                .choiceGender(myChoiceGender)
+                .choiceGender(parseChoiceGender(requestDto))
                 .minAge(requestDto.getMinAge())
                 .maxAge(requestDto.getMaxAge())
                 .regionCode(requestDto.getRegionCode())
-                .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
+                .interestsJson(toJsonArray(requestDto.getInterests()))
                 .status(MatchRequest.MatchStatus.WAITING)
                 .build());
 
-        long waitingCount = matchRequestRepository.countByStatusExcludingUser(MatchRequest.MatchStatus.WAITING, me);
-
-        return MatchStartResponseDto.builder()
-                .state(MatchStartResponseDto.MatchState.WAITING)
-                .myRequestId(newRequest.getRequestId())
-                .waitingCount(waitingCount)
-                .message(waitingCount > 0 ? "다른 사용자를 찾고 있습니다." : "현재 대기 중인 사용자가 없습니다.")
-                .shouldCreateOffer(false)
-                .myStatus(newRequest.getStatus())
-                .partnerStatus(null)
-                .bothAccepted(false)
-                .build();
+        log.info("User {} entered the waiting queue", loginId);
+        return buildWaitingResponse(waiting, false);
     }
 
     @Transactional(readOnly = true)
@@ -222,266 +116,244 @@ public class MatchService {
         MatchRequest myRequest = matchRequestRepository.findByRequestIdAndUser_LoginId(requestId, loginId)
                 .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
 
-        MatchRequest.MatchStatus status = myRequest.getStatus();
+        if (myRequest.getStatus() == MatchRequest.MatchStatus.WAITING) {
+            return buildWaitingResponse(myRequest, true);
+        }
 
-        if (status == MatchRequest.MatchStatus.WAITING) {
-            long waitingCount = matchRequestRepository.countByStatusExcludingUser(MatchRequest.MatchStatus.WAITING, myRequest.getUser());
-            String message = waitingCount > 0 ? "다른 사용자를 찾고 있습니다." : "현재 대기 중인 사용자가 없습니다.";
+        MatchRequest partner = findPartner(myRequest);
+        return buildMatchedResponse(myRequest, partner, "매칭이 성사되었습니다.");
+    }
 
-            return MatchStartResponseDto.builder()
-                    .state(MatchStartResponseDto.MatchState.WAITING)
+    public MatchDecisionResponseDto respondToMatch(String loginId, Long requestId, boolean accept) {
+        MatchRequest myRequest = matchRequestRepository.findByRequestIdAndUser_LoginId(requestId, loginId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        if (myRequest.getRoom() == null) {
+            throw new IllegalStateException("매칭 세션 정보가 없습니다.");
+        }
+
+        if (myRequest.getStatus() != MatchRequest.MatchStatus.MATCHED
+                && myRequest.getStatus() != MatchRequest.MatchStatus.CONFIRMED) {
+            throw new IllegalStateException("현재 상태에서는 응답할 수 없습니다.");
+        }
+
+        MatchRequest partner = findPartner(myRequest);
+        boolean partnerConfirmed = partner != null && partner.getStatus() == MatchRequest.MatchStatus.CONFIRMED;
+        Long roomId = myRequest.getRoom().getRoomId();
+
+        if (accept) {
+            myRequest.setStatus(MatchRequest.MatchStatus.CONFIRMED);
+            if (partner != null) {
+                if (partnerConfirmed) {
+                    notifyBothConfirmed(myRequest, partner);
+                } else {
+                    sendMatchEvent(partner.getUser(), MatchEventMessage.builder()
+                            .eventType(MatchEventMessage.EventType.PARTNER_ACCEPTED)
+                            .roomId(myRequest.getRoom().getRoomId())
+                            .myRequestId(partner.getRequestId())
+                            .partnerRequestId(myRequest.getRequestId())
+                            .partnerLoginId(loginId)
+                            .partnerNickName(myRequest.getUser().getNickName())
+                            .message(String.format("%s님이 매칭을 수락했습니다.", myRequest.getUser().getNickName()))
+                            .shouldCreateOffer(false)
+                            .build());
+                }
+            }
+
+            String message = partnerConfirmed
+                    ? "상대도 이미 수락했습니다. 지금 바로 대화를 시작하세요."
+                    : "매칭을 수락했습니다. 상대의 응답을 기다리는 중입니다.";
+
+            return MatchDecisionResponseDto.builder()
+                    .decision(MatchDecisionResponseDto.Decision.ACCEPTED)
+                    .roomId(roomId)
                     .myRequestId(myRequest.getRequestId())
-                    .waitingCount(waitingCount)
+                    .partnerRequestId(partner != null ? partner.getRequestId() : null)
+                    .myStatus(myRequest.getStatus())
+                    .partnerStatus(partner != null ? partner.getStatus() : null)
+                    .bothAccepted(partnerConfirmed)
                     .message(message)
+                    .build();
+        }
+
+        myRequest.setStatus(MatchRequest.MatchStatus.DECLINED);
+        myRequest.setRoom(null);
+
+        if (partner != null) {
+            Long partnerRoomId = roomId;
+            partner.setStatus(MatchRequest.MatchStatus.CANCELLED);
+            partner.setRoom(null);
+            sendMatchEvent(partner.getUser(), MatchEventMessage.builder()
+                    .eventType(MatchEventMessage.EventType.PARTNER_DECLINED)
+                    .roomId(partnerRoomId)
+                    .myRequestId(partner.getRequestId())
+                    .partnerRequestId(myRequest.getRequestId())
+                    .partnerLoginId(loginId)
+                    .partnerNickName(myRequest.getUser().getNickName())
+                    .message(String.format("%s님이 매칭을 거절했습니다.", myRequest.getUser().getNickName()))
                     .shouldCreateOffer(false)
-                    .myStatus(myRequest.getStatus())
-                    .partnerStatus(null)
-                    .bothAccepted(false)
-                    .build();
+                    .build());
         }
 
-        if (status == MatchRequest.MatchStatus.MATCHED || status == MatchRequest.MatchStatus.CONFIRMED) {
-            MatchRequest opponent = findOpponentRequest(myRequest.getRoom(), myRequest.getRequestId());
-
-            boolean shouldCreateOffer = shouldCreateOffer(myRequest, opponent);
-            MatchRequest.MatchStatus partnerStatus = opponent != null ? opponent.getStatus() : null;
-            boolean bothAccepted = status == MatchRequest.MatchStatus.CONFIRMED
-                    && partnerStatus == MatchRequest.MatchStatus.CONFIRMED;
-
-            return MatchStartResponseDto.builder()
-                    .state(MatchStartResponseDto.MatchState.MATCHED)
-                    .myRequestId(myRequest.getRequestId())
-                    .partnerRequestId(opponent != null ? opponent.getRequestId() : null)
-                    .roomId(myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null)
-                    .partnerLoginId(opponent != null ? opponent.getUser().getLoginId() : null)
-                    .partnerNickName(opponent != null ? opponent.getUser().getNickName() : null)
-                    .message("매칭이 성사되었습니다.")
-                    .shouldCreateOffer(shouldCreateOffer)
-                    .myStatus(myRequest.getStatus())
-                    .partnerStatus(partnerStatus)
-                    .bothAccepted(bothAccepted)
-                    .build();
-        }
-
-        String message = switch (status) {
-            case DECLINED, CANCELLED -> "매칭이 종료되었습니다.";
-            default -> "현재 매칭 상태를 확인할 수 없습니다.";
-        };
-
-        return MatchStartResponseDto.builder()
-                .state(MatchStartResponseDto.MatchState.WAITING)
+        return MatchDecisionResponseDto.builder()
+                .decision(MatchDecisionResponseDto.Decision.DECLINED)
+                .roomId(roomId)
                 .myRequestId(myRequest.getRequestId())
+                .partnerRequestId(partner != null ? partner.getRequestId() : null)
+                .myStatus(myRequest.getStatus())
+                .partnerStatus(partner != null ? partner.getStatus() : null)
+                .bothAccepted(false)
+                .message("매칭을 거절했습니다.")
+                .build();
+    }
+
+    private MatchRequest findActiveMatch(User user) {
+        MatchRequest matched = matchRequestRepository.findByUserAndStatus(user, MatchRequest.MatchStatus.MATCHED)
+                .orElse(null);
+        if (matched != null) {
+            return matched;
+        }
+        return matchRequestRepository.findByUserAndStatus(user, MatchRequest.MatchStatus.CONFIRMED)
+                .orElse(null);
+    }
+
+    private MatchRequest findPartner(MatchRequest myRequest) {
+        if (myRequest.getRoom() == null) {
+            return null;
+        }
+        List<MatchRequest> participants = matchRequestRepository.findByRoom(myRequest.getRoom());
+        return participants.stream()
+                .filter(request -> !request.getRequestId().equals(myRequest.getRequestId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private MatchStartResponseDto buildWaitingResponse(MatchRequest request, boolean alreadyWaiting) {
+        long totalWaiting = matchRequestRepository.countByStatus(MatchRequest.MatchStatus.WAITING);
+        if (totalWaiting > 0) {
+            totalWaiting = Math.max(0, totalWaiting - 1);
+        }
+        String message = totalWaiting > 0 ? "다른 사용자를 찾고 있습니다." : "현재 대기 중인 사용자가 없습니다.";
+        return MatchStartResponseDto.builder()
+                .state(alreadyWaiting ? MatchStartResponseDto.MatchState.ALREADY_WAITING : MatchStartResponseDto.MatchState.WAITING)
+                .myRequestId(request.getRequestId())
+                .waitingCount(totalWaiting)
                 .message(message)
                 .shouldCreateOffer(false)
-                .myStatus(myRequest.getStatus())
+                .myStatus(request.getStatus())
                 .partnerStatus(null)
                 .bothAccepted(false)
                 .build();
     }
 
-    public MatchDecisionResponseDto respondToMatch(String loginId, Long requestId, boolean accept) {
-        MatchRequest snapshot = matchRequestRepository.findByRequestIdAndUser_LoginId(requestId, loginId)
-                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+    private MatchStartResponseDto buildMatchedResponse(MatchRequest myRequest, MatchRequest partner, String message) {
+        boolean bothAccepted = partner != null
+                && myRequest.getStatus() == MatchRequest.MatchStatus.CONFIRMED
+                && partner.getStatus() == MatchRequest.MatchStatus.CONFIRMED;
 
-        Room room = snapshot.getRoom();
-        if (room == null) {
-            throw new IllegalStateException("매칭 세션 정보가 없습니다.");
-        }
-
-        List<MatchRequest> roomParticipants = matchRequestRepository.findAllByRoomForUpdate(room);
-
-        MatchRequest myRequest = roomParticipants.stream()
-                .filter(request -> request.getRequestId().equals(requestId))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
-
-        if (!myRequest.getUser().getLoginId().equals(loginId)) {
-            throw new IllegalArgumentException("해당 매칭 요청에 대한 권한이 없습니다.");
-        }
-
-        if (myRequest.getStatus() != MatchRequest.MatchStatus.MATCHED && myRequest.getStatus() != MatchRequest.MatchStatus.CONFIRMED) {
-            throw new IllegalStateException("현재 상태에서는 응답할 수 없습니다.");
-        }
-
-        MatchRequest opponentRequest = roomParticipants.stream()
-                .filter(request -> !request.getRequestId().equals(requestId))
-                .findFirst()
-                .orElse(null);
-
-        if (accept) {
-            myRequest.setStatus(MatchRequest.MatchStatus.CONFIRMED);
-            entityManager.flush();
-            if (opponentRequest != null) {
-                entityManager.refresh(opponentRequest);
-            }
-        } else {
-            myRequest.setStatus(MatchRequest.MatchStatus.DECLINED);
-            if (opponentRequest != null) {
-                opponentRequest.setStatus(MatchRequest.MatchStatus.CANCELLED);
-                opponentRequest.setRoom(null);
-            }
-            myRequest.setRoom(null);
-        }
-
-        MatchRequest.MatchStatus partnerStatus = opponentRequest != null ? opponentRequest.getStatus() : null;
-        boolean partnerAlreadyAccepted = partnerStatus == MatchRequest.MatchStatus.CONFIRMED;
-        boolean partnerDeclined = partnerStatus == MatchRequest.MatchStatus.DECLINED || partnerStatus == MatchRequest.MatchStatus.CANCELLED;
-        boolean bothAccepted = accept && partnerAlreadyAccepted;
-
-        boolean shouldCreateOfferForMe = shouldCreateOffer(myRequest, opponentRequest);
-        boolean shouldCreateOfferForOpponent = shouldCreateOffer(opponentRequest, myRequest);
-
-        if (opponentRequest != null && (!bothAccepted || !accept)) {
-            MatchEventMessage.EventType eventType = accept
-                    ? MatchEventMessage.EventType.PARTNER_ACCEPTED
-                    : MatchEventMessage.EventType.PARTNER_DECLINED;
-
-            String notice = accept
-                    ? String.format("%s님이 매칭을 수락했습니다.", myRequest.getUser().getNickName())
-                    : String.format("%s님이 매칭을 거절했습니다.", myRequest.getUser().getNickName());
-
-            MatchEventMessage event = MatchEventMessage.builder()
-                    .eventType(eventType)
-                    .roomId(room.getRoomId())
-                    .myRequestId(opponentRequest.getRequestId())
-                    .partnerRequestId(myRequest.getRequestId())
-                    .partnerLoginId(myRequest.getUser().getLoginId())
-                    .partnerNickName(myRequest.getUser().getNickName())
-                    .message(notice)
-                    .shouldCreateOffer(false)
-                    .build();
-            sendMatchEvent(opponentRequest.getUser(), event);
-        }
-
-        if (bothAccepted && opponentRequest != null) {
-            MatchEventMessage bothForMe = MatchEventMessage.builder()
-                    .eventType(MatchEventMessage.EventType.BOTH_CONFIRMED)
-                    .roomId(room.getRoomId())
-                    .myRequestId(myRequest.getRequestId())
-                    .partnerRequestId(opponentRequest.getRequestId())
-                    .partnerLoginId(opponentRequest.getUser().getLoginId())
-                    .partnerNickName(opponentRequest.getUser().getNickName())
-                    .message("서로 매칭을 수락했습니다. 대화를 시작하세요!")
-                    .shouldCreateOffer(shouldCreateOfferForMe)
-                    .build();
-            sendMatchEvent(myRequest.getUser(), bothForMe);
-
-            MatchEventMessage bothForOpponent = MatchEventMessage.builder()
-                    .eventType(MatchEventMessage.EventType.BOTH_CONFIRMED)
-                    .roomId(room.getRoomId())
-                    .myRequestId(opponentRequest.getRequestId())
-                    .partnerRequestId(myRequest.getRequestId())
-                    .partnerLoginId(myRequest.getUser().getLoginId())
-                    .partnerNickName(myRequest.getUser().getNickName())
-                    .message("서로 매칭을 수락했습니다. 대화를 시작하세요!")
-                    .shouldCreateOffer(shouldCreateOfferForOpponent)
-                    .build();
-            sendMatchEvent(opponentRequest.getUser(), bothForOpponent);
-        }
-
-        String responseMessage;
-        if (accept) {
-            if (partnerDeclined) {
-                responseMessage = "상대가 이미 매칭을 종료했습니다.";
-            } else if (bothAccepted) {
-                responseMessage = "상대도 이미 수락했습니다. 지금 바로 대화를 시작하세요.";
-            } else {
-                responseMessage = "매칭을 수락했습니다. 상대의 응답을 기다리는 중입니다.";
-            }
-        } else {
-            responseMessage = "매칭을 거절했습니다.";
-        }
-
-        return MatchDecisionResponseDto.builder()
-                .decision(accept ? MatchDecisionResponseDto.Decision.ACCEPTED : MatchDecisionResponseDto.Decision.DECLINED)
-                .roomId(room.getRoomId())
+        return MatchStartResponseDto.builder()
+                .state(MatchStartResponseDto.MatchState.MATCHED)
                 .myRequestId(myRequest.getRequestId())
-                .partnerRequestId(opponentRequest != null ? opponentRequest.getRequestId() : null)
+                .partnerRequestId(partner != null ? partner.getRequestId() : null)
+                .roomId(myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null)
+                .partnerLoginId(partner != null ? partner.getUser().getLoginId() : null)
+                .partnerNickName(partner != null ? partner.getUser().getNickName() : null)
+                .waitingCount(0)
+                .message(message)
+                .shouldCreateOffer(shouldCreateOffer(myRequest, partner))
                 .myStatus(myRequest.getStatus())
-                .partnerStatus(partnerStatus)
+                .partnerStatus(partner != null ? partner.getStatus() : null)
                 .bothAccepted(bothAccepted)
-                .message(responseMessage)
                 .build();
     }
 
-    private MatchRequest selectFinalOpponent(User me, List<MatchRequest> potentialMatches) {
-        long myAge = ChronoUnit.YEARS.between(me.getBirthDate(), LocalDate.now());
-        for (MatchRequest opponentRequest : potentialMatches) {
-
-            boolean isGenderMatch = opponentRequest.getChoiceGender() == MatchRequest.Gender.A ||
-                    opponentRequest.getChoiceGender().name().equals(me.getGender().toString());
-
-            boolean isAgeMatch = myAge >= opponentRequest.getMinAge() && myAge <= opponentRequest.getMaxAge();
-
-            if (isGenderMatch && isAgeMatch) {
-                return opponentRequest;
-            }
-        }
-        return null;
-    }
-
-    private MatchRequest findOpponentRequest(Room room, Long myRequestId) {
+    private void notifyBothConfirmed(MatchRequest requestA, MatchRequest requestB) {
+        Room room = requestA.getRoom();
         if (room == null) {
-            return null;
-        }
-        return matchRequestRepository.findByRoom(room).stream()
-                .filter(req -> !req.getRequestId().equals(myRequestId))
-                .findFirst()
-                .orElse(null);
-    }
-
-    private boolean shouldCreateOffer(MatchRequest current, MatchRequest opponent) {
-        if (current == null) {
-            return false;
-        }
-        if (opponent == null) {
-            return true;
+            return;
         }
 
-        LocalDateTime currentRequestedAt = current.getRequestedAt();
-        LocalDateTime opponentRequestedAt = opponent.getRequestedAt();
+        MatchEventMessage first = MatchEventMessage.builder()
+                .eventType(MatchEventMessage.EventType.BOTH_CONFIRMED)
+                .roomId(room.getRoomId())
+                .myRequestId(requestA.getRequestId())
+                .partnerRequestId(requestB.getRequestId())
+                .partnerLoginId(requestB.getUser().getLoginId())
+                .partnerNickName(requestB.getUser().getNickName())
+                .message("서로 매칭을 수락했습니다. 대화를 시작하세요!")
+                .shouldCreateOffer(shouldCreateOffer(requestA, requestB))
+                .build();
+        sendMatchEvent(requestA.getUser(), first);
 
-        if (currentRequestedAt != null && opponentRequestedAt != null) {
-            if (currentRequestedAt.isAfter(opponentRequestedAt)) {
-                return true;
-            }
-            if (currentRequestedAt.isBefore(opponentRequestedAt)) {
-                return false;
-            }
-        }
-
-        Long currentId = current.getRequestId();
-        Long opponentId = opponent.getRequestId();
-        if (currentId != null && opponentId != null) {
-            return currentId > opponentId;
-        }
-
-        return false;
+        MatchEventMessage second = MatchEventMessage.builder()
+                .eventType(MatchEventMessage.EventType.BOTH_CONFIRMED)
+                .roomId(room.getRoomId())
+                .myRequestId(requestB.getRequestId())
+                .partnerRequestId(requestA.getRequestId())
+                .partnerLoginId(requestA.getUser().getLoginId())
+                .partnerNickName(requestA.getUser().getNickName())
+                .message("서로 매칭을 수락했습니다. 대화를 시작하세요!")
+                .shouldCreateOffer(shouldCreateOffer(requestB, requestA))
+                .build();
+        sendMatchEvent(requestB.getUser(), second);
     }
 
     private void sendMatchEvent(User target, MatchEventMessage message) {
-        if (target == null) {
+        if (target == null || message == null) {
             return;
         }
         messagingTemplate.convertAndSendToUser(target.getLoginId(), "/queue/match-results", message);
     }
 
-    private boolean isRequestExpired(MatchRequest request, LocalDateTime referenceTime) {
-        if (request == null || request.getRequestedAt() == null) {
-            return false;
+    private MatchRequest.Gender parseChoiceGender(MatchRequestDto dto) {
+        if (dto == null || dto.getChoiceGender() == null) {
+            return MatchRequest.Gender.A;
         }
-        LocalDateTime expiryThreshold = referenceTime.minus(WAITING_TIMEOUT);
-        return request.getRequestedAt().isBefore(expiryThreshold);
+        return MatchRequest.Gender.valueOf(dto.getChoiceGender().toUpperCase(Locale.ROOT));
     }
 
-    private void cancelExpiredRequest(MatchRequest request) {
-        if (request == null) {
-            return;
+    private boolean shouldCreateOffer(MatchRequest me, MatchRequest partner) {
+        if (me == null || partner == null) {
+            return false;
         }
-        if (request.getStatus() == MatchRequest.MatchStatus.WAITING) {
-            log.debug("Cancelling expired waiting request: {}", request.getRequestId());
-            request.setStatus(MatchRequest.MatchStatus.CANCELLED);
-            request.setRoom(null);
+        Long myId = me.getRequestId();
+        Long partnerId = partner.getRequestId();
+        if (myId == null || partnerId == null) {
+            return false;
         }
+        return myId > partnerId;
+    }
+
+    private String toJsonArray(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return "[]";
+        }
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append('"').append(escapeJson(values.get(i))).append('"');
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (char c : value.toCharArray()) {
+            switch (c) {
+                case '\\' -> builder.append("\\\\");
+                case '\"' -> builder.append("\\\"");
+                case '\n' -> builder.append("\\n");
+                case '\r' -> builder.append("\\r");
+                case '\t' -> builder.append("\\t");
+                default -> builder.append(c);
+            }
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
## Summary
- streamline the match REST controller to rely solely on authenticated users and the simplified service
- trim the match repository to the minimal queries used by the lighter matchmaking flow
- rebuild the matchmaking service around a straightforward queue, room creation, and websocket notifications for accept/decline/both-confirmed events

## Testing
- `./gradlew test` *(fails: unable to download dependencies from Maven Central, received HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d9ea84508325a389540fce0ef6a6