### PR TITLE
Improve STOMP security, signaling, and WebRTC stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Matcha Talk Development Notes
+
+## Local HTTPS Setup with mkcert
+
+The frontend uses WebRTC and secure cookies, so running the dev stack over HTTPS avoids most browser permission prompts.
+
+1. [Install mkcert](https://github.com/FiloSottile/mkcert) for your platform.
+2. Trust the local certificate authority:
+   ```bash
+   mkcert -install
+   ```
+3. Create a certificate for your dev hostname (adjust as needed):
+   ```bash
+   mkcert localhost 127.0.0.1 ::1
+   ```
+   This produces `localhost+2.pem` and `localhost+2-key.pem`. Move them to a safe place inside the repo (e.g. `certs/`).
+4. Reference the certificates from Vite by updating `frontend/vite.config.ts` (or `.js`):
+   ```ts
+   import fs from 'node:fs'
+   import { defineConfig } from 'vite'
+
+   export default defineConfig({
+     server: {
+       https: {
+         cert: fs.readFileSync('certs/localhost+2.pem'),
+         key: fs.readFileSync('certs/localhost+2-key.pem'),
+       },
+       host: '0.0.0.0',
+       port: 5173,
+     },
+   })
+   ```
+5. Restart the Vite dev server. Visit `https://localhost:5173/` and accept the certificate once in each browser profile.
+
+## Backend WebSocket Origins
+
+The WebSocket endpoint `/ws-stomp` reads allowed origins from `app.ws.allowed-origins`. Define it via environment variable for development:
+
+```properties
+# backend/src/main/resources/application.properties
+app.ws.allowed-origins=${APP_WS_ALLOWED_ORIGINS:}
+```
+
+Set it before starting Spring Boot:
+
+```bash
+export APP_WS_ALLOWED_ORIGINS="https://localhost:5173,https://192.168.0.100:5173"
+./gradlew bootRun
+```
+
+If the variable is empty the server permits the standard localhost patterns.
+
+## HTTPS/Vite/Spring Checklist
+
+- [ ] mkcert certificates installed and referenced by Vite.
+- [ ] Vite dev server runs with `https://` URL that matches `APP_WS_ALLOWED_ORIGINS`.
+- [ ] `.env` (frontend) points `VITE_API_BASE_URL` to the backend origin (`https://localhost:8080/api` for example).
+- [ ] Backend runs with TLS termination handled externally (nginx, dev proxy) or stays on HTTP if you forward via HTTPS proxy.
+- [ ] STOMP clients reconnect automatically when tokens refresh; monitor the browser console for `[stomp]` logs in dev mode.
+
+## TURN/STUN Notes
+
+The TURN client logs the chosen ICE servers in development with credentials redacted. Configure `VITE_TURN_URLS`, `VITE_TURN_CREDENTIAL`, or a credentials endpoint (`VITE_TURN_CREDENTIALS_URL`) if you have a TURN service. When the API call fails the app falls back to `stun:stun.l.google.com:19302`.
+
+## Error Handling Visibility
+
+The backend now emits structured errors on `/user/queue/errors` when signaling fails. The frontend surfaces these as status messages and console warnings so you can diagnose invalid routing or authentication problems quickly.

--- a/backend/src/main/java/net/datasa/project01/config/StompHandler.java
+++ b/backend/src/main/java/net/datasa/project01/config/StompHandler.java
@@ -9,11 +9,16 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -41,48 +46,78 @@ public class StompHandler implements ChannelInterceptor {
     private void authenticateWebSocketConnection(StompHeaderAccessor accessor) {
         String authHeader = resolveAuthorizationHeader(accessor);
 
-        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
-            Object nativeHeaders = accessor.getMessageHeaders().get(NativeMessageHeaderAccessor.NATIVE_HEADERS);
-            log.warn("No valid authorization header found for WebSocket connection. headers={}, raw={}", nativeHeaders, authHeader);
-            throw new IllegalArgumentException("Authorization header가 누락된 WebSocket 연결입니다.");
+        if (!StringUtils.hasText(authHeader)) {
+            log.warn("STOMP CONNECT rejected: missing Authorization header. sessionId={}", accessor.getSessionId());
+            throw new AccessDeniedException("Authorization header가 누락된 WebSocket 연결입니다.");
         }
 
-        String token = authHeader.substring(BEARER_PREFIX.length());
+        if (!authHeader.startsWith(BEARER_PREFIX)) {
+            log.warn("STOMP CONNECT rejected: Authorization header is not Bearer. sessionId={}, header={}",
+                    accessor.getSessionId(), authHeader);
+            throw new AccessDeniedException("Bearer 타입의 Authorization 헤더만 허용됩니다.");
+        }
+
+        String token = authHeader.substring(BEARER_PREFIX.length()).trim();
+        if (!StringUtils.hasText(token)) {
+            log.warn("STOMP CONNECT rejected: empty token after Bearer prefix. sessionId={}", accessor.getSessionId());
+            throw new AccessDeniedException("JWT 토큰이 비어 있습니다.");
+        }
 
         try {
             if (!jwtUtil.validateToken(token)) {
-                log.warn("Invalid JWT token for WebSocket connection");
-                throw new IllegalArgumentException("유효하지 않은 JWT 토큰입니다.");
+                log.warn("STOMP CONNECT rejected: invalid JWT token. sessionId={}", accessor.getSessionId());
+                throw new AccessDeniedException("유효하지 않은 JWT 토큰입니다.");
             }
 
             String loginId = jwtUtil.getUsernameFromToken(token);
             UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
 
             UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.getAuthorities());
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
             accessor.setUser(authentication);
 
-            log.info("WebSocket authentication successful for user: {}", loginId);
+            log.debug("STOMP CONNECT authenticated. user={}, sessionId={}", loginId, accessor.getSessionId());
+        } catch (AccessDeniedException ex) {
+            SecurityContextHolder.clearContext();
+            throw ex;
         } catch (Exception e) {
-            log.error("Error during WebSocket authentication", e);
-            if (e instanceof IllegalArgumentException illegalArgumentException) {
-                throw illegalArgumentException;
-            }
-            throw new IllegalArgumentException("WebSocket 인증에 실패했습니다.", e);
+            SecurityContextHolder.clearContext();
+            log.warn("STOMP CONNECT rejected: authentication failure. sessionId={}, cause={}",
+                    accessor.getSessionId(), e.getMessage(), e);
+            throw new AccessDeniedException("WebSocket 인증에 실패했습니다.", e);
         }
     }
 
     private String resolveAuthorizationHeader(StompHeaderAccessor accessor) {
         String header = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
-        if (header == null) {
-            header = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER.toLowerCase());
+        if (StringUtils.hasText(header)) {
+            return header;
         }
-        if (header == null) {
-            header = accessor.getFirstNativeHeader("AUTHORIZATION");
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> nativeHeaders = (Map<String, List<String>>) accessor.getHeader(
+                NativeMessageHeaderAccessor.NATIVE_HEADERS);
+
+        if (nativeHeaders == null || nativeHeaders.isEmpty()) {
+            return null;
         }
-        return header;
+
+        for (Map.Entry<String, List<String>> entry : nativeHeaders.entrySet()) {
+            if (entry.getKey() == null) {
+                continue;
+            }
+            if (AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey())) {
+                List<String> values = entry.getValue();
+                if (values == null || values.isEmpty()) {
+                    continue;
+                }
+                return values.get(0);
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
@@ -1,15 +1,20 @@
 package net.datasa.project01.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.StringUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -17,7 +22,15 @@ import jakarta.annotation.PostConstruct;
 @Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = List.of(
+            "http://localhost:*",
+            "https://localhost:*",
+            "http://127.0.0.1:*",
+            "https://127.0.0.1:*"
+    );
+
     private final StompHandler stompHandler;
+    private final Environment environment;
 
     @PostConstruct
     public void init() {
@@ -26,32 +39,41 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        List<String> allowedOrigins = resolveAllowedOrigins();
+        String[] originPatterns = allowedOrigins.isEmpty()
+                ? DEFAULT_ALLOWED_ORIGINS.toArray(String[]::new)
+                : allowedOrigins.toArray(String[]::new);
+
         registry.addEndpoint("/ws-stomp")
-                //.setAllowedOriginPatterns("http://localhost:5173","https://*.ngrok-free.app") // 개발용
-                .setAllowedOriginPatterns(
-                        "http://localhost:*",
-                        "https://localhost:*",
-                        "http://127.0.0.1:*",
-                        "https://127.0.0.1:*",
-                        "http://192.168.*.*:*",
-                        "https://192.168.*.*:*",
-                        "http://[::1]:*",
-                        "https://[::1]:*",
-                        "https://*.ngrok-free.app"
-                ) // 개발용
-                .withSockJS();  // ★ SockJS 필수
+                .setAllowedOriginPatterns(originPatterns)
+                .withSockJS()
+                .setClientLibraryUrl("https://cdn.jsdelivr.net/sockjs/1.5.1/sockjs.min.js");
+
+        log.debug("Registered /ws-stomp endpoint with origins: {}", Arrays.toString(originPatterns));
     }
 
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setApplicationDestinationPrefixes("/app");
-        registry.enableSimpleBroker("/topic", "/queue");
+        registry.enableSimpleBroker("/topic", "/queue")
+                .setHeartbeatValue(new long[]{25_000L, 25_000L});
     }
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         log.debug("Configuring client inbound channel with StompHandler interceptor");
         registration.interceptors(stompHandler);
+    }
+
+    private List<String> resolveAllowedOrigins() {
+        String raw = environment.getProperty("app.ws.allowed-origins", "");
+        if (!StringUtils.hasText(raw)) {
+            return List.of();
+        }
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/net/datasa/project01/config/WebSocketSecurityConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebSocketSecurityConfig.java
@@ -1,31 +1,68 @@
 package net.datasa.project01.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
 import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+
+import java.util.Objects;
 
 @Configuration
 @EnableWebSocketSecurity
 public class WebSocketSecurityConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(WebSocketSecurityConfig.class);
+
     @Bean
     public AuthorizationManager<Message<?>> messageAuthorizationManager(
             MessageMatcherDelegatingAuthorizationManager.Builder messages) {
         messages
-            .simpTypeMatchers(
-                SimpMessageType.CONNECT,
-                SimpMessageType.HEARTBEAT,
-                SimpMessageType.UNSUBSCRIBE,
-                SimpMessageType.DISCONNECT
-            ).permitAll()
-            .simpDestMatchers("/app/**", "/topic/**", "/queue/**", "/user/**").authenticated()
-            .simpSubscribeDestMatchers("/topic/**", "/queue/**", "/user/**").authenticated()
-            .anyMessage().denyAll();
+                .simpTypeMatchers(
+                        SimpMessageType.CONNECT,
+                        SimpMessageType.HEARTBEAT,
+                        SimpMessageType.UNSUBSCRIBE,
+                        SimpMessageType.DISCONNECT
+                ).permitAll()
+                .simpDestMatchers("/app/**", "/topic/**", "/queue/**", "/user/**").authenticated()
+                .simpSubscribeDestMatchers("/topic/**", "/queue/**", "/user/**").authenticated()
+                .anyMessage().denyAll();
 
-        return messages.build();
+        AuthorizationManager<Message<?>> delegate = messages.build();
+        return (authentication, message) -> {
+            AuthorizationDecision decision = delegate.check(authentication, message);
+
+            if (decision == null || !decision.isGranted()) {
+                if (log.isWarnEnabled()) {
+                    SimpMessageType type = (SimpMessageType) message.getHeaders()
+                            .get(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER);
+                    String destination = Objects.toString(
+                            message.getHeaders().get(SimpMessageHeaderAccessor.DESTINATION_HEADER),
+                            "<none>");
+                    log.warn("Denied STOMP frame. type={}, destination={}, user={}",
+                            type,
+                            destination,
+                            authentication != null ? authentication.get().getName() : "anonymous");
+                }
+            } else if (log.isTraceEnabled()) {
+                SimpMessageType type = (SimpMessageType) message.getHeaders()
+                        .get(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER);
+                String destination = Objects.toString(
+                        message.getHeaders().get(SimpMessageHeaderAccessor.DESTINATION_HEADER),
+                        "<none>");
+                log.trace("Allowed STOMP frame. type={}, destination={}, user={}",
+                        type,
+                        destination,
+                        authentication != null ? authentication.get().getName() : "anonymous");
+            }
+
+            return decision;
+        };
     }
 }

--- a/backend/src/main/java/net/datasa/project01/controller/WebSocketChatController.java
+++ b/backend/src/main/java/net/datasa/project01/controller/WebSocketChatController.java
@@ -3,6 +3,7 @@ package net.datasa.project01.controller;
 import lombok.RequiredArgsConstructor;
 import net.datasa.project01.domain.dto.ChatMessageRequestDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
+import net.datasa.project01.domain.dto.ErrorPayload;
 import net.datasa.project01.domain.dto.SignalMessage;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.repository.RoomMemberRepository;
@@ -14,6 +15,9 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
+import java.util.Map;
+
+import org.springframework.util.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,16 +70,39 @@ public class WebSocketChatController {
             }
             if (signalMessage == null) {
                 log.warn("Received null signal message from user: {}", principal.getName());
+                notifyUserError(principal.getName(), "SIGNAL_PAYLOAD_EMPTY",
+                        "전달된 시그널 데이터가 비어 있습니다.", Map.of("reason", "payload-null"));
                 return;
             }
 
-            if (signalMessage.getReceiverLoginId() == null ||
-                    signalMessage.getReceiverLoginId().trim().isEmpty()) {
-                log.warn("Signal message missing receiver ID from user: {}", principal.getName());
+            String authenticatedLoginId = principal.getName();
+            String declaredSender = signalMessage.getSenderLoginId();
+            String receiverLoginId = signalMessage.getReceiverLoginId();
+
+            if (StringUtils.hasText(declaredSender) && !authenticatedLoginId.equals(declaredSender)) {
+                log.warn("Signal sender mismatch. authenticated={}, declared={} session ignored.",
+                        authenticatedLoginId, declaredSender);
+                notifyUserError(authenticatedLoginId, "SIGNAL_SENDER_MISMATCH",
+                        "시그널 발신자 정보가 올바르지 않습니다.",
+                        Map.of("expected", authenticatedLoginId, "received", declaredSender));
                 return;
             }
 
-            signalMessage.setSenderLoginId(principal.getName());
+            if (!StringUtils.hasText(receiverLoginId)) {
+                log.warn("Signal message missing receiver ID from user: {}", authenticatedLoginId);
+                notifyUserError(authenticatedLoginId, "SIGNAL_INVALID_RECEIVER",
+                        "시그널 수신자 정보가 누락되었습니다.", Map.of("reason", "receiver-missing"));
+                return;
+            }
+
+            if (authenticatedLoginId.equals(receiverLoginId)) {
+                log.warn("Signal receiver is same as sender. user={}", authenticatedLoginId);
+                notifyUserError(authenticatedLoginId, "SIGNAL_SELF_TARGET",
+                        "자기 자신에게 시그널을 보낼 수 없습니다.", Map.of("receiver", receiverLoginId));
+                return;
+            }
+
+            signalMessage.setSenderLoginId(authenticatedLoginId);
 
             if (!roomMemberRepository.existsActiveRoomBetweenUsers(
                     signalMessage.getSenderLoginId(),
@@ -83,6 +110,9 @@ public class WebSocketChatController {
                     Room.RoomType.PRIVATE)) {
                 log.warn("WebRTC signal blocked due to missing active private room between {} and {}",
                         signalMessage.getSenderLoginId(), signalMessage.getReceiverLoginId());
+                notifyUserError(authenticatedLoginId, "SIGNAL_NO_ACTIVE_ROOM",
+                        "상대방과 활성화된 매칭을 찾을 수 없습니다.",
+                        Map.of("receiver", receiverLoginId));
                 return;
             }
 
@@ -93,10 +123,27 @@ public class WebSocketChatController {
             );
 
             log.debug("WebRTC signal sent from {} to {}",
-                    principal.getName(), signalMessage.getReceiverLoginId());
+                    authenticatedLoginId, signalMessage.getReceiverLoginId());
 
         } catch (Exception e) {
             log.error("Error handling WebRTC signal from user: {}", principal.getName(), e);
+            notifyUserError(principal.getName(), "SIGNAL_INTERNAL_ERROR",
+                    "시그널 처리 중 오류가 발생했습니다.", Map.of("error", e.getClass().getSimpleName()));
         }
+    }
+
+    private void notifyUserError(String loginId, String code, String message, Map<String, Object> details) {
+        if (!StringUtils.hasText(loginId)) {
+            log.warn("Cannot send STOMP error without loginId. code={} message={}", code, message);
+            return;
+        }
+
+        ErrorPayload payload = ErrorPayload.builder()
+                .code(code)
+                .message(message)
+                .details(details != null ? details : Map.of())
+                .build();
+
+        messagingTemplate.convertAndSendToUser(loginId, "/queue/errors", payload);
     }
 }

