### PR TITLE
Configure WebSocket heartbeat scheduler

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package net.datasa.project01.config;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -11,6 +12,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -57,6 +59,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setApplicationDestinationPrefixes("/app");
         registry.enableSimpleBroker("/topic", "/queue")
+                .setTaskScheduler(webSocketMessageBrokerTaskScheduler())
                 .setHeartbeatValue(new long[]{25_000L, 25_000L});
     }
 
@@ -75,5 +78,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .map(String::trim)
                 .filter(StringUtils::hasText)
                 .collect(Collectors.toList());
+    }
+
+    @Bean
+    public ThreadPoolTaskScheduler webSocketMessageBrokerTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("websocket-heartbeat-");
+        scheduler.setRemoveOnCancelPolicy(true);
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated ThreadPoolTaskScheduler bean for WebSocket heartbeats
- wire the scheduler into the simple broker configuration with custom thread naming and shutdown behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e93b2a648325b2a184b7ff2fa1d5