### PR TITLE
Implement match handshake flow

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/MatchController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/MatchController.java
@@ -8,12 +8,14 @@ import net.datasa.project01.domain.dto.MatchFoundResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.service.MatchService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,6 +57,9 @@ public class MatchController {
         } catch (JsonProcessingException e) {
             log.error("JSON processing error during match request.", e);
             return ResponseEntity.internalServerError().build();
+        } catch (IllegalStateException e) {
+            log.warn("Match request could not be processed. Reason: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
         } catch (IllegalArgumentException e) {
             log.warn("Invalid match request. Reason: {}", e.getMessage());
             return ResponseEntity.badRequest().build();
@@ -77,6 +82,48 @@ public class MatchController {
                     .orElseGet(() -> ResponseEntity.noContent().build());
         } catch (IllegalArgumentException e) {
             log.warn("Invalid match lookup request. Reason: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PostMapping("/requests/{id}/accept")
+    public ResponseEntity<MatchFoundResponseDto> acceptMatchRequest(
+            @PathVariable("id") Long requestId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestHeader(value = "X-Login-Id", required = false) String headerLoginId) {
+
+        try {
+            String loginId = resolveLoginId(userDetails, null, headerLoginId);
+            if (!StringUtils.hasText(loginId)) {
+                return ResponseEntity.badRequest().build();
+            }
+
+            MatchFoundResponseDto response = matchService.acceptMatchRequest(loginId, requestId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid accept request. Reason: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException e) {
+            log.warn("Accept request rejected. Reason: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
+    @PostMapping("/requests/{id}/decline")
+    public ResponseEntity<MatchFoundResponseDto> declineMatchRequest(
+            @PathVariable("id") Long requestId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestHeader(value = "X-Login-Id", required = false) String headerLoginId) {
+        try {
+            String loginId = resolveLoginId(userDetails, null, headerLoginId);
+            if (!StringUtils.hasText(loginId)) {
+                return ResponseEntity.badRequest().build();
+            }
+
+            MatchFoundResponseDto response = matchService.declineMatchRequest(loginId, requestId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid decline request. Reason: {}", e.getMessage());
             return ResponseEntity.badRequest().build();
         }
     }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
@@ -1,12 +1,23 @@
 package net.datasa.project01.domain.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import net.datasa.project01.domain.entity.MatchRequest;
+
+import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class MatchFoundResponseDto {
-    private Long roomId;
-    private String partnerNickName;
+    private final Long myRequestId;
+    private final Long partnerRequestId;
+    private final String partnerLoginId;
+    private final String partnerNickName;
+    private final Long roomId;
+    private final String handshakeKey;
+    private final LocalDateTime expiresAt;
+    private final MatchRequest.MatchStatus status;
     // 향후 파트너의 프로필 사진, 관심사 등 추가 정보 포함 가능
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchStartResponseDto.java
@@ -3,19 +3,24 @@ package net.datasa.project01.domain.dto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import net.datasa.project01.domain.entity.MatchRequest;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MatchStartResponseDto {
     private final boolean matchedNow;
     private final boolean alreadyQueued;
+    private final Long requestId;
+    private final MatchRequest.MatchStatus status;
     private final MatchFoundResponseDto match;
 
-    public static MatchStartResponseDto matched(MatchFoundResponseDto match) {
-        return new MatchStartResponseDto(true, false, match);
+    public static MatchStartResponseDto matched(MatchRequest request, MatchFoundResponseDto match) {
+        return new MatchStartResponseDto(true, false, request.getRequestId(), request.getStatus(), match);
     }
 
-    public static MatchStartResponseDto queued(boolean alreadyQueued) {
-        return new MatchStartResponseDto(false, alreadyQueued, null);
+    public static MatchStartResponseDto queued(MatchRequest request, boolean alreadyQueued) {
+        Long requestId = request != null ? request.getRequestId() : null;
+        MatchRequest.MatchStatus status = request != null ? request.getStatus() : null;
+        return new MatchStartResponseDto(false, alreadyQueued, requestId, status, null);
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
@@ -46,7 +46,16 @@ public class MatchRequest {
     @Column(name = "interests_json", columnDefinition = "JSON", nullable = false)
     private String interestsJson;
 
-    // [수정됨] String -> Enum
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @Column(name = "handshake_key", length = 64)
+    private String handshakeKey;
+
+    @Column(name = "handshake_expires_at")
+    private LocalDateTime handshakeExpiresAt;
+
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 10, nullable = false)
@@ -62,6 +71,10 @@ public class MatchRequest {
     }
 
     public enum MatchStatus {
-        WAITING, MATCHED, CANCELLED
+        WAITING,
+        MATCHED,
+        CONFIRMED,
+        DECLINED,
+        CANCELLED
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -1,18 +1,31 @@
 package net.datasa.project01.repository;
 
 import net.datasa.project01.domain.entity.MatchRequest;
+import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
 
-    // 현재 사용자가 대기열에 있는지 확인하는 메소드는 그대로 유지합니다.
+    // 현재 사용자가 특정 상태로 존재하는지 확인
     Optional<MatchRequest> findByUserAndStatus(User user, MatchRequest.MatchStatus status);
+
+    Optional<MatchRequest> findFirstByUserAndStatusOrderByRequestedAtDesc(User user, MatchRequest.MatchStatus status);
+
+    @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user WHERE mr.requestId = :id")
+    Optional<MatchRequest> findByIdWithUser(@Param("id") Long id);
+
+    List<MatchRequest> findAllByHandshakeKey(String handshakeKey);
+
+    List<MatchRequest> findByRoom(Room room);
+
+    List<MatchRequest> findAllByRoomAndStatusIn(Room room, Collection<MatchRequest.MatchStatus> statuses);
 
     // [수정됨] '나의 조건'에 맞는 잠재적 매칭 상대를 찾는 더 간단한 쿼리
     @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user u " +

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -128,6 +128,31 @@ public class ChatService {
                 return newRoom;
         }
 
+        @Transactional
+        public Room createRandomRoom(User user1, User user2) {
+                Room newRoom = Room.builder()
+                        .roomType(Room.RoomType.RANDOM)
+                        .capacity(2)
+                        .build();
+                roomRepository.save(newRoom);
+
+                RoomMember member1 = RoomMember.builder()
+                        .room(newRoom)
+                        .user(user1)
+                        .role("MEMBER")
+                        .build();
+
+                RoomMember member2 = RoomMember.builder()
+                        .room(newRoom)
+                        .user(user2)
+                        .role("MEMBER")
+                        .build();
+
+                roomMemberRepository.saveAll(java.util.List.of(member1, member2));
+
+                return newRoom;
+        }
+
         @Transactional(readOnly = true)
         public List<RoomListResponseDto> findRoomsByUser(String loginId) {
                 User user = userRepository.findByLoginId(loginId)

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -9,19 +9,20 @@ import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
-import net.datasa.project01.domain.entity.RoomMember;
 import net.datasa.project01.domain.entity.User;
 import net.datasa.project01.websocket.RealTimeMessagingService;
 import net.datasa.project01.repository.MatchRequestRepository;
-import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +32,11 @@ public class MatchService {
 
     private final MatchRequestRepository matchRequestRepository;
     private final UserRepository userRepository;
-    private final RoomMemberRepository roomMemberRepository;
     private final ChatService chatService;
     private final RealTimeMessagingService messagingService;
     private final ObjectMapper objectMapper;
+
+    private static final Duration HANDSHAKE_TIMEOUT = Duration.ofMinutes(2);
 
     /**
      * 랜덤 매칭을 시작하거나 대기열에서 상대를 찾기
@@ -45,24 +47,32 @@ public class MatchService {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 1. 이미 대기열에 있는지 확인
-        Optional<MatchRequest> existingRequest = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING);
-        if (existingRequest.isPresent()) {
-            log.info("User {} is already in the matching queue.", loginId);
-
-            // ✅ 테스트용: 이미 대기열에 있는 사용자에게 대기 상태 알림
-            sendWaitingNotification(loginId);
-            return MatchStartResponseDto.queued(true);
+        Optional<MatchRequest> activeHandshake = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.MATCHED);
+        if (activeHandshake.isPresent()) {
+            MatchRequest handshakeRequest = activeHandshake.get();
+            if (isHandshakeExpired(handshakeRequest)) {
+                expireHandshake(handshakeRequest);
+            } else {
+                MatchRequest opponent = findHandshakePartner(handshakeRequest)
+                        .orElseThrow(() -> new IllegalStateException("상대 매칭 정보를 찾을 수 없습니다."));
+                MatchFoundResponseDto responseDto = buildMatchFoundResponse(handshakeRequest, opponent);
+                return MatchStartResponseDto.matched(handshakeRequest, responseDto);
+            }
         }
 
-        // 2. 나의 조건에 맞는 잠재적 매칭 상대 목록 조회
+        Optional<MatchRequest> waitingRequest = matchRequestRepository.findByUserAndStatus(me, MatchRequest.MatchStatus.WAITING);
+        if (waitingRequest.isPresent()) {
+            log.info("User {} is already in the matching queue.", loginId);
+            sendWaitingNotification(loginId);
+            return MatchStartResponseDto.queued(waitingRequest.get(), true);
+        }
+
         List<MatchRequest> potentialMatches = matchRequestRepository.findPotentialMatches(
                 me.getUserPid(),
                 MatchRequest.MatchStatus.WAITING,
                 requestDto.getRegionCode()
         );
 
-        // 3. Java 코드로 최종 매칭 상대 결정 (역방향 검증)
         MatchRequest matchedOpponentRequest = null;
         for (MatchRequest opponentRequest : potentialMatches) {
             if (isMutuallyCompatible(me, requestDto, opponentRequest)) {
@@ -72,55 +82,36 @@ public class MatchService {
         }
 
         if (matchedOpponentRequest != null) {
-            // 4. 매칭 성공 처리
-            User opponent = matchedOpponentRequest.getUser();
-            log.info("✅ Match found for user {}: {}", loginId, opponent.getLoginId());
+            log.info("✅ Match found for user {}: {}", loginId, matchedOpponentRequest.getUser().getLoginId());
 
-            // 두 요청의 상태를 MATCHED로 변경
+            String handshakeKey = UUID.randomUUID().toString();
+            LocalDateTime expiresAt = LocalDateTime.now().plus(HANDSHAKE_TIMEOUT);
+
             matchedOpponentRequest.setStatus(MatchRequest.MatchStatus.MATCHED);
+            matchedOpponentRequest.setHandshakeKey(handshakeKey);
+            matchedOpponentRequest.setHandshakeExpiresAt(expiresAt);
 
-            // 나의 매칭 요청도 'MATCHED' 상태로 생성하여 기록을 남김
-            MatchRequest myMatchedRequest = MatchRequest.builder()
-                    .user(me)
-                    .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
-                    .minAge(requestDto.getMinAge())
-                    .maxAge(requestDto.getMaxAge())
-                    .regionCode(requestDto.getRegionCode())
-                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
-                    .status(MatchRequest.MatchStatus.MATCHED)
-                    .build();
+            MatchRequest myMatchedRequest = buildMatchRequest(me, requestDto, MatchRequest.MatchStatus.MATCHED);
+            myMatchedRequest.setHandshakeKey(handshakeKey);
+            myMatchedRequest.setHandshakeExpiresAt(expiresAt);
+
             matchRequestRepository.save(myMatchedRequest);
+            matchRequestRepository.save(matchedOpponentRequest);
 
-            // 1:1 채팅방 생성
-            Room privateRoom = chatService.createPrivateRoom(me, opponent);
+            MatchFoundResponseDto myResponse = buildMatchFoundResponse(myMatchedRequest, matchedOpponentRequest);
+            MatchFoundResponseDto opponentResponse = buildMatchFoundResponse(matchedOpponentRequest, myMatchedRequest);
 
-            // 양쪽 사용자에게 매칭 성공 알림 전송 (웹소켓)
-            MatchFoundResponseDto myResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), opponent.getNickName());
-            MatchFoundResponseDto opponentResponse = new MatchFoundResponseDto(privateRoom.getRoomId(), me.getNickName());
+            notifyMatchFound(myMatchedRequest, myResponse);
+            notifyMatchFound(matchedOpponentRequest, opponentResponse);
 
-            sendMatchResult(me.getLoginId(), myResponse);
-            sendMatchResult(opponent.getLoginId(), opponentResponse);
-
-            return MatchStartResponseDto.matched(myResponse);
-
-        } else {
-            // 5. 매칭 실패 -> 대기열에 등록
-            log.info("❌ No match found for user {}. Adding to queue.", loginId);
-            MatchRequest newRequest = MatchRequest.builder()
-                    .user(me)
-                    .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
-                    .minAge(requestDto.getMinAge())
-                    .maxAge(requestDto.getMaxAge())
-                    .regionCode(requestDto.getRegionCode())
-                    .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
-                    .status(MatchRequest.MatchStatus.WAITING)
-                    .build();
-            matchRequestRepository.save(newRequest);
-
-            // ✅ 테스트용: 대기열에 등록된 사용자에게 대기 상태 알림
-            sendWaitingNotification(loginId);
-            return MatchStartResponseDto.queued(false);
+            return MatchStartResponseDto.matched(myMatchedRequest, myResponse);
         }
+
+        log.info("❌ No match found for user {}. Adding to queue.", loginId);
+        MatchRequest newRequest = buildMatchRequest(me, requestDto, MatchRequest.MatchStatus.WAITING);
+        matchRequestRepository.save(newRequest);
+        sendWaitingNotification(loginId);
+        return MatchStartResponseDto.queued(newRequest, false);
     }
 
     @Transactional(readOnly = true)
@@ -128,50 +119,190 @@ public class MatchService {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        return roomMemberRepository
-                .findFirstByUserAndRoom_RoomTypeOrderByJoinedAtDesc(me, Room.RoomType.PRIVATE)
-                .flatMap(membership -> {
-                    Room room = membership.getRoom();
-                    List<RoomMember> participants = roomMemberRepository.findByRoom(room);
-                    return participants.stream()
-                            .map(RoomMember::getUser)
-                            .filter(user -> !user.getLoginId().equals(loginId))
-                            .findFirst()
-                            .map(opponent -> new MatchFoundResponseDto(room.getRoomId(), opponent.getNickName()));
-                });
+        return matchRequestRepository.findFirstByUserAndStatusOrderByRequestedAtDesc(me, MatchRequest.MatchStatus.CONFIRMED)
+                .filter(request -> request.getRoom() != null)
+                .flatMap(request -> findConfirmedPartner(request)
+                        .map(partner -> buildMatchFoundResponse(request, partner)));
     }
-    
-    /**
-     * ✅ 매칭 결과 전송 (공통 메서드)
-     */
-    private void sendMatchResult(String loginId, MatchFoundResponseDto response) {
-        try {
-            log.info("🚀 Sending match result to user: {}", loginId);
-            
-            // 사용자별 큐로 전송
-            messagingService.sendEventToUser(loginId, "match-result", response);
-            
-            log.info("✅ Match result sent successfully to: {}", loginId);
-        } catch (Exception e) {
-            log.error("❌ Failed to send match result to user {}: {}", loginId, e.getMessage());
-        }
-    }
-    
+
     /**
      * ✅ 테스트용: 대기 상태 알림
      */
     private void sendWaitingNotification(String loginId) {
         try {
             log.info("📋 Sending waiting notification to user: {}", loginId);
-            
+
             String waitingMessage = "매칭 대기 중입니다. 상대방을 찾고 있어요...";
-            
+
             // 사용자별 큐로 전송
-            messagingService.sendEventToUser(loginId, "match-status", waitingMessage);
-            
+            messagingService.sendEventToUser(loginId, RealTimeMessagingService.EVENT_MATCH_STATUS, waitingMessage);
+
             log.info("✅ Waiting notification sent to: {}", loginId);
         } catch (Exception e) {
             log.error("❌ Failed to send waiting notification to user {}: {}", loginId, e.getMessage());
+        }
+    }
+
+    public MatchFoundResponseDto acceptMatchRequest(String loginId, Long requestId) {
+        MatchRequest request = matchRequestRepository.findByIdWithUser(requestId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        validateOwnership(loginId, request);
+
+        if (request.getStatus() != MatchRequest.MatchStatus.MATCHED) {
+            throw new IllegalStateException("이미 처리된 매칭입니다.");
+        }
+
+        if (isHandshakeExpired(request)) {
+            expireHandshake(request);
+            throw new IllegalStateException("매칭 수락 시간이 만료되었습니다.");
+        }
+
+        request.setStatus(MatchRequest.MatchStatus.CONFIRMED);
+        matchRequestRepository.save(request);
+
+        MatchRequest partner = findHandshakePartner(request)
+                .orElseThrow(() -> new IllegalStateException("상대 매칭 정보를 찾을 수 없습니다."));
+
+        if (partner.getStatus() == MatchRequest.MatchStatus.CONFIRMED) {
+            Room room = chatService.createRandomRoom(request.getUser(), partner.getUser());
+            request.setRoom(room);
+            partner.setRoom(room);
+            request.setHandshakeExpiresAt(null);
+            partner.setHandshakeExpiresAt(null);
+            request.setHandshakeKey(null);
+            partner.setHandshakeKey(null);
+
+            matchRequestRepository.save(request);
+            matchRequestRepository.save(partner);
+
+            MatchFoundResponseDto myPayload = buildMatchFoundResponse(request, partner);
+            MatchFoundResponseDto partnerPayload = buildMatchFoundResponse(partner, request);
+
+            messagingService.sendEventToUser(loginId, RealTimeMessagingService.EVENT_MATCH_ROOM_READY, myPayload);
+            messagingService.sendEventToUser(partner.getUser().getLoginId(), RealTimeMessagingService.EVENT_MATCH_ROOM_READY, partnerPayload);
+
+            return myPayload;
+        }
+
+        MatchFoundResponseDto response = buildMatchFoundResponse(request, partner);
+        messagingService.sendEventToUser(partner.getUser().getLoginId(), RealTimeMessagingService.EVENT_MATCH_FOUND, buildMatchFoundResponse(partner, request));
+        return response;
+    }
+
+    public MatchFoundResponseDto declineMatchRequest(String loginId, Long requestId) {
+        MatchRequest request = matchRequestRepository.findByIdWithUser(requestId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다."));
+
+        validateOwnership(loginId, request);
+
+        request.setStatus(MatchRequest.MatchStatus.DECLINED);
+        request.setHandshakeExpiresAt(null);
+        request.setHandshakeKey(null);
+        matchRequestRepository.save(request);
+
+        MatchRequest partner = findHandshakePartner(request)
+                .map(other -> {
+                    other.setStatus(MatchRequest.MatchStatus.DECLINED);
+                    other.setHandshakeExpiresAt(null);
+                    other.setHandshakeKey(null);
+                    matchRequestRepository.save(other);
+                    return other;
+                })
+                .orElse(null);
+
+        MatchFoundResponseDto response = buildMatchFoundResponse(request, partner);
+
+        if (partner != null) {
+            MatchFoundResponseDto partnerResponse = buildMatchFoundResponse(partner, request);
+            messagingService.sendEventToUser(partner.getUser().getLoginId(), RealTimeMessagingService.EVENT_MATCH_DECLINED, partnerResponse);
+        }
+
+        messagingService.sendEventToUser(loginId, RealTimeMessagingService.EVENT_MATCH_DECLINED, response);
+        return response;
+    }
+
+    private MatchRequest buildMatchRequest(User user, MatchRequestDto requestDto, MatchRequest.MatchStatus status) throws JsonProcessingException {
+        return MatchRequest.builder()
+                .user(user)
+                .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
+                .minAge(requestDto.getMinAge())
+                .maxAge(requestDto.getMaxAge())
+                .regionCode(requestDto.getRegionCode())
+                .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
+                .status(status)
+                .build();
+    }
+
+    private MatchFoundResponseDto buildMatchFoundResponse(MatchRequest myRequest, MatchRequest partnerRequest) {
+        Long partnerRequestId = partnerRequest != null ? partnerRequest.getRequestId() : null;
+        String partnerLoginId = partnerRequest != null ? partnerRequest.getUser().getLoginId() : null;
+        String partnerNickName = partnerRequest != null ? partnerRequest.getUser().getNickName() : null;
+        Long roomId = myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null;
+
+        return MatchFoundResponseDto.builder()
+                .myRequestId(myRequest.getRequestId())
+                .partnerRequestId(partnerRequestId)
+                .partnerLoginId(partnerLoginId)
+                .partnerNickName(partnerNickName)
+                .roomId(roomId)
+                .handshakeKey(myRequest.getHandshakeKey())
+                .expiresAt(myRequest.getHandshakeExpiresAt())
+                .status(myRequest.getStatus())
+                .build();
+    }
+
+    private Optional<MatchRequest> findHandshakePartner(MatchRequest request) {
+        String handshakeKey = request.getHandshakeKey();
+        if (handshakeKey == null) {
+            return Optional.empty();
+        }
+
+        return matchRequestRepository.findAllByHandshakeKey(handshakeKey).stream()
+                .filter(other -> !other.getRequestId().equals(request.getRequestId()))
+                .findFirst();
+    }
+
+    private Optional<MatchRequest> findConfirmedPartner(MatchRequest request) {
+        Room room = request.getRoom();
+        if (room == null) {
+            return Optional.empty();
+        }
+        return matchRequestRepository.findByRoom(room).stream()
+                .filter(other -> !other.getRequestId().equals(request.getRequestId()))
+                .findFirst();
+    }
+
+    private boolean isHandshakeExpired(MatchRequest request) {
+        LocalDateTime expiresAt = request.getHandshakeExpiresAt();
+        return expiresAt != null && expiresAt.isBefore(LocalDateTime.now());
+    }
+
+    private void expireHandshake(MatchRequest request) {
+        findHandshakePartner(request).ifPresent(partner -> {
+            partner.setStatus(MatchRequest.MatchStatus.CANCELLED);
+            partner.setHandshakeKey(null);
+            partner.setHandshakeExpiresAt(null);
+            matchRequestRepository.save(partner);
+        });
+
+        request.setStatus(MatchRequest.MatchStatus.CANCELLED);
+        request.setHandshakeKey(null);
+        request.setHandshakeExpiresAt(null);
+        matchRequestRepository.save(request);
+    }
+
+    private void notifyMatchFound(MatchRequest request, MatchFoundResponseDto payload) {
+        try {
+            messagingService.sendEventToUser(request.getUser().getLoginId(), RealTimeMessagingService.EVENT_MATCH_FOUND, payload);
+        } catch (Exception e) {
+            log.error("❌ Failed to send match found event to user {}: {}", request.getUser().getLoginId(), e.getMessage());
+        }
+    }
+
+    private void validateOwnership(String loginId, MatchRequest request) {
+        if (!request.getUser().getLoginId().equals(loginId)) {
+            throw new IllegalArgumentException("본인의 매칭 요청만 처리할 수 있습니다.");
         }
     }
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
@@ -19,6 +19,11 @@ public class RealTimeMessagingService {
     private final WebSocketSessionRegistry sessionRegistry;
     private final ObjectMapper objectMapper;
 
+    public static final String EVENT_MATCH_FOUND = "match-found";
+    public static final String EVENT_MATCH_ROOM_READY = "match-room-ready";
+    public static final String EVENT_MATCH_DECLINED = "match-declined";
+    public static final String EVENT_MATCH_STATUS = "match-status";
+
     public void sendEventToUser(String loginId, String event, Object payload) {
         broadcastToUsers(java.util.List.of(loginId), event, payload);
     }


### PR DESCRIPTION
## Summary
- extend match request entity and repository to support room links, handshake metadata, and new statuses
- add handshake-based matching workflow with accept/decline endpoints and websocket events
- enrich match response DTOs and align fallback lookup with confirmed random rooms

## Testing
- `./gradlew test` *(fails: Gradle toolchain could not locate Java 17 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b521a3748325a773436e87abfa95