### PR TITLE
Gracefully handle missing optional configuration

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebConfig.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebConfig.java
@@ -16,11 +16,15 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final String[] allowedOrigins;
 
-    public WebConfig(@Value("${app.cors.allowed-origins}") String allowedOriginsProperty) {
+    public WebConfig(@Value("${app.cors.allowed-origins:*}") String allowedOriginsProperty) {
         this.allowedOrigins = Arrays.stream(allowedOriginsProperty.split(","))
                 .map(String::trim)
                 .filter(StringUtils::hasText)
                 .toArray(String[]::new);
+
+        if (this.allowedOrigins.length == 0) {
+            this.allowedOrigins = new String[] {"*"};
+        }
     }
 
     @Override

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/WebSocketConfig.java
@@ -31,13 +31,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     public WebSocketConfig(SessionHandshakeInterceptor sessionHandshakeInterceptor,
                            StompSecurityChannelInterceptor stompSecurityChannelInterceptor,
-                           @Value("${app.cors.allowed-origins}") String allowedOriginsProperty) {
+                           @Value("${app.cors.allowed-origins:*}") String allowedOriginsProperty) {
         this.sessionHandshakeInterceptor = sessionHandshakeInterceptor;
         this.stompSecurityChannelInterceptor = stompSecurityChannelInterceptor;
         this.allowedOrigins = Arrays.stream(allowedOriginsProperty.split(","))
                 .map(String::trim)
                 .filter(StringUtils::hasText)
                 .toArray(String[]::new);
+
+        if (this.allowedOrigins.length == 0) {
+            this.allowedOrigins = new String[] {"*"};
+        }
     }
 
     @Override

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/exception/FeatureUnavailableException.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/exception/FeatureUnavailableException.java
@@ -1,0 +1,15 @@
+package net.datasa.project01.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * 선택 기능이 비활성화된 경우 사용자가 명확한 응답을 받을 수 있도록 하는 예외입니다.
+ */
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class FeatureUnavailableException extends RuntimeException {
+
+    public FeatureUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/exception/GlobalExceptionHandler.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/exception/GlobalExceptionHandler.java
@@ -2,7 +2,8 @@ package net.datasa.project01.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
 
@@ -26,5 +27,10 @@ public class GlobalExceptionHandler {
                 ? fe.getField() + ": " + fe.getDefaultMessage()
                 : "요청이 올바르지 않습니다.";
         return ResponseEntity.badRequest().body(Map.of("message", msg));
+    }
+
+    @ExceptionHandler(FeatureUnavailableException.class)
+    public ResponseEntity<?> serviceUnavailable(FeatureUnavailableException e) {
+        return ResponseEntity.status(503).body(Map.of("message", e.getMessage()));
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/FileUploadPresignService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/FileUploadPresignService.java
@@ -2,6 +2,7 @@ package net.datasa.project01.service;
 
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.exception.FeatureUnavailableException;
 import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.RoomRepository;
 import net.datasa.project01.repository.UserRepository;
@@ -44,7 +45,7 @@ public class FileUploadPresignService {
                                                    String contentType,
                                                    long contentLength) {
         if (!StringUtils.hasText(baseUrl)) {
-            throw new IllegalStateException("파일 업로드 사전 서명을 위한 base-url이 설정되어 있지 않습니다.");
+            throw new FeatureUnavailableException("파일 업로드 사전 서명 기능이 비활성화되어 있습니다.");
         }
 
         if (contentLength <= 0) {

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/TranslationService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/TranslationService.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -17,17 +18,19 @@ import org.springframework.web.client.RestTemplate;
 public class TranslationService {
 
     // application.properties에 설정한 Papago API 인증 정보를 주입받습니다.
-    @Value("${papago.api.client-id}")
+    @Value("${papago.api.client-id:}")
     private String clientId;
 
-    @Value("${papago.api.client-secret}")
+    @Value("${papago.api.client-secret:}")
     private String clientSecret;
 
-    @Value("${papago.api.url}")
+    @Value("${papago.api.url:}")
     private String apiUrl;
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Object configLock = new Object();
+    private volatile boolean configurationWarned;
 
     /**
      * Papago API를 호출하여 텍스트를 번역합니다.
@@ -37,6 +40,11 @@ public class TranslationService {
      * @return 번역된 텍스트
      */
     public String translate(String text, String sourceLang, String targetLang) {
+        if (!isConfigured()) {
+            logConfigurationWarning();
+            return text;
+        }
+
         try {
             // 1. HTTP 요청 헤더 설정
             HttpHeaders headers = new HttpHeaders();
@@ -63,6 +71,23 @@ public class TranslationService {
         } catch (Exception e) {
             log.error("Papago API translation failed", e);
             return text; // 번역 실패 시 원본 텍스트를 그대로 반환
+        }
+    }
+
+    private boolean isConfigured() {
+        return StringUtils.hasText(clientId)
+                && StringUtils.hasText(clientSecret)
+                && StringUtils.hasText(apiUrl);
+    }
+
+    private void logConfigurationWarning() {
+        if (!configurationWarned) {
+            synchronized (configLock) {
+                if (!configurationWarned) {
+                    log.warn("Papago API 자격 증명이 설정되지 않아 번역 기능이 비활성화되었습니다.");
+                    configurationWarned = true;
+                }
+            }
         }
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/email/NoopEmailSender.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/email/NoopEmailSender.java
@@ -1,0 +1,19 @@
+package net.datasa.project01.service.email;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * 실제 메일 발송 설정이 존재하지 않을 때 기본으로 사용되는 더미 구현입니다.
+ */
+@Slf4j
+@Component
+@Profile("!db & !mock")
+public class NoopEmailSender implements EmailSender {
+
+    @Override
+    public void send(String to, String subject, String content) {
+        log.debug("메일 발송이 구성되지 않아 메시지를 저장하지 않았습니다. to={}, subject={}", to, subject);
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/translation/ExternalTranslateService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/translation/ExternalTranslateService.java
@@ -2,13 +2,14 @@ package net.datasa.project01.service.translation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.exception.FeatureUnavailableException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
@@ -38,7 +39,7 @@ public class ExternalTranslateService implements TranslateService {
     @Override
     public TranslationResult translate(String text, String sourceLang, String targetLang, @Nullable String context) {
         if (!StringUtils.hasText(baseUrl)) {
-            throw new IllegalStateException("번역 API 기본 URL이 설정되어 있지 않습니다.");
+            throw new FeatureUnavailableException("외부 번역 서비스가 비활성화되어 있습니다.");
         }
 
         try {


### PR DESCRIPTION
## Summary
- default CORS configuration now tolerates missing app.cors.allowed-origins values
- disable Papago and external translation integrations gracefully when credentials or endpoints are absent
- add a fallback email sender and user-facing errors for disabled optional features

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7937ce26483259fd72ce71113ecd1