### PR TITLE
Add immediate match bootstrap flow across backend and frontend

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.MatchFoundResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.service.MatchService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -31,7 +34,7 @@ public class MatchController {
      * @return 요청 접수 결과
      */
     @PostMapping("/requests")
-    public ResponseEntity<String> startRandomMatch(
+    public ResponseEntity<MatchStartResponseDto> startRandomMatch(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestHeader(value = "X-Login-Id", required = false) String headerLoginId,
             @Valid @RequestBody MatchRequestDto dto) {
@@ -39,23 +42,42 @@ public class MatchController {
         try {
             String loginId = resolveLoginId(userDetails, dto.getLoginId(), headerLoginId);
             if (!StringUtils.hasText(loginId)) {
-                return ResponseEntity.badRequest().body("loginId is required to request matching.");
+                return ResponseEntity.badRequest().build();
             }
 
             log.info("Match request received from user: {}", loginId);
             log.info("Match request data: {}", dto);
             
-            matchService.startOrFindMatch(loginId, dto);
-            
-            // TODO: MatchService의 결과에 따라 다른 응답 반환 (대기열 등록 or 매칭 성공)
-            return ResponseEntity.ok("매칭 요청이 성공적으로 접수되었습니다.");
-            
+            MatchStartResponseDto result = matchService.startOrFindMatch(loginId, dto);
+
+            return ResponseEntity.ok(result);
+
         } catch (JsonProcessingException e) {
             log.error("JSON processing error during match request.", e);
-            return ResponseEntity.internalServerError().body("매칭 요청 처리 중 오류가 발생했습니다.");
+            return ResponseEntity.internalServerError().build();
         } catch (IllegalArgumentException e) {
             log.warn("Invalid match request. Reason: {}", e.getMessage());
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/results/latest")
+    public ResponseEntity<MatchFoundResponseDto> getLatestMatch(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestHeader(value = "X-Login-Id", required = false) String headerLoginId) {
+
+        try {
+            String loginId = resolveLoginId(userDetails, null, headerLoginId);
+            if (!StringUtils.hasText(loginId)) {
+                return ResponseEntity.badRequest().build();
+            }
+
+            return matchService.findLatestMatch(loginId)
+                    .map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.noContent().build());
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid match lookup request. Reason: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
         }
     }
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
@@ -1,0 +1,21 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchStartResponseDto {
+    private final boolean matchedNow;
+    private final boolean alreadyQueued;
+    private final MatchFoundResponseDto match;
+
+    public static MatchStartResponseDto matched(MatchFoundResponseDto match) {
+        return new MatchStartResponseDto(true, false, match);
+    }
+
+    public static MatchStartResponseDto queued(boolean alreadyQueued) {
+        return new MatchStartResponseDto(false, alreadyQueued, null);
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
@@ -23,6 +23,8 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemb
     /** 특정 채팅방에 특정 사용자가 멤버로 있는지 확인 (권한 검사용) */
     Optional<RoomMember> findByRoomAndUser(Room room, User user);
 
+    Optional<RoomMember> findFirstByUserAndRoom_RoomTypeOrderByJoinedAtDesc(User user, Room.RoomType roomType);
+
     /**
      * 특정 사용자가 속한 모든 채팅방과 그 방의 모든 멤버 정보를 한 번의 쿼리로 조회 (N+1 문제 해결)
      */

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -6,11 +6,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchFoundResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
+import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
+import net.datasa.project01.domain.entity.RoomMember;
 import net.datasa.project01.domain.entity.User;
 import net.datasa.project01.websocket.RealTimeMessagingService;
 import net.datasa.project01.repository.MatchRequestRepository;
+import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,7 @@ public class MatchService {
 
     private final MatchRequestRepository matchRequestRepository;
     private final UserRepository userRepository;
+    private final RoomMemberRepository roomMemberRepository;
     private final ChatService chatService;
     private final RealTimeMessagingService messagingService;
     private final ObjectMapper objectMapper;
@@ -37,7 +41,7 @@ public class MatchService {
      * @param loginId 요청한 사용자의 ID
      * @param requestDto 매칭 조건
      */
-    public void startOrFindMatch(String loginId, MatchRequestDto requestDto) throws JsonProcessingException {
+    public MatchStartResponseDto startOrFindMatch(String loginId, MatchRequestDto requestDto) throws JsonProcessingException {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
@@ -45,10 +49,10 @@ public class MatchService {
         Optional<MatchRequest> existingRequest = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING);
         if (existingRequest.isPresent()) {
             log.info("User {} is already in the matching queue.", loginId);
-            
+
             // ✅ 테스트용: 이미 대기열에 있는 사용자에게 대기 상태 알림
             sendWaitingNotification(loginId);
-            return;
+            return MatchStartResponseDto.queued(true);
         }
 
         // 2. 나의 조건에 맞는 잠재적 매칭 상대 목록 조회
@@ -97,6 +101,8 @@ public class MatchService {
             sendMatchResult(me.getLoginId(), myResponse);
             sendMatchResult(opponent.getLoginId(), opponentResponse);
 
+            return MatchStartResponseDto.matched(myResponse);
+
         } else {
             // 5. 매칭 실패 -> 대기열에 등록
             log.info("❌ No match found for user {}. Adding to queue.", loginId);
@@ -110,10 +116,29 @@ public class MatchService {
                     .status(MatchRequest.MatchStatus.WAITING)
                     .build();
             matchRequestRepository.save(newRequest);
-            
+
             // ✅ 테스트용: 대기열에 등록된 사용자에게 대기 상태 알림
             sendWaitingNotification(loginId);
+            return MatchStartResponseDto.queued(false);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MatchFoundResponseDto> findLatestMatch(String loginId) {
+        User me = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return roomMemberRepository
+                .findFirstByUserAndRoom_RoomTypeOrderByJoinedAtDesc(me, Room.RoomType.PRIVATE)
+                .flatMap(membership -> {
+                    Room room = membership.getRoom();
+                    List<RoomMember> participants = roomMemberRepository.findByRoom(room);
+                    return participants.stream()
+                            .map(RoomMember::getUser)
+                            .filter(user -> !user.getLoginId().equals(loginId))
+                            .findFirst()
+                            .map(opponent -> new MatchFoundResponseDto(room.getRoomId(), opponent.getNickName()));
+                });
     }
     
     /**

--- a/Matcha-Talk/frontend/src/stores/match.js
+++ b/Matcha-Talk/frontend/src/stores/match.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia'
+
+const STORAGE_KEY = 'match-bootstrap'
+
+function hasWindow () {
+  return typeof window !== 'undefined'
+}
+
+function readFromStorage () {
+  if (!hasWindow()) return null
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch (error) {
+    console.warn('Failed to parse stored match bootstrap payload', error)
+    sessionStorage.removeItem(STORAGE_KEY)
+    return null
+  }
+}
+
+function writeToStorage (payload) {
+  if (!hasWindow()) return
+  if (!payload) {
+    sessionStorage.removeItem(STORAGE_KEY)
+    return
+  }
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+  } catch (error) {
+    console.warn('Failed to persist match bootstrap payload', error)
+  }
+}
+
+export const useMatchStore = defineStore('match', {
+  state: () => ({
+    bootstrap: readFromStorage(),
+  }),
+
+  actions: {
+    setBootstrap (payload) {
+      this.bootstrap = payload || null
+      writeToStorage(this.bootstrap)
+    },
+    clearBootstrap () {
+      this.bootstrap = null
+      writeToStorage(null)
+    },
+  },
+})

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -66,14 +66,18 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { createRealtimeClient } from '../services/ws'
 import { camelizeKeys } from '../utils/case'
 import { resolveClientIdentity } from '../utils/identity'
+import api from '../services/api'
+import { useMatchStore } from '../stores/match'
 
 const router = useRouter()
+const route = useRoute()
 const auth = useAuthStore()
+const matchStore = useMatchStore()
 
 const matchFound = ref(false)
 const partnerName = ref('')
@@ -91,7 +95,22 @@ let reconnectTimer = null
 let manualDisconnect = false
 const teardownHandlers = []
 
-onMounted(() => {
+onMounted(async () => {
+  const routeBootstrap = extractBootstrapFromRoute()
+  const queuedFromRoute = isQueuedFromRoute()
+  if (routeBootstrap) {
+    applyMatchBootstrap(routeBootstrap, { persist: true })
+  } else if (queuedFromRoute) {
+    matchStore.clearBootstrap()
+    sessionStatus.value = '매칭 대기열에 등록되었습니다.'
+  } else if (matchStore.bootstrap) {
+    applyMatchBootstrap(matchStore.bootstrap)
+  }
+
+  if (!matchFound.value) {
+    await fetchLatestMatchFromRest()
+  }
+
   connectWebSocket()
 })
 
@@ -171,6 +190,11 @@ function handleMatchResult (payload) {
   partnerName.value = normalized.partnerNickName || normalized.partnerNickname || '상대방'
   roomId.value = normalized.roomId ?? normalized.room_id ?? null
   sessionStatus.value = '매칭 성공!'
+  matchStore.setBootstrap({
+    matchFound: matchFound.value,
+    partnerName: partnerName.value,
+    roomId: roomId.value,
+  })
 }
 
 function handleMatchStatus (payload) {
@@ -191,6 +215,7 @@ function acceptMatch () {
   }
 
   manualDisconnect = true
+  matchStore.clearBootstrap()
   router.push({
     name: 'chat',
     query: {
@@ -202,6 +227,7 @@ function acceptMatch () {
 
 function declineMatch () {
   if (confirm('매칭을 거절하시겠습니까?')) {
+    matchStore.clearBootstrap()
     router.push({ name: 'match' })
   }
 }
@@ -228,6 +254,77 @@ onBeforeUnmount(() => {
     websocketClient = null
   }
 })
+
+function extractBootstrapFromRoute () {
+  const { matched, roomId: routeRoomId, partner } = route.query
+  if (matched === '1' || matched === 'true') {
+    const parsedRoomId = typeof routeRoomId !== 'undefined' ? Number(routeRoomId) : null
+    return {
+      matchFound: true,
+      roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
+      partnerName: typeof partner === 'string' ? partner : '',
+    }
+  }
+  return null
+}
+
+function isQueuedFromRoute () {
+  const { queued } = route.query
+  return queued === '1' || queued === 'true'
+}
+
+function applyMatchBootstrap (payload, options = {}) {
+  if (!payload) return
+
+  const { persist = false, statusMessage } = options
+  const normalizedName = payload.partnerName || payload.partnerNickName || payload.partnerNickname || ''
+  const normalizedRoomId = typeof payload.roomId === 'number' ? payload.roomId : payload.roomId != null ? Number(payload.roomId) : null
+
+  matchFound.value = !!payload.matchFound
+  partnerName.value = normalizedName
+  roomId.value = Number.isFinite(normalizedRoomId) ? normalizedRoomId : null
+  sessionStatus.value = statusMessage || (matchFound.value ? '매칭 성공!' : '매칭 대기 중입니다...')
+
+  if (persist) {
+    if (matchFound.value) {
+      matchStore.setBootstrap({
+        matchFound: true,
+        partnerName: partnerName.value,
+        roomId: roomId.value,
+      })
+    } else {
+      matchStore.clearBootstrap()
+    }
+  }
+}
+
+async function fetchLatestMatchFromRest () {
+  try {
+    const loginId = resolveClientIdentity(auth)
+    if (!loginId) return
+
+    const response = await api.get('/match/results/latest', {
+      headers: {
+        'X-Login-Id': loginId,
+      },
+      skipSnakifyParams: true,
+    })
+
+    if (response.status === 204 || !response.data) {
+      return
+    }
+
+    const payload = {
+      matchFound: true,
+      roomId: response.data.roomId ?? null,
+      partnerName: response.data.partnerNickName ?? response.data.partnerNickname ?? '',
+    }
+
+    applyMatchBootstrap(payload, { persist: true, statusMessage: '최근 매칭 정보를 불러왔습니다.' })
+  } catch (error) {
+    console.warn('Failed to fetch latest match result', error?.response?.data || error?.message)
+  }
+}
 </script>
 
 <style scoped>

--- a/Matcha-Talk/frontend/src/views/MatchingSetup.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingSetup.vue
@@ -107,10 +107,12 @@ import { ref, computed } from 'vue'
 import api from '../services/api'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { useMatchStore } from '../stores/match'
 import { resolveClientIdentity } from '../utils/identity'
 
 const router = useRouter()
 const auth = useAuthStore()
+const matchStore = useMatchStore()
 const ageRange = ref([20, 30])
 const gender = ref('A')
 const regions = [
@@ -148,12 +150,30 @@ async function startMatch(){
   }
   
   try{
-    await api.post('/match/requests', payload, {
+    const { data } = await api.post('/match/requests', payload, {
       headers: {
         'X-Login-Id': loginId
       }
     })
-    router.push('/match/result')
+    if (data?.matchedNow && data?.match) {
+      const bootstrapPayload = {
+        matchFound: true,
+        roomId: data.match.roomId ?? null,
+        partnerName: data.match.partnerNickName ?? data.match.partnerNickname ?? '',
+      }
+      matchStore.setBootstrap(bootstrapPayload)
+      router.push({
+        name: 'match-result',
+        query: {
+          matched: '1',
+          roomId: bootstrapPayload.roomId != null ? String(bootstrapPayload.roomId) : undefined,
+          partner: bootstrapPayload.partnerName || undefined,
+        },
+      })
+    } else {
+      matchStore.clearBootstrap()
+      router.push({ name: 'match-result', query: { queued: '1' } })
+    }
   }catch(e){
     alert('매칭 실패: ' + (e?.response?.data?.message || e.message))
   }finally{


### PR DESCRIPTION
## Summary
- update the match service/controller to return structured match outcomes and expose a latest-match lookup
- add a shared Pinia store and route payload handling so the matching setup view passes immediate results forward
- hydrate the matching result view from the navigation payload or REST fallback before relying on WebSocket events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fe19e72c8325a52091ed8b4750ea