### PR TITLE
Fix signaling guards and SDP readiness

### DIFF
--- a/frontend/src/services/signaling.js
+++ b/frontend/src/services/signaling.js
@@ -24,6 +24,8 @@ export function setupSignalRoutes(
     const payload = parseBody(msg)
     if (payload) {
       onSignal?.(payload)
+    } else {
+      console.warn('[signaling] Received empty signaling payload. Ignored.')
     }
   })
   subscriptions.push(signalSubscription)
@@ -39,7 +41,18 @@ export function setupSignalRoutes(
   subscriptions.push(errorSubscription)
 
   function sendSignal(signal = {}) {
-    const payload = { senderLoginId: me, ...signal }
+    const { receiverLoginId, data, ...rest } = signal || {}
+    const payload = { senderLoginId: me, ...rest }
+    if (receiverLoginId !== undefined) {
+      payload.receiverLoginId = receiverLoginId
+    }
+    if (data !== undefined) {
+      payload.data = data
+    }
+    if (!payload.receiverLoginId) {
+      console.error('[signaling] receiverLoginId is required but missing. Signal not sent.')
+      return
+    }
     client.publish({
       destination: '/app/signal',
       body: JSON.stringify(payload),

--- a/frontend/src/views/MatchSession.vue
+++ b/frontend/src/views/MatchSession.vue
@@ -564,13 +564,20 @@ async function ensurePeerConnection() {
         }
       }
       pc.onicecandidate = (event) => {
-        if (event.candidate && signalRoute) {
-          signalRoute.sendSignal({
-            type: 'ice-candidate',
-            receiverLoginId: matchStore.partnerLoginId,
-            data: event.candidate,
-          })
+        if (!event.candidate || !signalRoute) {
+          // null 후보는 ICE 수집 종료 신호이므로 전송하지 않는다.
+          return
         }
+        const receiverId = matchStore.partnerLoginId
+        if (!receiverId) {
+          console.error('[match-session] Cannot send ICE candidate without receiverLoginId')
+          return
+        }
+        signalRoute.sendSignal({
+          type: 'ice-candidate',
+          receiverLoginId: receiverId,
+          data: event.candidate,
+        })
       }
       pc.oniceconnectionstatechange = () => {
         if (!pc) {
@@ -630,7 +637,7 @@ function scheduleIceRestart(reason) {
 }
 
 async function renegotiate({ iceRestart = false } = {}) {
-  if (!pc || !signalRoute || !matchStore.partnerLoginId) {
+  if (!pc || !signalRoute) {
     return
   }
   if (makingOffer.value) {
@@ -642,11 +649,20 @@ async function renegotiate({ iceRestart = false } = {}) {
     lastOffer.value = offer
     debugLog('create-offer', { offer, iceRestart })
     await pc.setLocalDescription(offer)
-    const description = pc.localDescription || offer
+    const localDescription = pc.localDescription
+    const receiverId = matchStore.partnerLoginId
+    if (!receiverId) {
+      console.error('[match-session] Cannot send offer without receiverLoginId')
+      return
+    }
+    if (!localDescription) {
+      console.error('[match-session] Local description missing while sending offer')
+      return
+    }
     signalRoute.sendSignal({
       type: 'offer',
-      receiverLoginId: matchStore.partnerLoginId,
-      data: description,
+      receiverLoginId: receiverId,
+      data: localDescription,
     })
     offerCreated.value = true
   } catch (error) {
@@ -686,11 +702,20 @@ async function handleSignal(message) {
       lastAnswer.value = answer
       debugLog('create-answer', answer)
       await pc.setLocalDescription(answer)
-      const description = pc.localDescription || answer
+      const localDescription = pc.localDescription
+      const receiverId = message.senderLoginId || matchStore.partnerLoginId
+      if (!receiverId) {
+        console.error('[match-session] Cannot send answer without receiverLoginId')
+        return
+      }
+      if (!localDescription) {
+        console.error('[match-session] Local description missing while sending answer')
+        return
+      }
       signalRoute?.sendSignal({
         type: 'answer',
-        receiverLoginId: matchStore.partnerLoginId,
-        data: description,
+        receiverLoginId: receiverId,
+        data: localDescription,
       })
       offerCreated.value = true
       ignoreOffer.value = false

--- a/frontend/src/views/RtcTest.vue
+++ b/frontend/src/views/RtcTest.vue
@@ -117,7 +117,18 @@ async function start () {
             await pc.setRemoteDescription(msg.data)
             const answer = await pc.createAnswer()
             await pc.setLocalDescription(answer)
-            signal.sendSignal({ type: 'answer', receiverLoginId: msg.senderLoginId, data: answer })
+            const localDescription = pc.localDescription
+            const receiverId = msg.senderLoginId || partner.value
+            // 수신자 또는 SDP가 비어 있으면 서버에서 거부되므로 전송하지 않는다.
+            if (!receiverId) {
+              console.error('[rtc-test] Cannot send answer without receiverLoginId')
+              return
+            }
+            if (!localDescription) {
+              console.error('[rtc-test] Local description missing while sending answer')
+              return
+            }
+            signal.sendSignal({ type: 'answer', receiverLoginId: receiverId, data: localDescription })
           } else if (msg.type === 'answer') {
             await pc.setRemoteDescription(msg.data)
           } else if (msg.type === 'ice-candidate') {
@@ -159,23 +170,40 @@ async function start () {
         if (remoteVideo.value) remoteVideo.value.srcObject = e.streams[0]
       }
       pc.onicecandidate = (e) => {
-        if (e.candidate) {
-          signal?.sendSignal?.({
-            type: 'ice-candidate',
-            receiverLoginId: partner.value,
-            data: e.candidate
-          })
+        if (!e.candidate) {
+          // null 후보는 ICE 수집이 완료되었음을 의미하므로 전송하지 않는다.
+          return
         }
+        const receiverId = partner.value
+        if (!receiverId) {
+          console.error('[rtc-test] Cannot send ICE candidate without receiverLoginId')
+          return
+        }
+        signal?.sendSignal?.({
+          type: 'ice-candidate',
+          receiverLoginId: receiverId,
+          data: e.candidate
+        })
       }
 
       // 7) 발신자면 offer 생성/전송
       if (isInitiator.value) {
         const offer = await pc.createOffer()
         await pc.setLocalDescription(offer)
+        const localDescription = pc.localDescription
+        const receiverId = partner.value
+        if (!receiverId) {
+          console.error('[rtc-test] Cannot send offer without receiverLoginId')
+          return
+        }
+        if (!localDescription) {
+          console.error('[rtc-test] Local description missing while sending offer')
+          return
+        }
         signal.sendSignal({
           type: 'offer',
-          receiverLoginId: partner.value,
-          data: offer
+          receiverLoginId: receiverId,
+          data: localDescription
         })
       }
     }


### PR DESCRIPTION
## Summary
- prevent WebRTC offer/answer/candidate messages from being sent without a receiver or populated SDP in RtcTest and MatchSession views
- ensure ICE end-of-candidates and missing partner IDs are handled safely in MatchSession
- harden signaling helper to drop undefined fields, require receiver IDs, and log empty payloads

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d5105e98c483259c3c4eebb5dbf9c3