### PR TITLE
Enhance random matching and enrich chat media features

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -5,13 +5,19 @@ import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.RoomDetailResponseDto;
 import net.datasa.project01.domain.dto.RoomCreateResponseDto;
 import net.datasa.project01.domain.dto.RoomListResponseDto;
+import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.service.ChatService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -78,6 +84,52 @@ public class ChatController {
         } catch (IllegalArgumentException e) {
             log.warn("Access denied or not found for room ID: {} by user '{}'", roomId, userDetails.getUsername());
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build(); // 혹은 403 Forbidden
+        }
+    }
+
+    @PostMapping("/{roomId}/attachments")
+    public ResponseEntity<ChatMessageResponseDto> uploadAttachment(
+            @PathVariable Long roomId,
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            String loginId = userDetails.getUsername();
+            ChatMessageResponseDto responseDto = chatService.saveAttachment(roomId, file, loginId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        } catch (IllegalArgumentException exception) {
+            log.warn("Attachment upload rejected: {}", exception.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (IOException exception) {
+            log.error("Failed to store attachment for room {}", roomId, exception);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/{roomId}/attachments/{messageId}")
+    public ResponseEntity<Resource> downloadAttachment(
+            @PathVariable Long roomId,
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            String loginId = userDetails.getUsername();
+            ChatService.AttachmentResource attachment = chatService.loadAttachment(roomId, messageId, loginId);
+
+            String fileName = attachment.fileName() != null ? attachment.fileName() : "attachment";
+            String contentDisposition = "attachment; filename=\"" + fileName + "\"";
+            MediaType mediaType = attachment.mimeType() != null
+                    ? MediaType.parseMediaType(attachment.mimeType())
+                    : MediaType.APPLICATION_OCTET_STREAM;
+
+            return ResponseEntity.ok()
+                    .contentType(mediaType)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
+                    .body(attachment.resource());
+        } catch (IllegalArgumentException exception) {
+            log.warn("Attachment download rejected: {}", exception.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (IOException exception) {
+            log.error("Failed to read attachment {} in room {}", messageId, roomId, exception);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -12,5 +12,10 @@ public class ChatMessageResponseDto {
     private final String senderNickName;
     private final String senderLanguageCode; // 발신자의 언어 코드
     private final String content;
+    private final String contentType;
+    private final String fileName;
+    private final String fileUrl;
+    private final String mimeType;
+    private final Long sizeBytes;
     private final LocalDateTime sentAt;
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -18,9 +18,11 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user u " +
            "WHERE mr.status = :status " +
            "AND u.userPid <> :myPid " +
+           "AND (:regionCode IS NULL OR mr.regionCode = :regionCode) " +
            "ORDER BY mr.requestedAt ASC")
     List<MatchRequest> findPotentialMatches(
             @Param("myPid") Long myPid,
-            @Param("status") MatchRequest.MatchStatus status
+            @Param("status") MatchRequest.MatchStatus status,
+            @Param("regionCode") String regionCode
     );
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -13,11 +13,23 @@ import net.datasa.project01.repository.UserRepository;
 import net.datasa.project01.domain.dto.ChatMessageRequestDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.entity.RoomMessage;
+import net.datasa.project01.websocket.RealTimeMessagingService;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
 
 import net.datasa.project01.domain.entity.Room.RoomType;
 
@@ -33,6 +45,9 @@ public class ChatService {
         private final UserRepository userRepository;
         private final RoomMessageRepository roomMessageRepository;
         private final TranslationService translationService;
+        private final RealTimeMessagingService messagingService;
+
+        private final Path attachmentBasePath = Paths.get("uploads", "attachments");
 
         // TODO: 알림 서비스 추가 (Push Notification)
         // private final NotificationService notificationService;
@@ -76,24 +91,15 @@ public class ChatService {
                 Room room = roomRepository.findById(requestDto.getRoomId())
                         .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
 
-                // 1. 원본 메시지를 DB에 저장
-                RoomMessage message = RoomMessage.builder()
-                        .room(room)
-                        .sender(sender)
-                        .contentType(RoomMessage.ContentType.TEXT)
-                        .textContent(requestDto.getContent())
-                        .build();
-                roomMessageRepository.save(message);
-
-        // 2. [수정] 번역은 클라이언트에게 위임. 서버는 원본 메시지와 발신자 언어 코드만 전달
-        return ChatMessageResponseDto.builder()
-                .roomId(room.getRoomId())
-                .senderNickName(sender.getNickName())
-                .senderLanguageCode(sender.getLanguageCode()) // 발신자 언어 코드 추가
-                .content(message.getTextContent())
-                // .translatedContent(null) // 이 필드는 이제 존재하지 않으므로 제거합니다.
-                .sentAt(message.getCreatedAt())
+        RoomMessage message = RoomMessage.builder()
+                .room(room)
+                .sender(sender)
+                .contentType(RoomMessage.ContentType.TEXT)
+                .textContent(requestDto.getContent())
                 .build();
+        roomMessageRepository.save(message);
+
+        return toResponseDto(message);
         }
         @Transactional
         public Room createPrivateRoom(User user1, User user2) {
@@ -168,6 +174,130 @@ public class ChatService {
                         .map(User::getLoginId)
                         .toList();
         }
+
+        @Transactional
+        public ChatMessageResponseDto saveAttachment(Long roomId, MultipartFile file, String loginId) throws IOException {
+                if (file == null || file.isEmpty()) {
+                        throw new IllegalArgumentException("업로드할 파일이 존재하지 않습니다.");
+                }
+
+                User sender = userRepository.findByLoginId(loginId)
+                        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                Room room = roomRepository.findById(roomId)
+                        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+                roomMemberRepository.findByRoomAndUser(room, sender)
+                        .orElseThrow(() -> new IllegalArgumentException("채팅방에 속한 사용자만 파일을 전송할 수 있습니다."));
+
+                Path uploadDir = ensureUploadDirectory(roomId);
+
+                String originalName = StringUtils.hasText(file.getOriginalFilename())
+                        ? file.getOriginalFilename()
+                        : "attachment";
+                String extension = "";
+                int dotIndex = originalName.lastIndexOf('.');
+                if (dotIndex > -1 && dotIndex < originalName.length() - 1) {
+                        extension = originalName.substring(dotIndex);
+                }
+
+                String storedName = UUID.randomUUID() + extension;
+                Path storedPath = uploadDir.resolve(storedName);
+                Files.copy(file.getInputStream(), storedPath, StandardCopyOption.REPLACE_EXISTING);
+
+                RoomMessage.ContentType contentType = determineContentType(file.getContentType());
+                String placeholderText = contentType == RoomMessage.ContentType.IMAGE ? "이미지 첨부" : originalName;
+
+                RoomMessage message = RoomMessage.builder()
+                        .room(room)
+                        .sender(sender)
+                        .contentType(contentType)
+                        .textContent(placeholderText)
+                        .fileName(originalName)
+                        .filePath(storedPath.toString())
+                        .mimeType(file.getContentType())
+                        .sizeBytes(file.getSize())
+                        .build();
+                roomMessageRepository.save(message);
+
+                ChatMessageResponseDto response = toResponseDto(message);
+
+                messagingService.broadcastToUsers(
+                        findParticipantLoginIds(roomId),
+                        "chat",
+                        response
+                );
+
+                return response;
+        }
+
+        @Transactional(readOnly = true)
+        public AttachmentResource loadAttachment(Long roomId, Long messageId, String loginId) throws IOException {
+                User requester = userRepository.findByLoginId(loginId)
+                        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+                RoomMessage message = roomMessageRepository.findById(messageId)
+                        .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+
+                if (!message.getRoom().getRoomId().equals(roomId)) {
+                        throw new IllegalArgumentException("요청한 파일이 해당 채팅방에 존재하지 않습니다.");
+                }
+
+                roomMemberRepository.findByRoomAndUser(message.getRoom(), requester)
+                        .orElseThrow(() -> new IllegalArgumentException("채팅방에 속한 사용자만 파일을 다운로드할 수 있습니다."));
+
+                Path filePath = Paths.get(message.getFilePath());
+                if (!Files.exists(filePath)) {
+                        throw new IllegalArgumentException("파일이 삭제되었거나 존재하지 않습니다.");
+                }
+
+                Resource resource = new UrlResource(filePath.toUri());
+                if (!resource.exists()) {
+                        throw new IllegalArgumentException("파일을 찾을 수 없습니다.");
+                }
+                return new AttachmentResource(resource, message.getFileName(), message.getMimeType());
+        }
+
+        private ChatMessageResponseDto toResponseDto(RoomMessage message) {
+                String downloadUrl = null;
+                if (message.getContentType() != RoomMessage.ContentType.TEXT && StringUtils.hasText(message.getFilePath())) {
+                        downloadUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                .path("/api/rooms/")
+                                .path(String.valueOf(message.getRoom().getRoomId()))
+                                .path("/attachments/")
+                                .path(String.valueOf(message.getMessageId()))
+                                .toUriString();
+                }
+
+                return ChatMessageResponseDto.builder()
+                        .roomId(message.getRoom().getRoomId())
+                        .senderNickName(message.getSender() != null ? message.getSender().getNickName() : "시스템")
+                        .senderLanguageCode(message.getSender() != null ? message.getSender().getLanguageCode() : null)
+                        .content(message.getTextContent())
+                        .contentType(message.getContentType().name())
+                        .fileName(message.getFileName())
+                        .fileUrl(downloadUrl)
+                        .mimeType(message.getMimeType())
+                        .sizeBytes(message.getSizeBytes())
+                        .sentAt(message.getCreatedAt())
+                        .build();
+        }
+
+        private RoomMessage.ContentType determineContentType(String mimeType) {
+                if (mimeType != null && mimeType.startsWith("image")) {
+                        return RoomMessage.ContentType.IMAGE;
+                }
+                return RoomMessage.ContentType.FILE;
+        }
+
+        private Path ensureUploadDirectory(Long roomId) throws IOException {
+                Path roomDir = attachmentBasePath.resolve(String.valueOf(roomId));
+                if (!Files.exists(roomDir)) {
+                        Files.createDirectories(roomDir);
+                }
+                return roomDir;
+        }
+
+        public record AttachmentResource(Resource resource, String fileName, String mimeType) {}
 
     // TODO: 추가 필요한 메서드들
     // public void joinRoom(Long roomId, String loginId) { }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -54,25 +54,16 @@ public class MatchService {
         // 2. 나의 조건에 맞는 잠재적 매칭 상대 목록 조회
         List<MatchRequest> potentialMatches = matchRequestRepository.findPotentialMatches(
                 me.getUserPid(),
-                MatchRequest.MatchStatus.WAITING
+                MatchRequest.MatchStatus.WAITING,
+                requestDto.getRegionCode()
         );
 
         // 3. Java 코드로 최종 매칭 상대 결정 (역방향 검증)
         MatchRequest matchedOpponentRequest = null;
         for (MatchRequest opponentRequest : potentialMatches) {
-            User opponent = opponentRequest.getUser();
-            long myAge = ChronoUnit.YEARS.between(me.getBirthDate(), LocalDate.now());
-
-            // 상대방의 희망 성별이 '모두(A)'이거나 '나의 성별'과 일치하는지 확인
-            boolean isGenderMatch = opponentRequest.getChoiceGender() == MatchRequest.Gender.A ||
-                                    opponentRequest.getChoiceGender().name().equals(me.getGender().toString());
-            
-            // 나의 나이가 상대방의 희망 나이 범위에 속하는지 확인
-            boolean isAgeMatch = myAge >= opponentRequest.getMinAge() && myAge <= opponentRequest.getMaxAge();
-
-            if (isGenderMatch && isAgeMatch) {
+            if (isMutuallyCompatible(me, requestDto, opponentRequest)) {
                 matchedOpponentRequest = opponentRequest;
-                break; // 첫 번째로 찾은 짝과 매칭
+                break;
             }
         }
 
@@ -156,6 +147,72 @@ public class MatchService {
             log.info("✅ Waiting notification sent to: {}", loginId);
         } catch (Exception e) {
             log.error("❌ Failed to send waiting notification to user {}: {}", loginId, e.getMessage());
+        }
+    }
+
+    private boolean isMutuallyCompatible(User me, MatchRequestDto myRequestDto, MatchRequest opponentRequest) {
+        User opponent = opponentRequest.getUser();
+        long myAge = ChronoUnit.YEARS.between(me.getBirthDate(), LocalDate.now());
+        long opponentAge = ChronoUnit.YEARS.between(opponent.getBirthDate(), LocalDate.now());
+
+        if (!isGenderSatisfied(opponentRequest.getChoiceGender(), me.getGender())) {
+            return false;
+        }
+        if (!isGenderSatisfied(MatchRequest.Gender.valueOf(myRequestDto.getChoiceGender()), opponent.getGender())) {
+            return false;
+        }
+
+        if (!isAgeWithinBounds(myAge, opponentRequest.getMinAge(), opponentRequest.getMaxAge())) {
+            return false;
+        }
+        if (!isAgeWithinBounds(opponentAge, myRequestDto.getMinAge(), myRequestDto.getMaxAge())) {
+            return false;
+        }
+
+        if (!hasInterestOverlap(myRequestDto.getInterests(), opponentRequest.getInterestsJson())) {
+            return false;
+        }
+
+        String requestedRegion = myRequestDto.getRegionCode();
+        if (requestedRegion != null && !requestedRegion.equals(opponentRequest.getRegionCode())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isGenderSatisfied(MatchRequest.Gender desiredGender, Character targetGender) {
+        if (desiredGender == MatchRequest.Gender.A) {
+            return true;
+        }
+        return targetGender != null && desiredGender.name().equalsIgnoreCase(targetGender.toString());
+    }
+
+    private boolean isAgeWithinBounds(long age, Integer minAge, Integer maxAge) {
+        if (minAge != null && age < minAge) {
+            return false;
+        }
+        if (maxAge != null && age > maxAge) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasInterestOverlap(List<String> myInterests, String opponentInterestsJson) {
+        if (myInterests == null || myInterests.isEmpty()) {
+            return false;
+        }
+        try {
+            List<String> opponentInterests = objectMapper.readValue(opponentInterestsJson, objectMapper.getTypeFactory()
+                    .constructCollectionType(List.class, String.class));
+            return opponentInterests.stream()
+                    .map(String::toLowerCase)
+                    .anyMatch(opponentInterest -> myInterests.stream()
+                            .map(String::toLowerCase)
+                            .anyMatch(myInterest -> myInterest.equals(opponentInterest)));
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse opponent interests JSON: {}", opponentInterestsJson, e);
+            return false;
         }
     }
 }

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -84,82 +84,119 @@
           </div>
           <v-spacer />
           <v-btn icon variant="text"><v-icon>mdi-magnify</v-icon></v-btn>
-          <v-btn v-if="!isGroup" icon variant="text"><v-icon>mdi-phone</v-icon></v-btn>
           <v-btn v-if="isGroup" icon variant="text" @click="inviteParticipant"><v-icon>mdi-account-plus</v-icon></v-btn>
-          <v-btn v-if="isGroup" icon variant="text" @click="startVideoCall"><v-icon>mdi-video</v-icon></v-btn>
-          <v-btn v-else icon variant="text"><v-icon>mdi-video</v-icon></v-btn>
+          <v-btn icon variant="text" :disabled="!current.id" @click="startVideoCall"><v-icon>mdi-video</v-icon></v-btn>
+          <v-btn icon variant="text" :disabled="!callActive" @click="hangUpCall"><v-icon>mdi-phone-hangup</v-icon></v-btn>
         </div>
         <v-divider />
-        <div class="chat-messages flex-grow-1 pa-4 overflow-y-auto" ref="chatMessagesContainer">
-          <div
-            v-if="isLoadingRooms && !current.id"
-            class="d-flex align-center justify-center h-100 text-caption text-grey"
-          >
-            채팅방 정보를 불러오는 중입니다...
+        <div class="chat-body d-flex flex-grow-1">
+          <div class="video-pane" v-if="current.id">
+            <VideoChat ref="videoChatRef" />
           </div>
-          <div
-            v-else-if="!current.id"
-            class="d-flex align-center justify-center h-100 text-caption text-grey"
-          >
-            좌측 목록에서 채팅방을 선택하세요.
-          </div>
-          <template v-else>
+          <div class="chat-messages flex-grow-1 pa-4 overflow-y-auto" ref="chatMessagesContainer">
             <div
-              v-for="(m, i) in messages"
-              :key="m.id || i"
-              class="d-flex mb-4"
-              :class="{ 'justify-end': m.me }"
+              v-if="isLoadingRooms && !current.id"
+              class="d-flex align-center justify-center h-100 text-caption text-grey"
             >
-              <template v-if="!m.me">
-                <v-avatar size="32" class="mr-2"><v-icon color="primary">mdi-account</v-icon></v-avatar>
-                <div class="message-wrapper">
-                  <div v-if="isGroup" class="text-caption font-weight-medium mb-1">{{ m.sender }}</div>
-                  <div class="message-bubble bg-grey-lighten-4 text-body-2">{{ m.text }}</div>
-                  <div v-if="m.translation" class="text-caption text-grey mt-1">
-                    {{ m.translation }}
-                    <v-icon size="16" class="ms-1 cursor-pointer" @click="saveWord(m)">mdi-content-save</v-icon>
-                  </div>
-                  <div class="message-tools">
-                    <v-btn
-                      icon
-                      variant="text"
-                      density="compact"
-                      @click="translateMessage(m)"
-                      :loading="m.translating"
-                    >
-                      <v-icon size="18">mdi-translate</v-icon>
-                    </v-btn>
-                    <span class="text-caption text-grey">{{ m.time }}</span>
-                  </div>
-                </div>
-              </template>
-              <template v-else>
-                <div class="message-wrapper text-right ml-auto">
-                  <div class="message-bubble bg-primary text-white text-body-2">{{ m.text }}</div>
-                  <div v-if="m.translation" class="text-caption text-grey-lighten-2 mt-1">
-                    {{ m.translation }}
-                    <v-icon size="16" class="ms-1 cursor-pointer" @click="saveWord(m)">mdi-content-save</v-icon>
-                  </div>
-                  <div class="message-tools justify-end">
-                    <v-btn
-                      icon
-                      variant="text"
-                      density="compact"
-                      color="white"
-                      @click="translateMessage(m)"
-                      :loading="m.translating"
-                    >
-                      <v-icon size="18">mdi-translate</v-icon>
-                    </v-btn>
-                    <span class="text-caption text-grey-lighten-1">{{ m.time }}</span>
-                  </div>
-                </div>
-              </template>
+              채팅방 정보를 불러오는 중입니다...
             </div>
-          </template>
+            <div
+              v-else-if="!current.id"
+              class="d-flex align-center justify-center h-100 text-caption text-grey"
+            >
+              좌측 목록에서 채팅방을 선택하세요.
+            </div>
+            <template v-else>
+              <div
+                v-for="(m, i) in messages"
+                :key="m.id || i"
+                class="d-flex mb-4"
+                :class="{ 'justify-end': m.me }"
+              >
+                <template v-if="!m.me">
+                  <v-avatar size="32" class="mr-2"><v-icon color="primary">mdi-account</v-icon></v-avatar>
+                  <div class="message-wrapper">
+                    <div v-if="isGroup" class="text-caption font-weight-medium mb-1">{{ m.sender }}</div>
+                    <div class="message-bubble" :class="bubbleClass(m)">
+                      <template v-if="m.contentType === 'IMAGE' && m.fileUrl">
+                        <img :src="m.fileUrl" :alt="m.fileName || '이미지'" class="message-image" />
+                        <div v-if="m.fileName" class="text-caption mt-1">{{ m.fileName }}</div>
+                      </template>
+                      <template v-else-if="m.contentType === 'FILE' && m.fileUrl">
+                        <a :href="m.fileUrl" target="_blank" rel="noopener" class="file-link">
+                          <v-icon size="18" class="mr-1">mdi-paperclip</v-icon>
+                          {{ m.fileName || m.text || '파일 다운로드' }}
+                        </a>
+                      </template>
+                      <template v-else>
+                        {{ m.text }}
+                      </template>
+                    </div>
+                    <div v-if="m.translation" class="text-caption text-grey mt-1">
+                      {{ m.translation }}
+                      <v-icon size="16" class="ms-1 cursor-pointer" @click="saveWord(m)">mdi-content-save</v-icon>
+                    </div>
+                    <div class="message-tools">
+                      <v-btn
+                        v-if="m.contentType === 'TEXT'"
+                        icon
+                        variant="text"
+                        density="compact"
+                        @click="translateMessage(m)"
+                        :loading="m.translating"
+                      >
+                        <v-icon size="18">mdi-translate</v-icon>
+                      </v-btn>
+                      <span class="text-caption text-grey">{{ m.time }}</span>
+                    </div>
+                  </div>
+                </template>
+                <template v-else>
+                  <div class="message-wrapper text-right ml-auto">
+                    <div class="message-bubble" :class="bubbleClass(m)">
+                      <template v-if="m.contentType === 'IMAGE' && m.fileUrl">
+                        <img :src="m.fileUrl" :alt="m.fileName || '이미지'" class="message-image" />
+                        <div v-if="m.fileName" class="text-caption mt-1">{{ m.fileName }}</div>
+                      </template>
+                      <template v-else-if="m.contentType === 'FILE' && m.fileUrl">
+                        <a :href="m.fileUrl" target="_blank" rel="noopener" class="file-link text-white">
+                          <v-icon size="18" class="mr-1">mdi-paperclip</v-icon>
+                          {{ m.fileName || m.text || '파일 다운로드' }}
+                        </a>
+                      </template>
+                      <template v-else>
+                        {{ m.text }}
+                      </template>
+                    </div>
+                    <div v-if="m.translation" class="text-caption text-grey-lighten-2 mt-1">
+                      {{ m.translation }}
+                      <v-icon size="16" class="ms-1 cursor-pointer" @click="saveWord(m)">mdi-content-save</v-icon>
+                    </div>
+                    <div class="message-tools justify-end">
+                      <v-btn
+                        v-if="m.contentType === 'TEXT'"
+                        icon
+                        variant="text"
+                        density="compact"
+                        color="white"
+                        @click="translateMessage(m)"
+                        :loading="m.translating"
+                      >
+                        <v-icon size="18">mdi-translate</v-icon>
+                      </v-btn>
+                      <span class="text-caption text-grey-lighten-1">{{ m.time }}</span>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
         </div>
         <div class="chat-input d-flex align-center pa-4 ga-2">
-          <v-btn icon variant="outlined" color="success"><v-icon>mdi-plus</v-icon></v-btn>
+          <input type="file" ref="fileInput" class="d-none" @change="handleFileSelect" />
+          <v-btn icon variant="outlined" color="success" :disabled="!current.id" @click="triggerFilePicker">
+            <v-icon>mdi-plus</v-icon>
+          </v-btn>
           <v-text-field
             v-model="draft"
             variant="outlined"
@@ -189,6 +226,7 @@ import api from '../services/api'
 import { translate } from '../services/translator'
 import { useVocabularyStore } from '../stores/vocabulary'
 import { resolveClientIdentity } from '../utils/identity'
+import VideoChat from '../components/VideoChat.vue'
 
 const query = ref('')
 const tab = ref('direct')
@@ -198,6 +236,9 @@ const conversations = ref({})
 const current = ref({})
 
 const chatMessagesContainer = ref(null)
+const fileInput = ref(null)
+const videoChatRef = ref(null)
+const callActive = ref(false)
 const isLoadingRooms = ref(false)
 
 const auth = useAuthStore()
@@ -215,12 +256,12 @@ const teardownHandlers = []
 
 onMounted(async () => {
   await loadRooms()
-  ensureActiveRoomFromRoute()
+  await ensureActiveRoomFromRoute()
   connectRealtime()
 })
 
 watch(() => route.query.roomId, () => {
-  ensureActiveRoomFromRoute()
+  void ensureActiveRoomFromRoute()
 })
 
 watch(
@@ -228,7 +269,7 @@ watch(
   async (userPid, prev) => {
     if (userPid && userPid !== prev) {
       await loadRooms()
-      ensureActiveRoomFromRoute()
+      await ensureActiveRoomFromRoute()
     }
   }
 )
@@ -236,6 +277,14 @@ watch(
 watch(
   () => current.value?.id,
   () => {
+    if (videoChatRef.value?.hangUp) {
+      try {
+        videoChatRef.value.hangUp()
+      } catch (error) {
+        console.warn('Failed to terminate active call when switching rooms', error)
+      }
+    }
+    callActive.value = false
     scrollToBottom()
   }
 )
@@ -283,7 +332,7 @@ async function loadRooms() {
     groups.value = groupRooms
 
     if (current.value?.id) {
-      selectRoomById(current.value.id, { skipRouteUpdate: true })
+      await selectRoomById(current.value.id, { skipRouteUpdate: true })
     }
   } catch (error) {
     console.error('[chat] Failed to load rooms', error)
@@ -309,6 +358,8 @@ function normalizeRoomListEntry(room, meNickname) {
     name: displayName,
     last: '',
     participants,
+    participantLogins: room.memberLoginIds || [],
+    participantsDetail: [],
     type
   }
 }
@@ -331,6 +382,8 @@ function normalizeRoomDetail(detail) {
     name: displayName,
     last: '',
     participants,
+    participantLogins: (detail.participants || []).map((participant) => participant.loginId).filter(Boolean),
+    participantsDetail: detail.participants || [],
     type
   }
 }
@@ -350,21 +403,21 @@ function findRoomById(roomId) {
   return chats.value.find((room) => room.id === roomId) || groups.value.find((room) => room.id === roomId)
 }
 
-function selectRoomById(roomId, options = {}) {
+async function selectRoomById(roomId, options = {}) {
   const room = findRoomById(roomId)
   if (room) {
-    openChat(room, options)
+    await openChat(room, options)
     return true
   }
   return false
 }
 
-function ensureActiveRoomFromRoute() {
+async function ensureActiveRoomFromRoute() {
   const rawId = route.query.roomId
   const parsedId = rawId ? Number(rawId) : NaN
 
   if (!Number.isNaN(parsedId) && parsedId) {
-    if (selectRoomById(parsedId, { skipRouteUpdate: true })) {
+    if (await selectRoomById(parsedId, { skipRouteUpdate: true })) {
       return
     }
   }
@@ -372,7 +425,7 @@ function ensureActiveRoomFromRoute() {
   if (!current.value?.id) {
     const fallback = chats.value[0] || groups.value[0]
     if (fallback) {
-      openChat(fallback, { skipRouteUpdate: true })
+      await openChat(fallback, { skipRouteUpdate: true })
     }
   }
 }
@@ -401,10 +454,11 @@ const isGroup = computed(() => current.value?.type === 'GROUP')
 const groupParticipants = computed(() => (current.value?.participants || []).join(', '))
 const messages = computed(() => conversations.value[current.value?.id] ?? [])
 
-function openChat(item, options = {}) {
+async function openChat(item, options = {}) {
   if (!item) return
 
-  current.value = item
+  const room = await ensureRoomExists(item.id, item.name)
+  current.value = room
   tab.value = item.type === 'GROUP' ? 'group' : 'direct'
   ensureConversation(item.id)
 
@@ -434,20 +488,36 @@ function scrollToBottom() {
 
 async function ensureRoomExists(roomId, fallbackName) {
   let room = findRoomById(roomId)
-  if (room) {
-    return room
+  const requiresHydration = !room || !(room.participantLogins && room.participantLogins.length)
+
+  if (requiresHydration) {
+    try {
+      const { data } = await api.get(`/rooms/${roomId}`)
+      room = addOrUpdateRoom(normalizeRoomDetail(data))
+    } catch (error) {
+      console.warn(`[chat] Failed to fetch room ${roomId}, using fallback`, error)
+      if (!room) {
+        room = addOrUpdateRoom({
+          id: roomId,
+          name: fallbackName || `대화방 #${roomId}`,
+          last: '',
+          participants: fallbackName ? [fallbackName] : [],
+          participantLogins: [],
+          participantsDetail: [],
+          type: 'PRIVATE'
+        })
+      }
+    }
   }
 
-  try {
-    const { data } = await api.get(`/rooms/${roomId}`)
-    room = addOrUpdateRoom(normalizeRoomDetail(data))
-  } catch (error) {
-    console.warn(`[chat] Failed to fetch room ${roomId}, using fallback`, error)
+  if (!room) {
     room = addOrUpdateRoom({
       id: roomId,
       name: fallbackName || `대화방 #${roomId}`,
       last: '',
       participants: fallbackName ? [fallbackName] : [],
+      participantLogins: [],
+      participantsDetail: [],
       type: 'PRIVATE'
     })
   }
@@ -473,6 +543,11 @@ async function handleIncomingMessage(payload) {
     time: formatTime(payload.sentAt),
     sender: senderNickname,
     me: myNickname ? senderNickname === myNickname : false,
+    contentType: (payload.contentType || 'TEXT').toUpperCase(),
+    fileName: payload.fileName || null,
+    fileUrl: payload.fileUrl || null,
+    mimeType: payload.mimeType || null,
+    sizeBytes: payload.sizeBytes || null,
     translation: null,
     translating: false,
     sentAt: payload.sentAt ?? null
@@ -481,11 +556,27 @@ async function handleIncomingMessage(payload) {
   messagesForRoom.push(message)
 
   const roomEntry = await ensureRoomExists(roomKey, senderNickname)
-  roomEntry.last = content
+  if (message.contentType === 'TEXT') {
+    roomEntry.last = content
+  } else {
+    roomEntry.last = message.fileName || content || '[첨부파일]'
+  }
 
   if (current.value?.id === roomKey) {
     scrollToBottom()
   }
+}
+
+function bubbleClass(message) {
+  const classes = []
+  if (message.contentType && message.contentType !== 'TEXT') {
+    classes.push('attachment-bubble')
+  } else if (message.me) {
+    classes.push('bg-primary', 'text-white', 'text-body-2')
+  } else {
+    classes.push('bg-grey-lighten-4', 'text-body-2')
+  }
+  return classes
 }
 
 async function connectRealtime() {
@@ -564,7 +655,7 @@ function formatTime(isoString) {
 }
 
 async function translateMessage(message) {
-  if (!message || message.translating || message.translation) return
+  if (!message || message.translating || message.translation || message.contentType !== 'TEXT') return
 
   message.translating = true
   try {
@@ -578,7 +669,7 @@ async function translateMessage(message) {
 }
 
 function saveWord(message) {
-  if (!message?.translation) return
+  if (!message?.translation || message.contentType !== 'TEXT') return
   vocabularyStore.addWord(message.text, message.translation)
 }
 
@@ -616,6 +707,33 @@ async function send() {
   }
 }
 
+function triggerFilePicker() {
+  if (!current.value?.id) return
+  fileInput.value?.click()
+}
+
+async function handleFileSelect(event) {
+  const [file] = event.target?.files || []
+  event.target.value = ''
+
+  if (!file) return
+  if (!current.value?.id) {
+    alert('채팅방이 선택되지 않았습니다.')
+    return
+  }
+
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    await api.post(`/rooms/${current.value.id}/attachments`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  } catch (error) {
+    console.error('[chat] 파일 업로드 실패', error)
+    alert('파일을 업로드하지 못했습니다. 잠시 후 다시 시도하세요.')
+  }
+}
+
 function inviteParticipant() {
   if (!isGroup.value || !current.value?.id) return
 
@@ -632,8 +750,51 @@ function inviteParticipant() {
   }
 }
 
-function startVideoCall() {
-  alert('영상 통화 기능은 준비 중입니다.')
+async function resolveParticipantLogins(roomId) {
+  const room = await ensureRoomExists(roomId)
+  return room.participantLogins?.filter(Boolean) ?? []
+}
+
+async function startVideoCall() {
+  if (!current.value?.id) {
+    alert('채팅방이 선택되지 않았습니다.')
+    return
+  }
+
+  const participantLogins = await resolveParticipantLogins(current.value.id)
+  const myLoginId = resolveClientIdentity(auth)
+  const targets = participantLogins.filter((loginId) => loginId !== myLoginId)
+
+  if (!targets.length) {
+    alert('통화할 상대가 없습니다.')
+    return
+  }
+
+  if (!videoChatRef.value?.startCall) {
+    console.warn('VideoChat component is not ready')
+    return
+  }
+
+  try {
+    for (const loginId of targets) {
+      await videoChatRef.value.startCall(loginId)
+    }
+    callActive.value = true
+  } catch (error) {
+    console.error('[chat] Failed to start video call', error)
+    alert('영상 통화를 시작하지 못했습니다.')
+  }
+}
+
+function hangUpCall() {
+  if (videoChatRef.value?.hangUp) {
+    try {
+      videoChatRef.value.hangUp()
+    } catch (error) {
+      console.warn('Failed to hang up call', error)
+    }
+  }
+  callActive.value = false
 }
 
 watch(messages, () => scrollToBottom())
@@ -656,8 +817,27 @@ watch(messages, () => scrollToBottom())
   height: 100%;
 }
 
+.chat-body {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+}
+
+.video-pane {
+  flex: 1 1 55%;
+  max-width: 55%;
+  display: flex;
+}
+
+.video-pane :deep(.video-chat) {
+  width: 100%;
+}
+
 .chat-messages {
   background: #fff;
+  flex: 1 1 45%;
+  max-width: 45%;
 }
 
 .chat-input {
@@ -675,6 +855,25 @@ watch(messages, () => scrollToBottom())
   padding: 12px;
   word-break: break-word;
   white-space: pre-wrap;
+}
+
+.attachment-bubble {
+  background: transparent;
+  padding: 0;
+}
+
+.message-image {
+  max-width: 100%;
+  border-radius: 12px;
+  display: block;
+}
+
+.file-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: inherit;
 }
 
 .message-tools {


### PR DESCRIPTION
## Summary
- enforce region and shared interest checks during random matchmaking so both sides' preferences are honoured
- add chat attachment upload and download APIs with enriched message metadata for broadcasting through WebSocket
- embed the reusable VideoChat component into the main chat layout and support file/image rendering and uploads on the client

## Testing
- ./gradlew test *(fails: no Java 17 toolchain available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d292de9883259136a58739e9225d