### PR TITLE
Harden CSRF enforcement and secure support/admin flows

### DIFF
--- a/Matcha-Talk/README.md
+++ b/Matcha-Talk/README.md
@@ -48,11 +48,37 @@ export TRANSLATE_API_PROVIDER="generic"  # generic | deepl | google 등 중 택 
 - 키/비밀번호는 절대로 로그에 남기지 마세요.
 - 프로바이더 문자열은 백엔드 `TranslateService`에서 응답 파싱 로직을 선택하는 데 사용됩니다.
 
+### 이메일 발송
+```bash
+export SPRING_MAIL_HOST="smtp.gmail.com"
+export SPRING_MAIL_PORT="587"
+export SPRING_MAIL_USERNAME="your-account@example.com"
+export SPRING_MAIL_PASSWORD="app-password-or-token"
+```
+- Gmail 등 외부 SMTP 사용 시 2단계 인증 + 앱 비밀번호 사용을 권장합니다.
+- 개발 환경에서는 MailHog, Mailpit 등의 로컬 SMTP를 지정해도 됩니다.
+
+### Papago 번역
+```bash
+export PAPAGO_CLIENT_ID="your-naver-client-id"
+export PAPAGO_CLIENT_SECRET="your-naver-client-secret"
+export PAPAGO_API_URL="https://papago.apigw.ntruss.com/nmt/v1/translation"
+```
+- Papago를 사용하지 않는다면 `PAPAGO_CLIENT_ID`와 `PAPAGO_CLIENT_SECRET`를 비워두고 `TRANSLATE_API_PROVIDER`를 `generic` 등 다른 제공자로 설정하세요.
+
 ### 파일 업로드 사전 서명
 ```bash
 export FILE_PRESIGN_BASE_URL="https://uploader.example.com"
 ```
 - 브라우저는 `/api/rooms/{id}/files/presign` 응답으로 받은 URL에 직접 업로드합니다.
