### PR TITLE
Promote random match rooms when follows become mutual

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomListResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomListResponseDto.java
@@ -15,6 +15,7 @@ public class RoomListResponseDto {
     private final Room.RoomType roomType;
     private final int memberCount;
     private final List<String> memberNicknames;
+    private final boolean temporary;
 
     public static RoomListResponseDto fromEntity(Room room, List<RoomMember> members) {
         List<String> nicknames = members.stream()
@@ -26,6 +27,7 @@ public class RoomListResponseDto {
                 .roomType(room.getRoomType())
                 .memberCount(members.size())
                 .memberNicknames(nicknames)
+                .temporary(room.isTemporary())
                 .build();
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/MatchRequest.java
@@ -75,6 +75,7 @@ public class MatchRequest {
         MATCHED,
         CONFIRMED,
         DECLINED,
-        CANCELLED
+        CANCELLED,
+        ARCHIVED
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/Room.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/Room.java
@@ -46,6 +46,17 @@ public class Room {
     @Column(name = "closed_at")
     private LocalDateTime closedAt;
 
+    public void markPromoted(RoomType targetType, Room origin, String reason, LocalDateTime promotedAt) {
+        this.roomType = targetType;
+        this.createdFromRoom = origin;
+        this.promotedAt = promotedAt;
+        this.promotedReason = reason;
+    }
+
+    public boolean isTemporary() {
+        return this.roomType == RoomType.RANDOM;
+    }
+
     // --- ENUM 타입 정의 ---
     public enum RoomType {
         RANDOM, PRIVATE, GROUP

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowRepository.java
@@ -5,6 +5,7 @@ import net.datasa.project01.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowee(User follower, User followee);
@@ -12,4 +13,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findAllByFollowerAndStatus(User follower, Follow.FollowStatus status);
 
     List<Follow> findAllByFolloweeAndStatus(User followee, Follow.FollowStatus status);
+
+    Optional<Follow> findByFollowerAndFollowee(User follower, User followee);
+
+    Optional<Follow> findByFollowerAndFolloweeAndStatus(User follower, User followee, Follow.FollowStatus status);
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMemberRepository.java
@@ -8,8 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 // JpaRepository의 두 번째 제네릭 타입으로 엔티티의 ID 클래스인 'RoomMemberId'를 지정
 public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemberId> {
@@ -25,6 +28,11 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemb
 
     Optional<RoomMember> findFirstByUserAndRoom_RoomTypeOrderByJoinedAtDesc(User user, Room.RoomType roomType);
 
+    Optional<RoomMember> findFirstByRoom_RoomTypeAndRoom_PromotedAtIsNullAndUser_UserPidInOrderByJoinedAtDesc(
+            Room.RoomType roomType,
+            Collection<Long> userPids
+    );
+
     /**
      * 특정 사용자가 속한 모든 채팅방과 그 방의 모든 멤버 정보를 한 번의 쿼리로 조회 (N+1 문제 해결)
      */
@@ -32,4 +40,18 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, RoomMemb
            "JOIN FETCH rm.room r " +
            "WHERE r IN (SELECT rm2.room FROM RoomMember rm2 WHERE rm2.user = :user)")
     List<RoomMember> findAllRoomsAndMembersByUser(@Param("user") User user);
+
+    default Optional<Room> findFirstRandomRoomByUsers(Long userPid1, Long userPid2) {
+        Set<Long> userPids = Set.of(userPid1, userPid2);
+
+        return findFirstByRoom_RoomTypeAndRoom_PromotedAtIsNullAndUser_UserPidInOrderByJoinedAtDesc(Room.RoomType.RANDOM, userPids)
+                .map(RoomMember::getRoom)
+                .filter(room -> {
+                    List<RoomMember> members = findByRoom(room);
+                    Set<Long> memberIds = members.stream()
+                            .map(member -> member.getUser().getUserPid())
+                            .collect(Collectors.toSet());
+                    return memberIds.containsAll(userPids);
+                });
+    }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,6 +47,8 @@ public class ChatService {
         private final RoomMessageRepository roomMessageRepository;
         private final TranslationService translationService;
         private final RealTimeMessagingService messagingService;
+
+        private static final String PROMOTION_REASON_MUTUAL_FOLLOW = "MUTUAL_FOLLOW";
 
         private final Path attachmentBasePath = Paths.get("uploads", "attachments");
 
@@ -130,9 +133,17 @@ public class ChatService {
 
         @Transactional
         public Room createRandomRoom(User user1, User user2) {
+                return createRandomMatchRoom(user1, user2);
+        }
+
+        @Transactional
+        public Room createRandomMatchRoom(User user1, User user2) {
                 Room newRoom = Room.builder()
                         .roomType(Room.RoomType.RANDOM)
                         .capacity(2)
+                        .createdFromRoom(null)
+                        .promotedAt(null)
+                        .promotedReason(null)
                         .build();
                 roomRepository.save(newRoom);
 
@@ -153,6 +164,18 @@ public class ChatService {
                 return newRoom;
         }
 
+        @Transactional
+        public Room promoteRandomRoom(Room room) {
+                if (room == null || room.getRoomType() != Room.RoomType.RANDOM) {
+                        return room;
+                }
+
+                Room origin = room.getCreatedFromRoom() != null ? room.getCreatedFromRoom() : room;
+                room.markPromoted(Room.RoomType.PRIVATE, origin, PROMOTION_REASON_MUTUAL_FOLLOW, LocalDateTime.now());
+
+                return roomRepository.save(room);
+        }
+
         @Transactional(readOnly = true)
         public List<RoomListResponseDto> findRoomsByUser(String loginId) {
                 User user = userRepository.findByLoginId(loginId)
@@ -167,6 +190,7 @@ public class ChatService {
 
                 // 3. 그룹핑된 데이터를 DTO로 변환
                 return roomsGroupedByRoom.entrySet().stream()
+                        .filter(entry -> !entry.getKey().isTemporary())
                         .map(entry -> RoomListResponseDto.fromEntity(entry.getKey(), entry.getValue()))
                         .collect(Collectors.toList());
         }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -165,7 +165,7 @@ public class MatchService {
                 .orElseThrow(() -> new IllegalStateException("상대 매칭 정보를 찾을 수 없습니다."));
 
         if (partner.getStatus() == MatchRequest.MatchStatus.CONFIRMED) {
-            Room room = chatService.createRandomRoom(request.getUser(), partner.getUser());
+            Room room = chatService.createRandomMatchRoom(request.getUser(), partner.getUser());
             request.setRoom(room);
             partner.setRoom(room);
             request.setHandshakeExpiresAt(null);
@@ -250,6 +250,23 @@ public class MatchService {
                 .expiresAt(myRequest.getHandshakeExpiresAt())
                 .status(myRequest.getStatus())
                 .build();
+    }
+
+    public void archiveMatchRequestsForRoom(Room room) {
+        List<MatchRequest> requests = matchRequestRepository.findAllByRoomAndStatusIn(
+                room,
+                java.util.List.of(MatchRequest.MatchStatus.CONFIRMED)
+        );
+
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        for (MatchRequest request : requests) {
+            request.setStatus(MatchRequest.MatchStatus.ARCHIVED);
+        }
+
+        matchRequestRepository.saveAll(requests);
     }
 
     private Optional<MatchRequest> findHandshakePartner(MatchRequest request) {

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
@@ -11,17 +11,21 @@ import net.datasa.project01.domain.dto.UserResponse;
 import net.datasa.project01.domain.dto.UserSignUpRequestDto;
 import net.datasa.project01.domain.entity.Follow;
 import net.datasa.project01.domain.entity.Profile;
+import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
 import net.datasa.project01.repository.FollowRepository;
 import net.datasa.project01.repository.ProfileRepository;
+import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.UserRepository;
 import net.datasa.project01.service.email.EmailSender;
+import net.datasa.project01.websocket.RealTimeMessagingService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -37,6 +41,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final ProfileRepository profileRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final ChatService chatService;
+    private final MatchService matchService;
+    private final RealTimeMessagingService messagingService;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationService emailVerificationService;
     private final EmailSender emailSender;
@@ -246,6 +254,10 @@ public class UserService {
         }
         follow.setStatus(newStatus);
         followRepository.save(follow);
+
+        if (newStatus == Follow.FollowStatus.ACCEPTED) {
+            handleMutualFollowPromotion(follow);
+        }
     }
 
     @Transactional
@@ -280,5 +292,32 @@ public class UserService {
                 .map(Follow::getFollower)
                 .map(UserResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    private void handleMutualFollowPromotion(Follow follow) {
+        followRepository.findByFollowerAndFolloweeAndStatus(
+                        follow.getFollowee(),
+                        follow.getFollower(),
+                        Follow.FollowStatus.ACCEPTED)
+                .ifPresent(ignored -> roomMemberRepository
+                        .findFirstRandomRoomByUsers(
+                                follow.getFollower().getUserPid(),
+                                follow.getFollowee().getUserPid())
+                        .ifPresent(randomRoom -> {
+                            Room promotedRoom = chatService.promoteRandomRoom(randomRoom);
+                            if (promotedRoom != null && promotedRoom.getRoomType() == Room.RoomType.PRIVATE) {
+                                matchService.archiveMatchRequestsForRoom(promotedRoom);
+                                messagingService.broadcastToUsers(
+                                        java.util.List.of(
+                                                follow.getFollower().getLoginId(),
+                                                follow.getFollowee().getLoginId()
+                                        ),
+                                        RealTimeMessagingService.EVENT_MATCH_ROOM_PROMOTED,
+                                        Map.of(
+                                                "roomId", promotedRoom.getRoomId(),
+                                                "temporary", false
+                                        ));
+                            }
+                        }));
     }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
@@ -23,6 +23,7 @@ public class RealTimeMessagingService {
     public static final String EVENT_MATCH_ROOM_READY = "match-room-ready";
     public static final String EVENT_MATCH_DECLINED = "match-declined";
     public static final String EVENT_MATCH_STATUS = "match-status";
+    public static final String EVENT_MATCH_ROOM_PROMOTED = "match-room-promoted";
 
     public void sendEventToUser(String loginId, String event, Object payload) {
         broadcastToUsers(java.util.List.of(loginId), event, payload);


### PR DESCRIPTION
## Summary
- add helpers to create and promote random match rooms while tracking promotion metadata and hiding temporary rooms from the room list
- extend follow and room-member repositories plus services so mutual follow acceptance promotes the shared random room and emits a WebSocket event
- archive confirmed match requests once their rooms are promoted to keep matchmaking history clean

## Testing
- ./gradlew test *(fails: missing Java toolchain in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bdae2fc88325b60a76e47014f8b1