### PR TITLE
Handle duplicate waiting requests without NonUniqueResultException

### DIFF
--- a/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
-    Optional<MatchRequest> findByUserAndStatus(User user, MatchRequest.MatchStatus status);
+    Optional<MatchRequest> findFirstByUserAndStatusOrderByRequestedAtDesc(User user, MatchRequest.MatchStatus status);
 
     Optional<MatchRequest> findByRequestIdAndUser_LoginId(Long requestId, String loginId);
 

--- a/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -34,7 +34,8 @@ public class MatchService {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        MatchRequest existingWaiting = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING)
+        MatchRequest existingWaiting = matchRequestRepository
+                .findFirstByUserAndStatusOrderByRequestedAtDesc(me, MatchRequest.MatchStatus.WAITING)
                 .orElse(null);
         if (existingWaiting != null) {
             log.debug("User {} is already waiting for a match", loginId);
@@ -208,12 +209,14 @@ public class MatchService {
     }
 
     private MatchRequest findActiveMatch(User user) {
-        MatchRequest matched = matchRequestRepository.findByUserAndStatus(user, MatchRequest.MatchStatus.MATCHED)
+        MatchRequest matched = matchRequestRepository
+                .findFirstByUserAndStatusOrderByRequestedAtDesc(user, MatchRequest.MatchStatus.MATCHED)
                 .orElse(null);
         if (matched != null) {
             return matched;
         }
-        return matchRequestRepository.findByUserAndStatus(user, MatchRequest.MatchStatus.CONFIRMED)
+        return matchRequestRepository
+                .findFirstByUserAndStatusOrderByRequestedAtDesc(user, MatchRequest.MatchStatus.CONFIRMED)
                 .orElse(null);
     }
 

--- a/backend/src/test/java/net/datasa/project01/service/MatchServiceDuplicateWaitingTest.java
+++ b/backend/src/test/java/net/datasa/project01/service/MatchServiceDuplicateWaitingTest.java
@@ -1,0 +1,96 @@
+package net.datasa.project01.service;
+
+import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
+import net.datasa.project01.domain.entity.MatchRequest;
+import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.MatchRequestRepository;
+import net.datasa.project01.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MatchServiceDuplicateWaitingTest {
+
+    @Autowired
+    private MatchService matchService;
+
+    @Autowired
+    private MatchRequestRepository matchRequestRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private ChatService chatService;
+
+    @MockBean
+    private SimpMessageSendingOperations messagingTemplate;
+
+    @BeforeEach
+    void cleanUp() {
+        matchRequestRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void whenMultipleWaitingRequestsExist_userIsReportedAsAlreadyWaiting() {
+        User user = userRepository.save(User.builder()
+                .loginId("duplicate-user")
+                .passwordHash("password")
+                .nickName("duplicate-user")
+                .email("duplicate@example.com")
+                .countryCode("KR")
+                .languageCode("ko")
+                .gender('M')
+                .birthDate(LocalDate.of(1995, 1, 1))
+                .build());
+
+        MatchRequest first = matchRequestRepository.saveAndFlush(MatchRequest.builder()
+                .user(user)
+                .choiceGender(MatchRequest.Gender.A)
+                .minAge(20)
+                .maxAge(30)
+                .regionCode("11")
+                .interestsJson("[]")
+                .status(MatchRequest.MatchStatus.WAITING)
+                .build());
+
+        MatchRequest second = matchRequestRepository.saveAndFlush(MatchRequest.builder()
+                .user(user)
+                .choiceGender(MatchRequest.Gender.A)
+                .minAge(20)
+                .maxAge(30)
+                .regionCode("11")
+                .interestsJson("[]")
+                .status(MatchRequest.MatchStatus.WAITING)
+                .build());
+
+        MatchRequestDto requestDto = new MatchRequestDto();
+        requestDto.setChoiceGender("A");
+        requestDto.setMinAge(20);
+        requestDto.setMaxAge(30);
+        requestDto.setRegionCode("11");
+        requestDto.setInterests(List.of("music"));
+
+        MatchStartResponseDto response = matchService.startOrFindMatch(user.getLoginId(), requestDto);
+
+        assertThat(response.getState()).isEqualTo(MatchStartResponseDto.MatchState.ALREADY_WAITING);
+        assertThat(response.getMyRequestId()).isEqualTo(second.getRequestId());
+        assertThat(matchRequestRepository.countByStatus(MatchRequest.MatchStatus.WAITING)).isEqualTo(2);
+        assertThat(matchRequestRepository.findFirstByUserAndStatusOrderByRequestedAtDesc(user, MatchRequest.MatchStatus.WAITING))
+                .contains(second);
+        assertThat(first.getRequestId()).isNotEqualTo(second.getRequestId());
+    }
+}


### PR DESCRIPTION
## Summary
- Update MatchRequestRepository to expose only the single-result finder that orders by requestedAt descending
- Use the new repository method throughout MatchService to avoid NonUniqueResultException when duplicate rows exist
- Add an integration test ensuring duplicate WAITING requests still produce the already-waiting response

## Testing
- `./gradlew test` *(fails: unable to download dependencies from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dfa791248325b8b10779c7545349