+
+### 세션 쿠키 플래그
+```bash
+export SERVER_SESSION_COOKIE_SECURE="true"     # HTTPS 배포 환경에서만 true
+export SERVER_SESSION_COOKIE_SAMESITE="None"   # 크로스 도메인에서 쿠키 전송이 필요할 때 조정
+```
+- 로컬 HTTP 개발 환경에서는 `SERVER_SESSION_COOKIE_SECURE`를 지정하지 않으면 기본값(`false`)이 적용되어 세션 쿠키가 전송됩니다.
+- 서로 다른 도메인에서 쿠키를 공유해야 한다면 `SameSite=None`과 함께 HTTPS(secure=true)를 반드시 사용하세요.
 
 환경 변수는 OS나 배포 플랫폼의 시크릿 매니저를 활용해 관리하고, `.env` 파일은 버전 관리 대상에서 제외하세요.
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/config/SecurityConfig.java
@@ -35,9 +35,6 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                        .ignoringRequestMatchers(
-                                "/api/**"
-                        )
                 )
                 .cors(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
@@ -45,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/login", "/api/auth/csrf", "/api/auth/find-id", "/api/auth/password-reset/**", "/api/users/signup", "/api/users/exists", "/api/users/email/**").permitAll()
                         .requestMatchers("/error", "/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/AdminController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/AdminController.java
@@ -2,9 +2,9 @@
 package net.datasa.project01.controller;
 
 import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.AdminUserResponse;
 import net.datasa.project01.domain.dto.InquiryResponse;
 import net.datasa.project01.domain.dto.ReportResponse;
-import net.datasa.project01.domain.entity.User;
 import net.datasa.project01.domain.entity.UserPenalty;
 import net.datasa.project01.service.AdminService;          // 사용자 관리(계정/잠금/권한/제재 조회)는 계속 AdminService 사용
 import net.datasa.project01.service.AdminSupportService;  // 문의/신고 전용 서비스
@@ -26,23 +26,23 @@ public class AdminController {
     // ============================================================
 
     @GetMapping("/users")
-    public List<User> searchUsers(@RequestParam(value = "q", required = false) String q) {
+    public List<AdminUserResponse> searchUsers(@RequestParam(value = "q", required = false) String q) {
         return adminService.searchUsers(q);
     }
 
     @PatchMapping("/users/{id}")
-    public User updateBasic(@PathVariable("id") Long userPid, @RequestBody UpdateReq req) {
+    public AdminUserResponse updateBasic(@PathVariable("id") Long userPid, @RequestBody UpdateReq req) {
         return adminService.updateUser(userPid, req.getNickName(), req.getEmail(), req.getRoleName());
     }
 
     @PostMapping("/users/{id}/lock")
-    public User lockUser(@PathVariable("id") Long userPid, @RequestBody LockReq req) {
+    public AdminUserResponse lockUser(@PathVariable("id") Long userPid, @RequestBody LockReq req) {
         long minutes = (req.getMinutes() <= 0 ? 10 : req.getMinutes());
         return adminService.lockUser(userPid, minutes);
     }
 
     @PatchMapping("/users/{id}/enable")
-    public User enableUser(@PathVariable("id") Long userPid, @RequestBody EnableReq req) {
+    public AdminUserResponse enableUser(@PathVariable("id") Long userPid, @RequestBody EnableReq req) {
         return adminService.setEnabled(userPid, req.isEnabled());
     }
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/SupportController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/SupportController.java
@@ -9,6 +9,7 @@ import net.datasa.project01.domain.dto.ReportCreateRequest;
 import net.datasa.project01.domain.dto.ReportResponse;
 import net.datasa.project01.service.SupportService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,33 +22,36 @@ public class SupportController {
     private final SupportService supportService;
 
     @PostMapping("/inquiries")
-    public ResponseEntity<InquiryResponse> createInquiry(@Valid @RequestBody InquiryCreateRequest req) {
+    public ResponseEntity<InquiryResponse> createInquiry(@AuthenticationPrincipal(expression = "username") String loginId,
+                                                         @Valid @RequestBody InquiryCreateRequest req) {
         InquiryResponse response = supportService.createInquiry(
-                req.getUserPid(), req.getCategory(), req.getTitle(), req.getContent());
+                loginId, req.getCategory(), req.getTitle(), req.getContent());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/inquiries")
-    public ResponseEntity<List<InquiryResponse>> myInquiries(@RequestParam("userPid") Long userPid) {
-        return ResponseEntity.ok(supportService.myInquiries(userPid));
+    public ResponseEntity<List<InquiryResponse>> myInquiries(@AuthenticationPrincipal(expression = "username") String loginId) {
+        return ResponseEntity.ok(supportService.myInquiries(loginId));
     }
 
     @PostMapping("/reports")
-    public ResponseEntity<ReportResponse> createReport(@Valid @RequestBody ReportCreateRequest req) {
+    public ResponseEntity<ReportResponse> createReport(@AuthenticationPrincipal(expression = "username") String loginId,
+                                                       @Valid @RequestBody ReportCreateRequest req) {
         ReportResponse response = supportService.createReport(
-                req.getReporterPid(), req.getReportedPid(), req.getReason(), req.getDetail());
+                loginId, req.getReportedPid(), req.getReason(), req.getDetail());
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/reports/by-login")
-    public ResponseEntity<ReportResponse> createReportByLogin(@Valid @RequestBody ReportCreateByLoginRequest req) {
+    public ResponseEntity<ReportResponse> createReportByLogin(@AuthenticationPrincipal(expression = "username") String loginId,
+                                                              @Valid @RequestBody ReportCreateByLoginRequest req) {
         ReportResponse response = supportService.createReportByLogin(
-                req.getReporterPid(), req.getReportedLoginId(), req.getReason(), req.getDetail());
+                loginId, req.getReportedLoginId(), req.getReason(), req.getDetail());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/reports")
-    public ResponseEntity<List<ReportResponse>> myReports(@RequestParam("reporterPid") Long reporterPid) {
-        return ResponseEntity.ok(supportService.myReports(reporterPid));
+    public ResponseEntity<List<ReportResponse>> myReports(@AuthenticationPrincipal(expression = "username") String loginId) {
+        return ResponseEntity.ok(supportService.myReports(loginId));
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/AdminUserResponse.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/AdminUserResponse.java
@@ -1,0 +1,40 @@
+package net.datasa.project01.domain.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Value;
+import net.datasa.project01.domain.entity.User;
+
+@Value
+@Builder
+public class AdminUserResponse {
+    Long userPid;
+    String loginId;
+    String email;
+    String nickName;
+    String roleName;
+    boolean enabled;
+    LocalDateTime lockedUntil;
+    Integer failedLoginCount;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+
+    public static AdminUserResponse of(User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("user is required");
+        }
+        return AdminUserResponse.builder()
+                .userPid(user.getUserPid())
+                .loginId(user.getLoginId())
+                .email(user.getEmail())
+                .nickName(user.getNickName())
+                .roleName(user.getRoleName())
+                .enabled(user.isEnabled())
+                .lockedUntil(user.getLockedUntil())
+                .failedLoginCount(user.getFailedLoginCount())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/InquiryCreateRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/InquiryCreateRequest.java
@@ -1,14 +1,12 @@
 package net.datasa.project01.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class InquiryCreateRequest {
-    @NotNull private Long userPid;
     @NotBlank @Size(max=30)  private String category;
     @NotBlank @Size(max=200) private String title;
     @NotBlank               private String content;

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ReportCreateByLoginRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ReportCreateByLoginRequest.java
@@ -1,15 +1,11 @@
 package net.datasa.project01.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class ReportCreateByLoginRequest {
-    @NotNull
-    private Long reporterPid;        // 신고자 PID (로그인 사용자)
-
     @NotBlank
     private String reportedLoginId;  // ✅ 피신고자 로그인 아이디
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ReportCreateRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ReportCreateRequest.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 
 @Getter @Setter
 public class ReportCreateRequest {
-    @NotNull private Long reporterPid;          // 신고자
     @NotNull private Long reportedPid;          // 피신고자 (DDL과 일치)
     @NotBlank @Size(max = 100) private String reason;
     @Size(max = 4000) private String detail;

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/AdminService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/AdminService.java
@@ -1,6 +1,7 @@
 package net.datasa.project01.service;
 
 import lombok.RequiredArgsConstructor;
+import net.datasa.project01.domain.dto.AdminUserResponse;
 import net.datasa.project01.domain.dto.InquiryResponse;
 import net.datasa.project01.domain.dto.ReportResponse;
 import net.datasa.project01.domain.entity.User;
@@ -31,22 +32,25 @@ public class AdminService {
      * 사용자 관리
      * ============================== */
     @Transactional(readOnly = true)
-    public List<User> searchUsers(String keyword) {
+    public List<AdminUserResponse> searchUsers(String keyword) {
         final String term = keyword == null ? "" : keyword.trim();
         return userRepository
-                .findTop100ByLoginIdContainingIgnoreCaseOrEmailContainingIgnoreCaseOrderByCreatedAtDesc(term, term);
+                .findTop100ByLoginIdContainingIgnoreCaseOrEmailContainingIgnoreCaseOrderByCreatedAtDesc(term, term)
+                .stream()
+                .map(AdminUserResponse::of)
+                .toList();
     }
 
-    public User lockUser(Long userPid, long minutes) {
+    public AdminUserResponse lockUser(Long userPid, long minutes) {
         User user = userRepository.findById(userPid)
                 .orElseThrow(() -> new IllegalArgumentException("user not found"));
         long min = Math.max(1, minutes);
         user.setLockedUntil(LocalDateTime.now().plusMinutes(min));
         user.setFailedLoginCount(0);
-        return userRepository.save(user);
+        return AdminUserResponse.of(userRepository.save(user));
     }
 
-    public User setEnabled(Long userPid, boolean enabled) {
+    public AdminUserResponse setEnabled(Long userPid, boolean enabled) {
         User user = userRepository.findById(userPid)
                 .orElseThrow(() -> new IllegalArgumentException("user not found"));
         user.setEnabled(enabled);
@@ -54,10 +58,10 @@ public class AdminService {
             user.setLockedUntil(null);
             user.setFailedLoginCount(0);
         }
-        return userRepository.save(user);
+        return AdminUserResponse.of(userRepository.save(user));
     }
 
-    public User updateUser(Long userPid, String nickName, String email, String roleName) {
+    public AdminUserResponse updateUser(Long userPid, String nickName, String email, String roleName) {
         User user = userRepository.findById(userPid)
                 .orElseThrow(() -> new IllegalArgumentException("user not found"));
         if (nickName != null && !nickName.isBlank()) {
@@ -69,7 +73,7 @@ public class AdminService {
         if (roleName != null && !roleName.isBlank()) {
             user.setRoleName(roleName.trim());
         }
-        return userRepository.save(user);
+        return AdminUserResponse.of(userRepository.save(user));
     }
 
     @Transactional(readOnly = true)

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/SupportService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/SupportService.java
@@ -26,9 +26,8 @@ public class SupportService {
     /* ==============================
      * 문의 등록/조회
      * ============================== */
-    public InquiryResponse createInquiry(Long userPid, String category, String title, String content) {
-        User user = userRepository.findById(userPid)
-                .orElseThrow(() -> new IllegalArgumentException("user not found"));
+    public InquiryResponse createInquiry(String loginId, String category, String title, String content) {
+        User user = requireUser(loginId);
 
         String normCategory = category == null ? "" : category.trim().toUpperCase();
         if (normCategory.isEmpty()) {
@@ -48,8 +47,9 @@ public class SupportService {
     }
 
     @Transactional(readOnly = true)
-    public List<InquiryResponse> myInquiries(Long userPid) {
-        return inquiryRepository.findTop200ByUser_UserPidOrderByInquiryIdDesc(userPid)
+    public List<InquiryResponse> myInquiries(String loginId) {
+        User user = requireUser(loginId);
+        return inquiryRepository.findTop200ByUser_UserPidOrderByInquiryIdDesc(user.getUserPid())
                 .stream()
                 .map(InquiryResponse::of)
                 .toList();
@@ -58,16 +58,15 @@ public class SupportService {
     /* ==============================
      * 신고 등록/조회
      * ============================== */
-    public ReportResponse createReport(Long reporterPid, Long reportedPid, String reason, String detail) {
-        if (reporterPid == null || reportedPid == null) {
-            throw new IllegalArgumentException("reporter/reported is required");
+    public ReportResponse createReport(String reporterLoginId, Long reportedPid, String reason, String detail) {
+        if (reportedPid == null) {
+            throw new IllegalArgumentException("reportedPid is required");
         }
-        if (reporterPid.equals(reportedPid)) {
+        User reporter = requireUser(reporterLoginId);
+        if (reporter.getUserPid().equals(reportedPid)) {
             throw new IllegalArgumentException("cannot report yourself");
         }
 
-        User reporter = userRepository.findById(reporterPid)
-                .orElseThrow(() -> new IllegalArgumentException("reporter not found"));
         User reported = userRepository.findById(reportedPid)
                 .orElseThrow(() -> new IllegalArgumentException("reported user not found"));
 
@@ -88,17 +87,13 @@ public class SupportService {
         return ReportResponse.of(saved);
     }
 
-    public ReportResponse createReportByLogin(Long reporterPid, String reportedLoginId, String reason, String detail) {
-        if (reporterPid == null) {
-            throw new IllegalArgumentException("reporterPid is required");
-        }
+    public ReportResponse createReportByLogin(String reporterLoginId, String reportedLoginId, String reason, String detail) {
         String loginId = reportedLoginId == null ? "" : reportedLoginId.trim();
         if (loginId.isEmpty()) {
             throw new IllegalArgumentException("reportedLoginId is required");
         }
 
-        User reporter = userRepository.findById(reporterPid)
-                .orElseThrow(() -> new IllegalArgumentException("reporter not found"));
+        User reporter = requireUser(reporterLoginId);
         User reported = userRepository.findByLoginId(loginId.toLowerCase())
                 .orElseThrow(() -> new IllegalArgumentException("reported user not found"));
 
@@ -124,10 +119,19 @@ public class SupportService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReportResponse> myReports(Long reporterPid) {
-        return reportRepository.findTop200ByReporter_UserPidOrderByReportIdDesc(reporterPid)
+    public List<ReportResponse> myReports(String reporterLoginId) {
+        User reporter = requireUser(reporterLoginId);
+        return reportRepository.findTop200ByReporter_UserPidOrderByReportIdDesc(reporter.getUserPid())
                 .stream()
                 .map(ReportResponse::of)
                 .toList();
+    }
+
+    private User requireUser(String loginId) {
+        if (loginId == null || loginId.isBlank()) {
+            throw new IllegalStateException("login is required");
+        }
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("user not found"));
     }
 }

--- a/Matcha-Talk/backend/src/main/resources/application-db.properties
+++ b/Matcha-Talk/backend/src/main/resources/application-db.properties
@@ -15,15 +15,16 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # Email Configuration (Moved from .env)
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
-spring.mail.username=cheonsanghun99@gmail.com
-spring.mail.password=irix kzpl meit bqpt
+spring.mail.host=${SPRING_MAIL_HOST:}
+spring.mail.port=${SPRING_MAIL_PORT:587}
+spring.mail.username=${SPRING_MAIL_USERNAME:}
+spring.mail.password=${SPRING_MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+spring.mail.properties.mail.smtp.ssl.trust=${SPRING_MAIL_HOST:}
 
 # App Mail Token Configuration (Moved from .env)
 app.mail.token.exp-seconds=600
 app.mail.token.cooldown-seconds=60
 app.mail.token.length=6
+

--- a/Matcha-Talk/backend/src/main/resources/application.properties
+++ b/Matcha-Talk/backend/src/main/resources/application.properties
@@ -32,10 +32,10 @@ spring.data.redis.port=${REDIS_PORT:6379}
 ############################################
 # 메일 (환경 변수 기반)
 ############################################
-spring.mail.host=${SPRING_MAIL_HOST:smtp.gmail.com}
+spring.mail.host=${SPRING_MAIL_HOST:}
 spring.mail.port=${SPRING_MAIL_PORT:587}
-spring.mail.username=${SPRING_MAIL_USERNAME:cheonsanghun99@gmail.com}
-spring.mail.password=${SPRING_MAIL_PASSWORD:irix kzpl meit bqpt}
+spring.mail.username=${SPRING_MAIL_USERNAME:}
+spring.mail.password=${SPRING_MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
@@ -60,8 +60,8 @@ spring.websocket.servlet.sockjs.disconnect.delay=5000
 server.port=8080
 server.servlet.context-path=/
 server.servlet.session.cookie.http-only=true
-server.servlet.session.cookie.secure=true
-server.servlet.session.cookie.same-site=None
+server.servlet.session.cookie.secure=${SERVER_SESSION_COOKIE_SECURE:false}
+server.servlet.session.cookie.same-site=${SERVER_SESSION_COOKIE_SAMESITE:Lax}
 
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=never
@@ -79,15 +79,15 @@ logging.level.org.springframework.security=DEBUG
 # 커스텀 설정
 ############################################
 webrtc.ice.urls=${METERED_TURN_URLS:}
-webrtc.ice.username=${METERED_TURN_USERNAME:1ef2a88d0379a8048e08c767}
-webrtc.ice.credential=${METERED_TURN_CREDENTIAL:Lj1tozp0QAevEsUd}
+webrtc.ice.username=${METERED_TURN_USERNAME:}
+webrtc.ice.credential=${METERED_TURN_CREDENTIAL:}
 
 translate.base-url=${TRANSLATE_API_BASE_URL:}
 translate.api-key=${TRANSLATE_API_KEY:}
 translate.provider=${TRANSLATE_API_PROVIDER:generic}
 
-papago.api.client-id=${PAPAGO_CLIENT_ID:ad6blrzhn1}
-papago.api.client-secret=${PAPAGO_CLIENT_SECRET:M4cfGKq0SQ72VrxW72Kedg7UpB4WN9JjQeuMvgoY}
+papago.api.client-id=${PAPAGO_CLIENT_ID:}
+papago.api.client-secret=${PAPAGO_CLIENT_SECRET:}
 papago.api.url=${PAPAGO_API_URL:https://papago.apigw.ntruss.com/nmt/v1/translation}
 
 jwt.secret=${JWT_SECRET:}

--- a/Matcha-Talk/frontend/src/services/support.js
+++ b/Matcha-Talk/frontend/src/services/support.js
@@ -1,10 +1,13 @@
 import api from './api'
 
 export const supportApi = {
-  createInquiry: (payload) => api.post('/support/inquiries', payload),
-  myInquiries:   (userPid)  => api.get('/support/inquiries', { params: { userPid } }),
+  createInquiry: ({ category, title, content }) =>
+    api.post('/support/inquiries', { category, title, content }),
+  myInquiries:   () => api.get('/support/inquiries'),
 
-  createReport:        (payload) => api.post('/support/reports', payload),              // 기존 PID 방식
-  createReportByLogin: (payload) => api.post('/support/reports/by-login', payload),    // ✅ 아이디 방식
-  myReports:     (reporterPid) => api.get('/support/reports', { params: { reporterPid } }),
+  createReport: ({ reportedPid, reason, detail }) =>
+    api.post('/support/reports', { reportedPid, reason, detail }),
+  createReportByLogin: ({ reportedLoginId, reason, detail }) =>
+    api.post('/support/reports/by-login', { reportedLoginId, reason, detail }),
+  myReports: () => api.get('/support/reports'),
 }

--- a/Matcha-Talk/frontend/src/views/SupportInquiry.vue
+++ b/Matcha-Talk/frontend/src/views/SupportInquiry.vue
@@ -82,7 +82,7 @@ function pretty(dt){ return dt?.replace('T',' ').slice(0,19) ?? '-' }
 /** 내 문의 목록 로드 */
 async function loadMy(){
   if(!mePid.value) return
-  const { data } = await supportApi.myInquiries(mePid.value)
+  const { data } = await supportApi.myInquiries()
   myList.value = data
 }
 watch(mePid, loadMy, { immediate: true })
@@ -102,8 +102,11 @@ async function submit(){
   loading.value = true; message.value=''; error.value=''
   try{
     // 🔥 userPid는 UI 없이 내부에서 주입
-    const payload = { userPid: mePid.value, category: category.value, title: title.value, content: content.value }
-    await supportApi.createInquiry(payload)
+    await supportApi.createInquiry({
+      category: category.value,
+      title: title.value,
+      content: content.value,
+    })
     message.value = '문의가 접수되었습니다.'
     reset()
     await loadMy()

--- a/Matcha-Talk/frontend/src/views/SupportReport.vue
+++ b/Matcha-Talk/frontend/src/views/SupportReport.vue
@@ -101,7 +101,7 @@ async function loadMy() {
   if (!mePid.value) return
   loadMyError.value = false
   try {
-    const { data } = await supportApi.myReports(mePid.value)
+    const { data } = await supportApi.myReports()
     myReportsList.value = Array.isArray(data) ? data : []
   } catch { loadMyError.value = true }
 }
@@ -114,10 +114,9 @@ async function submit() {
   loading.value = true; error.value = ''; message.value = ''
   try {
     await supportApi.createReportByLogin({
-      reporterPid: mePid.value,
       reportedLoginId: reportedLoginId.value.trim(),
       reason: reason.value.trim(),
-      detail: (detail.value || '').trim() || null
+      detail: (detail.value || '').trim() || null,
     })
     message.value = '신고가 접수되었습니다.'
     reset()


### PR DESCRIPTION
## Summary
- enforce CSRF protection across API routes while restricting /api/admin/** to ADMIN role only
- return sanitized AdminUserResponse DTOs from admin endpoints and require session identity in support APIs
- strip committed secrets from properties, document new environment toggles, and update frontend support flows to stop sending user IDs

## Testing
- `./gradlew test` *(fails: Gradle toolchain could not download Java 17 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7981b561c8325b8c5f8bf4f1f406c