--- a/backend/src/main/java/net/datasa/project01/domain/dto/ErrorPayload.java
+++ b/backend/src/main/java/net/datasa/project01/domain/dto/ErrorPayload.java
@@ -1,0 +1,27 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * STOMP 오류를 사용자별 큐로 전달하기 위한 표준 페이로드.
+ */
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorPayload {
+
+    @Builder.Default
+    private Instant timestamp = Instant.now();
+    private String code;
+    private String message;
+    @Builder.Default
+    private Map<String, Object> details = Collections.emptyMap();
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -61,6 +61,7 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 spring.websocket.servlet.allowed-origins=*
 spring.websocket.servlet.sockjs.heartbeat.time=25000
 spring.websocket.servlet.sockjs.disconnect.delay=5000
+app.ws.allowed-origins=${APP_WS_ALLOWED_ORIGINS:}
 
 
 jwt.secret=MatchTalkSecretKeyForJwtTokenGenerationAndValidationAndMustBeLongerThan256BitsForSecureAuthentication2024

--- a/backend/src/test/java/net/datasa/project01/websocket/SignalRoutingTest.java
+++ b/backend/src/test/java/net/datasa/project01/websocket/SignalRoutingTest.java
@@ -1,0 +1,78 @@
+package net.datasa.project01.websocket;
+
+import net.datasa.project01.controller.WebSocketChatController;
+import net.datasa.project01.domain.dto.ErrorPayload;
+import net.datasa.project01.domain.dto.SignalMessage;
+import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.repository.RoomMemberRepository;
+import net.datasa.project01.service.ChatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * WebSocket 시그널 라우팅 검증을 위한 최소 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class SignalRoutingTest {
+
+    @Mock
+    private ChatService chatService;
+
+    @Mock
+    private SimpMessageSendingOperations messagingTemplate;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    private WebSocketChatController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new WebSocketChatController(chatService, messagingTemplate, roomMemberRepository);
+    }
+
+    @Test
+    void sendsSignalToReceiverQueueWhenAuthorized() {
+        when(roomMemberRepository.existsActiveRoomBetweenUsers("alice", "bob", Room.RoomType.PRIVATE))
+                .thenReturn(true);
+
+        SignalMessage message = new SignalMessage("offer", "alice", "bob", Map.of("sdp", "dummy"));
+        Principal principal = () -> "alice";
+
+        controller.handleSignal(message, principal);
+
+        verify(messagingTemplate).convertAndSendToUser(eq("bob"), eq("/queue/signals"), eq(message));
+        verify(messagingTemplate, never()).convertAndSendToUser(eq("alice"), eq("/queue/errors"), org.mockito.Mockito.any());
+    }
+
+    @Test
+    void routesErrorWhenSenderDoesNotMatchPrincipal() {
+        SignalMessage message = new SignalMessage("offer", "mallory", "bob", Map.of("sdp", "dummy"));
+        Principal principal = () -> "alice";
+
+        controller.handleSignal(message, principal);
+
+        ArgumentCaptor<ErrorPayload> errorCaptor = ArgumentCaptor.forClass(ErrorPayload.class);
+        verify(messagingTemplate).convertAndSendToUser(eq("alice"), eq("/queue/errors"), errorCaptor.capture());
+        verify(messagingTemplate, never()).convertAndSendToUser(eq("bob"), eq("/queue/signals"), org.mockito.Mockito.any());
+
+        ErrorPayload payload = errorCaptor.getValue();
+        assertThat(payload.getCode()).isEqualTo("SIGNAL_SENDER_MISMATCH");
+        assertThat(payload.getMessage()).isNotBlank();
+        assertThat(payload.getDetails()).containsEntry("expected", "alice");
+    }
+}

