### PR TITLE
Improve websocket auth failure handling

### DIFF
--- a/backend/src/main/java/net/datasa/project01/config/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/net/datasa/project01/config/JwtAccessDeniedHandler.java
@@ -1,0 +1,63 @@
+package net.datasa.project01.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Custom {@link AccessDeniedHandler} that writes a JSON payload when a request is
+ * rejected by Spring Security. This allows the frontend SockJS client to inspect
+ * the response body/reason phrase and decide whether a token refresh flow should
+ * be triggered.
+ */
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        if (response.isCommitted()) {
+            log.debug("Response already committed. Unable to write access denied body for path={}", request.getRequestURI());
+            return;
+        }
+
+        String message = accessDeniedException.getMessage();
+        if (!StringUtils.hasText(message)) {
+            message = "UNAUTHORIZED: Access denied";
+        }
+
+        log.warn("Access denied for path={} - message={}", request.getRequestURI(), message);
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader("X-Error-Code", "ACCESS_DENIED");
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", HttpStatus.FORBIDDEN.value());
+        body.put("error", "ACCESS_DENIED");
+        body.put("message", message);
+        body.put("path", request.getRequestURI());
+
+        OBJECT_MAPPER.writeValue(response.getWriter(), body);
+    }
+}
+

--- a/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final JwtAccessDeniedHandler accessDeniedHandler;
 
     /**
      * SecurityFilterChain 빈 등록
@@ -62,7 +63,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
-                .exceptionHandling(handler -> handler.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+                .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/net/datasa/project01/config/StompHandler.java
+++ b/backend/src/main/java/net/datasa/project01/config/StompHandler.java
@@ -27,6 +27,7 @@ public class StompHandler implements ChannelInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String UNAUTHORIZED_PREFIX = "UNAUTHORIZED: ";
     
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
@@ -48,25 +49,25 @@ public class StompHandler implements ChannelInterceptor {
 
         if (!StringUtils.hasText(authHeader)) {
             log.warn("STOMP CONNECT rejected: missing Authorization header. sessionId={}", accessor.getSessionId());
-            throw new AccessDeniedException("Authorization header가 누락된 WebSocket 연결입니다.");
+            throw new AccessDeniedException(UNAUTHORIZED_PREFIX + "Authorization header가 누락된 WebSocket 연결입니다.");
         }
 
         if (!authHeader.startsWith(BEARER_PREFIX)) {
             log.warn("STOMP CONNECT rejected: Authorization header is not Bearer. sessionId={}, header={}",
                     accessor.getSessionId(), authHeader);
-            throw new AccessDeniedException("Bearer 타입의 Authorization 헤더만 허용됩니다.");
+            throw new AccessDeniedException(UNAUTHORIZED_PREFIX + "Bearer 타입의 Authorization 헤더만 허용됩니다.");
         }
 
         String token = authHeader.substring(BEARER_PREFIX.length()).trim();
         if (!StringUtils.hasText(token)) {
             log.warn("STOMP CONNECT rejected: empty token after Bearer prefix. sessionId={}", accessor.getSessionId());
-            throw new AccessDeniedException("JWT 토큰이 비어 있습니다.");
+            throw new AccessDeniedException(UNAUTHORIZED_PREFIX + "JWT 토큰이 비어 있습니다.");
         }
 
         try {
             if (!jwtUtil.validateToken(token)) {
                 log.warn("STOMP CONNECT rejected: invalid JWT token. sessionId={}", accessor.getSessionId());
-                throw new AccessDeniedException("유효하지 않은 JWT 토큰입니다.");
+                throw new AccessDeniedException(UNAUTHORIZED_PREFIX + "유효하지 않은 JWT 토큰입니다.");
             }
 
             String loginId = jwtUtil.getUsernameFromToken(token);
@@ -87,7 +88,7 @@ public class StompHandler implements ChannelInterceptor {
             SecurityContextHolder.clearContext();
             log.warn("STOMP CONNECT rejected: authentication failure. sessionId={}, cause={}",
                     accessor.getSessionId(), e.getMessage(), e);
-            throw new AccessDeniedException("WebSocket 인증에 실패했습니다.", e);
+            throw new AccessDeniedException(UNAUTHORIZED_PREFIX + "WebSocket 인증에 실패했습니다.", e);
         }
     }
 

--- a/frontend/src/services/ws.js
+++ b/frontend/src/services/ws.js
@@ -188,7 +188,9 @@ export function createStompClient(options = {}) {
     const message = frame?.headers?.message || ''
     const body = frame?.body || ''
     const combined = `${message} ${body}`.toLowerCase()
-    const authError = /unauthor|forbidden|denied|expired/.test(combined)
+    const authError =
+      /unauthor|forbidden|denied|expired|access\s*denied/.test(combined) ||
+      /권한|만료|접근\s*거부/.test(`${message} ${body}`)
 
     if (typeof client.__userOnStompError === 'function') {
       try {
@@ -212,7 +214,13 @@ export function createStompClient(options = {}) {
   client.onWebSocketClose = async (event) => {
     const reason = `${event?.reason || ''}`.toLowerCase()
     const code = event?.code ?? 0
-    const authHint = reason.includes('401') || reason.includes('unauthor') || code === 4001
+    const authHint =
+      reason.includes('401') ||
+      reason.includes('403') ||
+      reason.includes('unauthor') ||
+      reason.includes('forbidden') ||
+      reason.includes('denied') ||
+      code === 4001
 
     if (typeof client.__userOnWebSocketClose === 'function') {
       try {


### PR DESCRIPTION
## Summary
- add a dedicated `JwtAccessDeniedHandler` that returns a JSON payload and logs when websocket auth is rejected
- augment the STOMP interceptor to emit `UNAUTHORIZED`-prefixed messages so clients can recognize auth failures
- broaden the frontend SockJS/STOMP client to treat 403/forbidden/denied reasons (including Korean messages) as auth errors and trigger token refresh

## Testing
- ./gradlew test *(fails: build cannot download dependencies from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d521d439cc8325b6cc45fdc036dce0