### PR TITLE
Harden STOMP authentication and stabilize matching WebSocket client

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/StompHandler.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/StompHandler.java
@@ -8,12 +8,16 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -34,53 +38,78 @@ public class StompHandler implements ChannelInterceptor {
         log.debug("Processing STOMP message with command: {}", command);
         
         // CONNECT 명령에서만 인증 수행
-        if (StompCommand.CONNECT.equals(command)) {
-            try {
+        try {
+            if (StompCommand.CONNECT.equals(command)) {
                 authenticateWebSocketConnection(accessor);
-            } catch (Exception e) {
-                log.error("WebSocket authentication failed", e);
-                // 인증 실패 시에도 연결은 허용하되 로그로 기록
-                // 실제 메시지 처리에서는 Security Context가 없으면 자동으로 거부됨
+            } else if (StompCommand.DISCONNECT.equals(command)) {
+                log.debug("Clearing security context on WebSocket disconnect");
+                SecurityContextHolder.clearContext();
+            } else {
+                propagateAuthentication(accessor);
             }
+        } catch (AuthenticationCredentialsNotFoundException | BadCredentialsException ex) {
+            log.warn("❌ WebSocket authentication rejected: {}", ex.getMessage());
+            SecurityContextHolder.clearContext();
+            throw ex;
+        } catch (Exception ex) {
+            log.error("Unexpected error during STOMP processing", ex);
+            SecurityContextHolder.clearContext();
+            throw ex;
         }
-        
+
         return message;
     }
-    
+
     private void authenticateWebSocketConnection(StompHeaderAccessor accessor) {
         String authHeader = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
-        
-        log.debug("Authorization header: {}", authHeader != null ? "Present" : "Missing");
-        
-        // 인증 헤더가 없는 경우 - 경고만 로그하고 진행
-        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
-            log.warn("No valid authorization header found for WebSocket connection");
-            // 테스트 환경에서는 인증 없이도 연결 허용
+
+        log.debug("Authorization header present: {}", authHeader != null);
+
+        if (!StringUtils.hasText(authHeader)) {
+            throw new AuthenticationCredentialsNotFoundException("Authorization header is missing");
+        }
+
+        if (!authHeader.startsWith(BEARER_PREFIX)) {
+            throw new BadCredentialsException("Authorization header must start with 'Bearer '");
+        }
+
+        String token = authHeader.substring(BEARER_PREFIX.length()).trim();
+        if (!StringUtils.hasText(token)) {
+            throw new BadCredentialsException("JWT token is empty");
+        }
+
+        if (!jwtUtil.validateToken(token)) {
+            throw new BadCredentialsException("JWT token is invalid or expired");
+        }
+
+        String loginId = jwtUtil.getUsernameFromToken(token);
+        log.debug("Extracted loginId {} from JWT for WebSocket", loginId);
+
+        try {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+
+            UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            accessor.setUser(authentication);
+
+            log.info("✅ WebSocket authentication successful for user: {}", loginId);
+        } catch (UsernameNotFoundException ex) {
+            throw new BadCredentialsException("User not found for WebSocket authentication");
+        }
+    }
+
+    private void propagateAuthentication(StompHeaderAccessor accessor) {
+        Authentication current = SecurityContextHolder.getContext().getAuthentication();
+        if (current != null) {
             return;
         }
-        
-        String token = authHeader.substring(BEARER_PREFIX.length());
-        log.debug("Extracted JWT token for WebSocket authentication");
-        
-        try {
-            if (jwtUtil.validateToken(token)) {
-                String loginId = jwtUtil.getUsernameFromToken(token);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
-                
-                UsernamePasswordAuthenticationToken authentication = 
-                    new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-                        
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                accessor.setUser(authentication);
-                
-                log.info("✅ WebSocket authentication successful for user: {}", loginId);
-            } else {
-                log.warn("❌ Invalid JWT token for WebSocket connection");
-            }
-        } catch (Exception e) {
-            log.error("❌ Error during WebSocket authentication: {}", e.getMessage());
-            // 예외가 발생해도 연결은 허용 (테스트 환경)
+
+        if (accessor.getUser() instanceof Authentication authentication) {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.trace("Propagated WebSocket authentication for user {}", authentication.getName());
         }
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebSocketSecurityConfig.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebSocketSecurityConfig.java
@@ -18,15 +18,14 @@ public class WebSocketSecurityConfig {
         messages
             // 애플리케이션 메시지는 인증 필요
             .simpDestMatchers("/app/**").authenticated()
-            // Topic과 Queue 구독은 인증 필요 (단, 더 관대하게 설정)
-            .simpDestMatchers("/topic/**", "/queue/**").permitAll()
+            // 사용자별 큐와 일반 토픽은 인증 필요
+            .simpDestMatchers("/topic/**", "/queue/**", "/user/**").authenticated()
             // 연결, 심박, 구독 해제, 연결 해제는 허용
             .simpTypeMatchers(
-                SimpMessageType.CONNECT, 
-                SimpMessageType.HEARTBEAT, 
-                SimpMessageType.UNSUBSCRIBE, 
-                SimpMessageType.DISCONNECT,
-                SimpMessageType.SUBSCRIBE  // 구독도 허용
+                SimpMessageType.CONNECT,
+                SimpMessageType.HEARTBEAT,
+                SimpMessageType.UNSUBSCRIBE,
+                SimpMessageType.DISCONNECT
             ).permitAll()
             // 나머지는 인증 필요 (denyAll에서 변경)
             .anyMessage().authenticated();

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -85,32 +85,66 @@ const roomId = ref(null)
 let stompClient = null
 const connectionAttempts = ref(0)
 const maxConnectionAttempts = 3
+const isConnecting = ref(false)
+const subscriptions = []
+let reconnectTimer = null
 
 onMounted(async () => {
   await setupWebSocket()
 })
 
-async function setupWebSocket() {
-  const token = localStorage.getItem('token')
+async function setupWebSocket(forceReconnect = false) {
+  const token = auth.token || localStorage.getItem('token')
   if (!token) {
     console.error('JWT token not found')
     router.push('/login')
     return
   }
 
+  if (stompClient?.connected && !forceReconnect) {
+    console.log('🔁 WebSocket is already connected, skip re-initialization')
+    return
+  }
+
+  if (isConnecting.value) {
+    console.log('⏳ WebSocket connection is in progress, skip duplicate attempt')
+    return
+  }
+
+  isConnecting.value = true
+
+  if (stompClient) {
+    try {
+      await stompClient.deactivate()
+    } catch (deactivateError) {
+      console.warn('⚠️ Failed to deactivate previous STOMP client:', deactivateError)
+    }
+  }
+
   console.log('Setting up WebSocket connection...')
   stompClient = createStompClient(token)
-  
+
   stompClient.onConnect = (frame) => {
     console.log('✅ Connected to WebSocket for matching results')
     console.log('Connection frame:', frame)
+    isConnecting.value = false
     connectionAttempts.value = 0
-    
+
+    // 구독 중복 방지
+    subscriptions.forEach((subscription) => {
+      try {
+        subscription.unsubscribe()
+      } catch (unsubscribeError) {
+        console.warn('⚠️ Failed to clean up old subscription', unsubscribeError)
+      }
+    })
+    subscriptions.length = 0
+
     try {
       // 매칭 결과 구독 - 더 안전한 방식으로 구독
-      const subscription = stompClient.subscribe('/user/queue/match-results', (message) => {
+      const matchResultSubscription = stompClient.subscribe('/user/queue/match-results', (message) => {
         console.log('📨 Received match result:', message.body)
-        
+
         try {
           const matchResult = JSON.parse(message.body)
           handleMatchResult(matchResult)
@@ -121,9 +155,10 @@ async function setupWebSocket() {
         // 구독 헤더에 토큰 추가 (필요한 경우)
         'Authorization': `Bearer ${token}`
       })
-      
+
       console.log('✅ Subscribed to /user/queue/match-results')
-      
+      subscriptions.push(matchResultSubscription)
+
       // 테스트용 공통 토픽도 구독 (매칭 상대가 없을 때 테스트용)
       const testSubscription = stompClient.subscribe('/topic/match-results', (message) => {
         console.log('📨 Received test match result:', message.body)
@@ -134,18 +169,21 @@ async function setupWebSocket() {
           console.error('❌ Error parsing test match result:', error)
         }
       })
-      
+      subscriptions.push(testSubscription)
+
       // 대기 상태 알림 구독
       const statusSubscription = stompClient.subscribe('/topic/match-status', (message) => {
         console.log('📋 Received match status:', message.body)
         sessionStatus.value = message.body || '매칭 대기 중...'
       })
-      
+      subscriptions.push(statusSubscription)
+
       const userStatusSubscription = stompClient.subscribe('/user/queue/match-status', (message) => {
         console.log('📋 Received user match status:', message.body)
         sessionStatus.value = message.body || '매칭 대기 중...'
       })
-      
+      subscriptions.push(userStatusSubscription)
+
     } catch (subscribeError) {
       console.error('❌ Subscription error:', subscribeError)
     }
@@ -155,18 +193,17 @@ async function setupWebSocket() {
     console.error('❌ STOMP error:', frame.headers?.message || 'Unknown error')
     console.error('Details:', frame.body)
     console.error('Full frame:', frame)
-    
-    // 연결 재시도
-    if (connectionAttempts.value < maxConnectionAttempts) {
-      setTimeout(() => {
-        connectionAttempts.value++
-        console.log(`🔄 Retrying WebSocket connection (${connectionAttempts.value}/${maxConnectionAttempts})`)
-        setupWebSocket()
-      }, 2000)
-    } else {
-      console.error('❌ Max connection attempts reached')
-      alert('매칭 서버 연결에 실패했습니다. 페이지를 새로고침해주세요.')
+    isConnecting.value = false
+
+    const errorMessage = frame.headers?.message || ''
+    if (errorMessage.toLowerCase().includes('unauthorized') || errorMessage.toLowerCase().includes('forbidden')) {
+      auth.logout()
+      alert('세션이 만료되었거나 인증 정보가 올바르지 않습니다. 다시 로그인해 주세요.')
+      router.push('/login')
+      return
     }
+
+    scheduleReconnect()
   }
 
   stompClient.onWebSocketError = (event) => {
@@ -175,6 +212,10 @@ async function setupWebSocket() {
 
   stompClient.onWebSocketClose = (event) => {
     console.log('🔌 WebSocket connection closed:', event)
+    isConnecting.value = false
+    if (!event.wasClean) {
+      scheduleReconnect()
+    }
   }
 
   // 연결 전 디버그 정보
@@ -187,7 +228,29 @@ async function setupWebSocket() {
     console.log('🚀 WebSocket activation initiated')
   } catch (error) {
     console.error('❌ Failed to activate WebSocket:', error)
+    isConnecting.value = false
+    scheduleReconnect()
   }
+}
+
+function scheduleReconnect() {
+  if (connectionAttempts.value >= maxConnectionAttempts) {
+    console.error('❌ Max connection attempts reached')
+    alert('매칭 서버 연결에 실패했습니다. 페이지를 새로고침해주세요.')
+    return
+  }
+
+  if (reconnectTimer) {
+    console.log('⏳ Reconnect already scheduled, skip new timer')
+    return
+  }
+
+  connectionAttempts.value++
+  console.log(`🔄 Retrying WebSocket connection (${connectionAttempts.value}/${maxConnectionAttempts})`)
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    setupWebSocket(true)
+  }, 2000)
 }
 
 function handleMatchResult(matchResult) {
@@ -222,10 +285,28 @@ function declineMatch() {
   }
 }
 
-onBeforeUnmount(() => {
-  if (stompClient && stompClient.connected) {
-    stompClient.deactivate()
-    console.log('🔌 Disconnected from WebSocket')
+onBeforeUnmount(async () => {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+
+  subscriptions.forEach((subscription) => {
+    try {
+      subscription.unsubscribe()
+    } catch (error) {
+      console.warn('⚠️ Failed to unsubscribe during cleanup', error)
+    }
+  })
+  subscriptions.length = 0
+
+  if (stompClient) {
+    try {
+      await stompClient.deactivate()
+      console.log('🔌 Disconnected from WebSocket')
+    } catch (error) {
+      console.warn('⚠️ Failed to cleanly deactivate STOMP client', error)
+    }
   }
 })
 </script>


### PR DESCRIPTION
## Summary
- enforce strict JWT validation in the STOMP channel interceptor and propagate the authenticated user across frames
- tighten WebSocket authorization rules so topic/queue destinations require an authenticated principal
- harden the matching result view’s STOMP client with guarded reconnect logic and graceful handling of unauthorized errors

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d501e22ae88325ba7ac0bd620bb1cc