--- a/frontend/src/services/signaling.js
+++ b/frontend/src/services/signaling.js
@@ -1,20 +1,60 @@
 import { camelizeKeys } from '../utils/case'
 
-export function setupSignalRoutes(client, { me, onSignal, subscribeDest } = {}) {
-    const destination = subscribeDest || '/user/queue/signals'
-    const sub = client.subscribe(destination, (msg) => {
-        const raw = msg.body ? JSON.parse(msg.body) : null
-        const payload = raw && typeof raw === 'object' ? camelizeKeys(raw) : raw
-        onSignal?.(payload)
-    })
+function parseBody(message) {
+  if (!message?.body) {
+    return null
+  }
+  try {
+    const raw = JSON.parse(message.body)
+    return raw && typeof raw === 'object' ? camelizeKeys(raw) : raw
+  } catch (error) {
+    console.warn('[signaling] Failed to parse STOMP message body.', error)
+    return null
+  }
+}
 
-    function sendSignal(signal = {}) {
-        const payload = { senderLoginId: me, ...signal }
-        client.publish({
-            destination: '/app/signal',
-            body: JSON.stringify(payload),
-        })
+export function setupSignalRoutes(
+  client,
+  { me, onSignal, onError, subscribeDest } = {}
+) {
+  const destination = subscribeDest || '/user/queue/signals'
+  const subscriptions = []
+
+  const signalSubscription = client.subscribe(destination, (msg) => {
+    const payload = parseBody(msg)
+    if (payload) {
+      onSignal?.(payload)
     }
+  })
+  subscriptions.push(signalSubscription)
 
-    return { sub, sendSignal }
+  const errorSubscription = client.subscribe('/user/queue/errors', (msg) => {
+    const payload = parseBody(msg) || { code: 'UNKNOWN', message: msg.body }
+    if (onError) {
+      onError(payload)
+    } else {
+      console.warn('[signaling] Received error payload.', payload)
+    }
+  })
+  subscriptions.push(errorSubscription)
+
+  function sendSignal(signal = {}) {
+    const payload = { senderLoginId: me, ...signal }
+    client.publish({
+      destination: '/app/signal',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  function unsubscribe() {
+    for (const subscription of subscriptions) {
+      try {
+        subscription?.unsubscribe?.()
+      } catch (error) {
+        console.warn('[signaling] Failed to unsubscribe from destination.', error)
+      }
+    }
+  }
+
+  return { sub: signalSubscription, errorSub: errorSubscription, subscriptions, unsubscribe, sendSignal }
 }

--- a/frontend/src/services/turn.js
+++ b/frontend/src/services/turn.js
@@ -161,7 +161,7 @@ async function fetchIceServersFromApi() {
 
     return dedupeIceServers(candidates)
   } catch (error) {
-    console.error('TURN credentials를 가져오는 중 오류가 발생했습니다.', error)
+    console.warn('TURN credentials를 가져오는 중 오류가 발생했습니다. 기본 STUN으로 폴백합니다.', error)
     return []
   }
 }
@@ -193,6 +193,20 @@ export async function getIceServers() {
 
   try {
     cachedIceServers = await pendingIceServersPromise
+    if (import.meta.env.DEV) {
+      const redacted = cachedIceServers.map((server) => {
+        if (!server || typeof server !== 'object') {
+          return server
+        }
+        const masked = { ...server }
+        if (masked.credential && typeof masked.credential === 'string') {
+          const prefix = masked.credential.slice(0, 3)
+          masked.credential = `${prefix}***`
+        }
+        return masked
+      })
+      console.log('[turn] Using ICE server configuration', redacted)
+    }
   } catch (error) {
     console.error('ICE 서버 구성을 불러오는 중 오류가 발생했습니다.', error)
     cachedIceServers = DEFAULT_ICE_SERVERS.map((server) => ({ ...server }))

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -2,27 +2,309 @@ import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client'
 import { SOCK_JS_URL } from './endpoints'
 
-export function createStompClient(token) {
-  let resolvedToken = token
-  if (!resolvedToken && typeof localStorage !== 'undefined') {
-    resolvedToken = localStorage.getItem('token') || null
-  }
-  if (resolvedToken && resolvedToken.startsWith('Bearer ')) {
-    resolvedToken = resolvedToken.slice('Bearer '.length)
-  }
+const INITIAL_BACKOFF_MS = 1000
+const MAX_BACKOFF_MS = 30000
 
-  const headers = {}
-  if (resolvedToken) {
-    const bearer = `Bearer ${resolvedToken}`
-    headers.Authorization = bearer
-    headers.authorization = bearer
+function normalizeToken(rawToken) {
+  if (!rawToken) {
+    return null
   }
+  return rawToken.startsWith('Bearer ') ? rawToken.slice('Bearer '.length) : rawToken
+}
+
+function buildHeaders(token) {
+  if (!token) {
+    return {}
+  }
+  const bearer = `Bearer ${token}`
+  return {
+    Authorization: bearer,
+    authorization: bearer,
+  }
+}
+
+export function createStompClient(options = {}) {
+  const config =
+    typeof options === 'string' || options instanceof String ? { token: options } : { ...(options || {}) }
+
+  let resolvedToken = normalizeToken(
+    config.token ?? (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)
+  )
+  let connectHeaders = buildHeaders(resolvedToken)
 
   const client = new Client({
     webSocketFactory: () => new SockJS(SOCK_JS_URL),
-    connectHeaders: headers,
-    reconnectDelay: 3000,
-    debug: () => {}, // 필요 시 콘솔 출력
+    connectHeaders: { ...connectHeaders },
+    reconnectDelay: 0,
+    debug:
+      typeof config.debug === 'function'
+        ? config.debug
+        : import.meta.env.DEV
+          ? (...args) => console.log('[stomp]', ...args)
+          : () => {},
   })
-  return client
+
+  const refreshTokenFn = typeof config.refreshToken === 'function' ? config.refreshToken : null
+  const onTokenRefreshed = typeof config.onTokenRefreshed === 'function' ? config.onTokenRefreshed : null
+
+  let refreshInFlight = null
+  let reconnectDelay = INITIAL_BACKOFF_MS
+  let reconnectTimeoutId = null
+  let manualStop = false
+
+  const logWarn = (...args) => {
+    if (import.meta.env.DEV) {
+      console.warn('[stomp]', ...args)
+    }
+  }
+
+  const logDebug = (...args) => {
+    if (import.meta.env.DEV) {
+      console.debug('[stomp]', ...args)
+    }
+  }
+
+  const applyHeadersFromToken = (token) => {
+    resolvedToken = normalizeToken(token)
+    connectHeaders = buildHeaders(resolvedToken)
+    client.connectHeaders = { ...connectHeaders }
+    if (typeof localStorage !== 'undefined') {
+      if (resolvedToken) {
+        localStorage.setItem('token', resolvedToken)
+      } else {
+        localStorage.removeItem('token')
+      }
+    }
+    if (resolvedToken && onTokenRefreshed) {
+      onTokenRefreshed(resolvedToken)
+    }
+  }
+
+  async function attemptTokenRefresh(reason) {
+    if (!refreshTokenFn) {
+      return false
+    }
+    if (refreshInFlight) {
+      return refreshInFlight
+    }
+
+    refreshInFlight = (async () => {
+      try {
+        const result = await refreshTokenFn({ reason })
+        const nextToken =
+          typeof result === 'string'
+            ? result
+            : result && typeof result === 'object'
+              ? result.token ?? result.accessToken ?? null
+              : null
+        if (!nextToken) {
+          logWarn('Token refresh did not return a token. reason=', reason)
+          return false
+        }
+        applyHeadersFromToken(nextToken)
+        return true
+      } catch (error) {
+        logWarn('Token refresh failed.', error)
+        return false
+      } finally {
+        refreshInFlight = null
+      }
+    })()
+
+    return refreshInFlight
+  }
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimeoutId) {
+      clearTimeout(reconnectTimeoutId)
+      reconnectTimeoutId = null
+    }
+  }
+
+  const deactivateQuietly = async () => {
+    try {
+      if (client.active || client.connected) {
+        await client.deactivate()
+      }
+    } catch (error) {
+      logWarn('Failed to deactivate STOMP client during reconnect.', error)
+    }
+  }
+
+  const scheduleReconnect = (source) => {
+    if (manualStop) {
+      return
+    }
+    if (reconnectTimeoutId) {
+      return
+    }
+    const delay = reconnectDelay
+    reconnectDelay = Math.min(reconnectDelay * 2, MAX_BACKOFF_MS)
+    reconnectTimeoutId = setTimeout(async () => {
+      reconnectTimeoutId = null
+      if (manualStop) {
+        return
+      }
+      logDebug('Attempting STOMP reconnect. source=%s delay=%dms', source, delay)
+      await deactivateQuietly()
+      try {
+        client.activate()
+      } catch (error) {
+        logWarn('STOMP reactivation failed. source=%s', source, error)
+        scheduleReconnect('retry')
+      }
+    }, delay)
+    logWarn(`Scheduled STOMP reconnect in ${delay}ms (source=${source})`)
+  }
+
+  client.beforeConnect = () => {
+    client.connectHeaders = { ...connectHeaders }
+  }
+
+  client.onConnect = (frame) => {
+    manualStop = false
+    reconnectDelay = INITIAL_BACKOFF_MS
+    clearReconnectTimer()
+    if (typeof client.__userOnConnect === 'function') {
+      try {
+        client.__userOnConnect(frame)
+      } catch (error) {
+        logWarn('User onConnect handler threw an error.', error)
+      }
+    }
+  }
+
+  client.onDisconnect = (frame) => {
+    if (typeof client.__userOnDisconnect === 'function') {
+      try {
+        client.__userOnDisconnect(frame)
+      } catch (error) {
+        logWarn('User onDisconnect handler threw an error.', error)
+      }
+    }
+  }
+
+  client.onStompError = async (frame) => {
+    const message = frame?.headers?.message || ''
+    const body = frame?.body || ''
+    const combined = `${message} ${body}`.toLowerCase()
+    const authError = /unauthor|forbidden|denied|expired/.test(combined)
+
+    if (typeof client.__userOnStompError === 'function') {
+      try {
+        client.__userOnStompError(frame)
+      } catch (error) {
+        logWarn('User onStompError handler threw an error.', error)
+      }
+    }
+
+    if (authError) {
+      const refreshed = await attemptTokenRefresh('stomp-error')
+      if (refreshed) {
+        scheduleReconnect('token-refreshed')
+        return
+      }
+    }
+
+    scheduleReconnect('stomp-error')
+  }
+
+  client.onWebSocketClose = async (event) => {
+    const reason = `${event?.reason || ''}`.toLowerCase()
+    const code = event?.code ?? 0
+    const authHint = reason.includes('401') || reason.includes('unauthor') || code === 4001
+
+    if (typeof client.__userOnWebSocketClose === 'function') {
+      try {
+        client.__userOnWebSocketClose(event)
+      } catch (error) {
+        logWarn('User onWebSocketClose handler threw an error.', error)
+      }
+    }
+
+    if (authHint) {
+      const refreshed = await attemptTokenRefresh('ws-close')
+      if (refreshed) {
+        scheduleReconnect('token-refreshed')
+        return
+      }
+    }
+
+    scheduleReconnect('ws-close')
+  }
+
+  client.onWebSocketError = (event) => {
+    if (typeof client.__userOnWebSocketError === 'function') {
+      try {
+        client.__userOnWebSocketError(event)
+      } catch (error) {
+        logWarn('User onWebSocketError handler threw an error.', error)
+      }
+    }
+  }
+
+  const proxy = new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop === 'onConnect') return target.__userOnConnect
+      if (prop === 'onDisconnect') return target.__userOnDisconnect
+      if (prop === 'onStompError') return target.__userOnStompError
+      if (prop === 'onWebSocketClose') return target.__userOnWebSocketClose
+      if (prop === 'onWebSocketError') return target.__userOnWebSocketError
+      if (prop === 'updateToken') return applyHeadersFromToken
+      if (prop === 'stopAndWait') {
+        return async () => {
+          manualStop = true
+          clearReconnectTimer()
+          await deactivateQuietly()
+        }
+      }
+      if (prop === 'activate') {
+        return (...args) => {
+          manualStop = false
+          reconnectDelay = INITIAL_BACKOFF_MS
+          return Reflect.get(target, prop).apply(target, args)
+        }
+      }
+      if (prop === 'deactivate') {
+        return async (...args) => {
+          manualStop = true
+          clearReconnectTimer()
+          return Reflect.get(target, prop).apply(target, args)
+        }
+      }
+      return Reflect.get(target, prop, receiver)
+    },
+    set(target, prop, value) {
+      if (prop === 'onConnect') {
+        target.__userOnConnect = value
+        return true
+      }
+      if (prop === 'onDisconnect') {
+        target.__userOnDisconnect = value
+        return true
+      }
+      if (prop === 'onStompError') {
+        target.__userOnStompError = value
+        return true
+      }
+      if (prop === 'onWebSocketClose') {
+        target.__userOnWebSocketClose = value
+        return true
+      }
+      if (prop === 'onWebSocketError') {
+        target.__userOnWebSocketError = value
+        return true
+      }
+      return Reflect.set(target, prop, value)
+    },
+  })
+
+  proxy.reconnectNow = async () => {
+    manualStop = false
+    clearReconnectTimer()
+    await deactivateQuietly()
+    client.activate()
+  }
+
+  return proxy
 }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,4 +1,20 @@
 import { defineStore } from 'pinia'
+import { API_BASE_URL } from '../services/endpoints'
+
+function joinApiPath(base, path) {
+  if (!base) {
+    return path
+  }
+  const hasTrailing = base.endsWith('/')
+  const hasLeading = path.startsWith('/')
+  if (hasTrailing && hasLeading) {
+    return `${base}${path.slice(1)}`
+  }
+  if (!hasTrailing && !hasLeading) {
+    return `${base}/${path}`
+  }
+  return `${base}${path}`
+}
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -12,15 +28,67 @@ export const useAuthStore = defineStore('auth', {
   actions: {
     login({ token, user }) {
       this.token = token ?? null
-      this.user  = user  ?? null
-      if (this.token) localStorage.setItem('token', this.token); else localStorage.removeItem('token')
-      if (this.user)  localStorage.setItem('user', JSON.stringify(this.user)); else localStorage.removeItem('user')
+      this.user = user ?? null
+      if (this.token) {
+        localStorage.setItem('token', this.token)
+      } else {
+        localStorage.removeItem('token')
+      }
+      if (this.user) {
+        localStorage.setItem('user', JSON.stringify(this.user))
+      } else {
+        localStorage.removeItem('user')
+      }
     },
     logout() {
       this.token = null
-      this.user  = null
+      this.user = null
       localStorage.removeItem('token')
       localStorage.removeItem('user')
-    }
-  }
+    },
+    async refreshToken() {
+      if (!this.token) {
+        return null
+      }
+
+      const endpoint = joinApiPath(API_BASE_URL, '/auth/refresh')
+      const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` }
+
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers,
+          credentials: 'include',
+        })
+
+        if (!response.ok) {
+          console.warn('토큰 갱신 요청 실패', response.status)
+          if (response.status === 401) {
+            this.logout()
+          }
+          return null
+        }
+
+        const body = await response.json().catch(() => null)
+        const nextToken =
+          typeof body?.token === 'string'
+            ? body.token
+            : typeof body?.accessToken === 'string'
+              ? body.accessToken
+              : null
+        const nextUser = body?.user && typeof body.user === 'object' ? body.user : this.user
+
+        if (!nextToken) {
+          console.warn('토큰 갱신 응답에 토큰이 없습니다.', body)
+          return null
+        }
+
+        this.login({ token: nextToken, user: nextUser })
+        return nextToken
+      } catch (error) {
+        console.warn('토큰 갱신 중 오류 발생', error)
+        return null
+      }
+    },
+  },
 })

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -263,6 +263,13 @@ const connectionReady = computed(() => {
   return Boolean(connected.value && currentRoomId.value)
 })
 
+function handleTokenRefresh(nextToken) {
+  if (!nextToken) {
+    return
+  }
+  auth.login({ token: nextToken, user: auth.user })
+}
+
 const connectionStatusText = computed(() => {
   if (isGroup.value) {
     return groupParticipants.value || '그룹 채팅'
@@ -488,7 +495,12 @@ function initStompClient() {
   if (client.value) {
     return
   }
-  client.value = createStompClient(auth.token)
+  const refreshTokenFn = typeof auth.refreshToken === 'function' ? auth.refreshToken.bind(auth) : undefined
+  client.value = createStompClient({
+    token: auth.token,
+    refreshToken: refreshTokenFn,
+    onTokenRefreshed: handleTokenRefresh,
+  })
   client.value.onConnect = () => {
     connected.value = true
     ensureChatRoute()

--- a/frontend/src/views/MatchSession.vue
+++ b/frontend/src/views/MatchSession.vue
@@ -179,6 +179,12 @@ const lastSignal = ref(null)
 const lastOffer = ref(null)
 const lastAnswer = ref(null)
 const lastIceCandidates = ref([])
+const signalError = ref(null)
+
+const makingOffer = ref(false)
+const ignoreOffer = ref(false)
+const settingRemoteAnswerPending = ref(false)
+let iceRestartTimeout = null
 
 function debugLog(label, payload) {
   // eslint-disable-next-line no-console
@@ -198,6 +204,13 @@ function logLocalState() {
     requestId: matchStore.requestId,
     partnerRequestId: matchStore.partnerRequestId,
   })
+}
+
+function handleTokenRefresh(nextToken) {
+  if (!nextToken) {
+    return
+  }
+  auth.login({ token: nextToken, user: auth.user })
 }
 let matchSubscription = null
 let followSubscription = null
@@ -239,6 +252,14 @@ const effectiveShouldCreateOffer = computed(() => {
 })
 const meLoginId = computed(() => auth.user?.loginId || auth.user?.login_id || auth.user?.loginID || null)
 const meNickName = computed(() => auth.user?.nickName || auth.user?.nickname || auth.user?.nick_name || '')
+const isPolitePeer = computed(() => {
+  const myId = meLoginId.value || ''
+  const partnerId = matchStore.partnerLoginId || ''
+  if (!myId || !partnerId) {
+    return false
+  }
+  return myId.localeCompare(partnerId) > 0
+})
 const followStatus = computed(() => matchStore.followStatus)
 const followDirection = computed(() => matchStore.followDirection)
 const followActionRequired = computed(() => matchStore.needsFollowAction)
@@ -503,6 +524,16 @@ async function ensurePeerConnection() {
       // 아래 로직은 기존 연결에 대해 계속 진행합니다.
     } else {
       pc = new RTCPeerConnection({ iceServers })
+      pc.onnegotiationneeded = async () => {
+        if (!pc || !matchStore.partnerLoginId) {
+          return
+        }
+        if (!isPolitePeer.value && pc.signalingState !== 'stable') {
+          debugLog('negotiation-skipped', { reason: 'impolite-and-unstable' })
+          return
+        }
+        await renegotiate({ iceRestart: false })
+      }
       pc.ontrack = (event) => {
         const track = event.track
         let [stream] = event.streams
@@ -541,9 +572,22 @@ async function ensurePeerConnection() {
           })
         }
       }
-      pc.onconnectionstatechange = () => {
-        if (pc && ['disconnected', 'failed', 'closed'].includes(pc.connectionState)) {
+      pc.oniceconnectionstatechange = () => {
+        if (!pc) {
+          return
+        }
+        const state = pc.iceConnectionState
+        debugLog('ice-state', state)
+        if (state === 'failed' || state === 'disconnected') {
           hasRemoteStream.value = false
+          scheduleIceRestart(state)
+        } else if (state === 'closed') {
+          hasRemoteStream.value = false
+        } else if (state === 'connected' || state === 'completed') {
+          if (iceRestartTimeout) {
+            clearTimeout(iceRestartTimeout)
+            iceRestartTimeout = null
+          }
         }
       }
     }
@@ -555,33 +599,60 @@ async function ensurePeerConnection() {
     signalRoute = setupSignalRoutes(client.value, {
       me: meLoginId.value,
       onSignal: handleSignal,
+      onError: handleSignalError,
     })
   }
 
   if (effectiveShouldCreateOffer.value && !offerCreated.value) {
-    await createOffer()
+    await renegotiate({ iceRestart: false })
   }
 }
 
-async function createOffer() {
+function scheduleIceRestart(reason) {
+  if (iceRestartTimeout || !pc) {
+    return
+  }
+  iceRestartTimeout = setTimeout(async () => {
+    iceRestartTimeout = null
+    if (!pc) {
+      return
+    }
+    debugLog('ice-restart', reason)
+    try {
+      if (typeof pc.restartIce === 'function') {
+        pc.restartIce()
+      }
+    } catch (error) {
+      console.warn('ICE restart invocation failed', error)
+    }
+    await renegotiate({ iceRestart: true })
+  }, 1500)
+}
+
+async function renegotiate({ iceRestart = false } = {}) {
   if (!pc || !signalRoute || !matchStore.partnerLoginId) {
     return
   }
+  if (makingOffer.value) {
+    return
+  }
   try {
-    const offer = await pc.createOffer()
+    makingOffer.value = true
+    const offer = await pc.createOffer(iceRestart ? { iceRestart: true } : undefined)
     lastOffer.value = offer
-    debugLog('create-offer', offer)
+    debugLog('create-offer', { offer, iceRestart })
     await pc.setLocalDescription(offer)
-    const payload = {
+    const description = pc.localDescription || offer
+    signalRoute.sendSignal({
       type: 'offer',
       receiverLoginId: matchStore.partnerLoginId,
-      data: offer,
-    }
-    debugLog('send-signal', payload)
-    signalRoute.sendSignal(payload)
+      data: description,
+    })
     offerCreated.value = true
   } catch (error) {
-    console.error('WebRTC Offer 생성 실패', error)
+    console.error('WebRTC negotiation 실패', error)
+  } finally {
+    makingOffer.value = false
   }
 }
 
@@ -591,6 +662,7 @@ async function handleSignal(message) {
   }
   lastSignal.value = message
   debugLog('signal-received', message)
+  signalError.value = null
   if (!pc) {
     await ensurePeerConnection()
   }
@@ -599,55 +671,102 @@ async function handleSignal(message) {
   }
 
   try {
-    if (message.type === 'offer') {
-      offerCreated.value = true
+    if (message.type === 'offer' && message.data) {
+      const offerCollision = makingOffer.value || pc.signalingState !== 'stable'
+      ignoreOffer.value = !isPolitePeer.value && offerCollision
+      debugLog('offer-received', { offerCollision, ignore: ignoreOffer.value })
+      if (ignoreOffer.value) {
+        return
+      }
+
+      settingRemoteAnswerPending.value = true
       await pc.setRemoteDescription(message.data)
       remoteDescriptionSet.value = true
       const answer = await pc.createAnswer()
       lastAnswer.value = answer
       debugLog('create-answer', answer)
       await pc.setLocalDescription(answer)
-      const payload = {
+      const description = pc.localDescription || answer
+      signalRoute?.sendSignal({
         type: 'answer',
         receiverLoginId: matchStore.partnerLoginId,
-        data: answer,
-      }
-      debugLog('send-signal', payload)
-      signalRoute?.sendSignal(payload)
-    } else if (message.type === 'answer') {
+        data: description,
+      })
       offerCreated.value = true
+      ignoreOffer.value = false
+    } else if (message.type === 'answer' && message.data) {
+      if (ignoreOffer.value) {
+        debugLog('answer-ignored', message)
+        return
+      }
       await pc.setRemoteDescription(message.data)
       remoteDescriptionSet.value = true
+      offerCreated.value = true
+      ignoreOffer.value = false
     } else if (message.type === 'ice-candidate' && message.data) {
       lastIceCandidates.value = [...lastIceCandidates.value, message.data]
       debugLog('ice-candidate-received', message.data)
+      const applyCandidate = async () => {
+        try {
+          await pc.addIceCandidate(message.data)
+        } catch (error) {
+          console.error('ICE candidate 적용 실패', error)
+        }
+      }
       if (!remoteDescriptionSet.value) {
         setTimeout(() => {
-          void pc?.addIceCandidate(message.data).catch((error) => {
-            console.error('ICE candidate 적용 실패', error)
-          })
+          void applyCandidate()
         }, 100)
         return
       }
-      await pc.addIceCandidate(message.data)
+      await applyCandidate()
     }
   } catch (error) {
     console.error('시그널 처리 실패', error)
+    signalError.value = error
+  } finally {
+    if (message.type === 'offer') {
+      settingRemoteAnswerPending.value = false
+    }
+  }
+}
+
+function handleSignalError(payload) {
+  signalError.value = payload
+  const message = payload?.message || '시그널 처리 중 오류가 발생했습니다.'
+  matchStore.statusMessage = message
+  if (import.meta.env.DEV) {
+    console.warn('[match-session] signal-error', payload)
   }
 }
 
 function teardownPeerConnection() {
-  if (signalRoute?.sub) {
-    signalRoute.sub.unsubscribe()
+  if (signalRoute?.unsubscribe) {
+    signalRoute.unsubscribe()
+  } else {
+    signalRoute?.sub?.unsubscribe?.()
+    signalRoute?.errorSub?.unsubscribe?.()
   }
   signalRoute = null
+  if (iceRestartTimeout) {
+    clearTimeout(iceRestartTimeout)
+    iceRestartTimeout = null
+  }
   if (pc) {
-    pc.close()
+    try {
+      pc.close()
+    } catch (error) {
+      console.warn('RTCPeerConnection close failed', error)
+    }
     pc = null
   }
   audioTransceiver = null
   videoTransceiver = null
   offerCreated.value = false
+  makingOffer.value = false
+  ignoreOffer.value = false
+  settingRemoteAnswerPending.value = false
+  signalError.value = null
   if (remoteVideo.value) {
     remoteVideo.value.srcObject = null
   }
@@ -957,7 +1076,13 @@ onMounted(async () => {
   await loadFollowStatus()
   await initLocalMedia()
 
-  client.value = createStompClient(auth.token)
+  const refreshTokenFn = typeof auth.refreshToken === 'function' ? auth.refreshToken.bind(auth) : undefined
+
+  client.value = createStompClient({
+    token: auth.token,
+    refreshToken: refreshTokenFn,
+    onTokenRefreshed: handleTokenRefresh,
+  })
   client.value.onConnect = () => {
     connected.value = true
     matchSubscription = client.value.subscribe('/user/queue/match-results', handleMatchMessage)
@@ -985,8 +1110,11 @@ onBeforeUnmount(() => {
   matchSubscription = null
   followSubscription?.unsubscribe()
   followSubscription = null
-  if (signalRoute?.sub) {
-    signalRoute.sub.unsubscribe()
+  if (signalRoute?.unsubscribe) {
+    signalRoute.unsubscribe()
+  } else {
+    signalRoute?.sub?.unsubscribe?.()
+    signalRoute?.errorSub?.unsubscribe?.()
   }
   signalRoute = null
   client.value?.deactivate?.()

--- a/frontend/src/views/MatchingResult.vue
+++ b/frontend/src/views/MatchingResult.vue
@@ -253,6 +253,13 @@ function checkSessionTransition() {
   }
 }
 
+function handleTokenRefresh(nextToken) {
+  if (!nextToken) {
+    return
+  }
+  auth.login({ token: nextToken, user: auth.user })
+}
+
 watch(
   () => matchStore.bothConfirmed,
   (confirmed) => {
@@ -286,7 +293,13 @@ watch(
 onMounted(() => {
   ensureStatusPolling(true)
 
-  client.value = createStompClient(auth.token)
+  const refreshTokenFn = typeof auth.refreshToken === 'function' ? auth.refreshToken.bind(auth) : undefined
+
+  client.value = createStompClient({
+    token: auth.token,
+    refreshToken: refreshTokenFn,
+    onTokenRefreshed: handleTokenRefresh,
+  })
   client.value.onConnect = () => {
     connected.value = true
     matchSubscription = client.value.subscribe('/user/queue/match-results', handleMatchMessage)

--- a/frontend/src/views/RtcTest.vue
+++ b/frontend/src/views/RtcTest.vue
@@ -69,6 +69,13 @@ const remoteVideo = ref(null)
 const chats = ref([])
 const draft = ref('')
 
+function handleTokenRefresh(nextToken) {
+  if (!nextToken) {
+    return
+  }
+  auth.login({ token: nextToken, user: auth.user })
+}
+
 // WebRTC PeerConnection
 const pc = new RTCPeerConnection({
   iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
@@ -85,7 +92,12 @@ async function start () {
 
     // 1) STOMP 클라이언트를 먼저 생성
     if (!client) {
-      client = createStompClient(auth.token)
+      const refreshTokenFn = typeof auth.refreshToken === 'function' ? auth.refreshToken.bind(auth) : undefined
+      client = createStompClient({
+        token: auth.token,
+        refreshToken: refreshTokenFn,
+        onTokenRefreshed: handleTokenRefresh,
+      })
     }
 
     // 2) 이벤트 핸들러를 설정
@@ -115,7 +127,10 @@ async function start () {
               console.warn('Failed to add ICE candidate:', e)
             }
           }
-        }
+        },
+        onError: (payload) => {
+          console.warn('[rtc-test] signaling error', payload)
+        },
       })
 
       // 4) 채팅 구독
@@ -194,7 +209,7 @@ function sendChat () {
 
 onBeforeUnmount(() => {
   try { chatSub?.unsubscribe?.() } catch {}
-  try { signal?.sub?.unsubscribe?.() } catch {}
+  try { signal?.unsubscribe?.() ?? signal?.sub?.unsubscribe?.() } catch {}
   try { client?.deactivate?.() } catch {}
   try { pc?.close?.() } catch {}
 })


### PR DESCRIPTION
## Summary
- Externalize allowed WebSocket origins, enable SockJS CDN usage, and add heartbeat tuning for the broker configuration.
- Harden STOMP authentication and authorization with detailed logging, emit structured error payloads, and add tests covering signal routing safeguards.
- Implement token-aware STOMP reconnect/backoff, perfect negotiation for WebRTC sessions, TURN logging, and expose signaling errors to the UI; document HTTPS development setup.

## Testing
- `./gradlew test` *(fails: maven central returned HTTP 403 when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e1a969808325989a68ec2b397cbe