### PR TITLE
Configure security exception handling and public endpoints

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package net.datasa.project01.config;
 
 import lombok.RequiredArgsConstructor;
+import net.datasa.project01.config.handler.RestAccessDeniedHandler;
+import net.datasa.project01.config.handler.RestAuthenticationEntryPoint;
 import net.datasa.project01.service.UserDetailsServiceImpl;
 import net.datasa.project01.util.JwtUtil;
 import org.springframework.context.annotation.Bean;
@@ -14,8 +16,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 /**
  * [SecurityConfig]
- * - 테스트 및 개발 편의성을 위해 모든 HTTP 요청을 인증 없이 허용합니다.
- * - REST API 환경에 맞춰 CSRF, 폼 로그인 등을 비활성화합니다.
+ * - JWT 기반 인증을 적용하고 REST API 환경에 맞춰 CSRF, 폼 로그인 등을 비활성화합니다.
+ * - 인증이 필요 없는 공개 엔드포인트(/error, WebSocket 등)는 permitAll로 예외 처리합니다.
+ * - 인증 실패/권한 부족 시 일관된 JSON 응답을 내려주도록 커스텀 핸들러를 등록합니다.
  * - 비밀번호 저장 시 BCrypt 해시를 사용하도록 PasswordEncoder 빈을 제공합니다.
  */
 @Configuration // 스프링 설정 클래스임을 명시
@@ -24,6 +27,8 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+    private final RestAccessDeniedHandler accessDeniedHandler;
 
     /**
      * SecurityFilterChain 빈 등록
@@ -48,6 +53,8 @@ public class SecurityConfig {
                         .requestMatchers("/ws-stomp/info").permitAll()
                         // 회원가입, 로그인, 중복확인, 이메일 인증 등 인증 없이 접근해야 하는 경로 허용
                         .requestMatchers("/api/auth/login", "/api/auth/find-id", "/api/auth/password-reset/**", "/api/users/signup", "/api/users/exists", "/api/users/email/**").permitAll()
+                        // 오류 및 상태 체크 엔드포인트는 인증 없이 접근 허용
+                        .requestMatchers("/error", "/actuator/health", "/actuator/info").permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )
@@ -55,6 +62,11 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 // HTTP Basic 인증 비활성화
                 .httpBasic(httpBasic -> httpBasic.disable())
+                // 인증/인가 예외 시 커스텀 JSON 응답
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
                 // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/handler/RestAccessDeniedHandler.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/handler/RestAccessDeniedHandler.java
@@ -1,0 +1,43 @@
+package net.datasa.project01.config.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 인가에 실패한 경우 403 JSON 응답을 내려주는 핸들러.
+ */
+@Component
+@RequiredArgsConstructor
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        if (response.isCommitted()) {
+            return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> body = Map.of(
+                "message", "접근 권한이 없습니다.",
+                "path", request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/handler/RestAuthenticationEntryPoint.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/handler/RestAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package net.datasa.project01.config.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 인증이 필요한 요청에 토큰이 없거나 잘못된 경우 401 JSON 응답을 내려주는 EntryPoint.
+ */
+@Component
+@RequiredArgsConstructor
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        if (response.isCommitted()) {
+            return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> body = Map.of(
+                "message", "인증이 필요합니다.",
+                "path", request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}


### PR DESCRIPTION
## Summary
- add REST-friendly authentication entry point and access denied handler to return JSON responses for unauthenticated or unauthorized requests
- register the handlers in the security configuration while permitting error and basic actuator endpoints without authentication
- update security configuration documentation to reflect JWT-based protection and new exception handling

## Testing
- `./gradlew test` *(fails: Java 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ff897cb48325830a3b2e9c7d2b28