### PR TITLE
Revamp matching flow with handshake states and inline chat

### DIFF
--- a/Matcha-Talk/frontend/src/components/MatchChatPanel.vue
+++ b/Matcha-Talk/frontend/src/components/MatchChatPanel.vue
@@ -1,0 +1,314 @@
+<template>
+  <v-card variant="outlined" class="match-chat-panel d-flex flex-column">
+    <div class="flex-grow-1 overflow-y-auto px-3 py-2" ref="messagesContainer">
+      <div v-if="!messages.length" class="text-caption text-medium-emphasis text-center mt-4">
+        {{ placeholderMessage }}
+      </div>
+      <div
+        v-for="message in messages"
+        :key="message.id"
+        class="chat-message my-2"
+        :class="{ 'chat-message--me': message.me }"
+      >
+        <div class="chat-message__meta text-caption text-medium-emphasis">
+          <span v-if="message.sender" class="me-2">{{ message.sender }}</span>
+          <span>{{ message.time }}</span>
+        </div>
+        <div class="chat-message__bubble">
+          {{ message.text }}
+        </div>
+      </div>
+    </div>
+    <v-divider />
+    <div class="px-3 py-2">
+      <v-text-field
+        v-model="draft"
+        :disabled="!canSend"
+        density="comfortable"
+        hide-details
+        variant="outlined"
+        placeholder="메시지를 입력하세요"
+        @keyup.enter.prevent="sendMessage"
+      >
+        <template #append-inner>
+          <v-icon
+            class="cursor-pointer"
+            :color="draft.trim() && canSend ? 'pink' : undefined"
+            @click="sendMessage"
+          >mdi-send</v-icon>
+        </template>
+      </v-text-field>
+      <div v-if="!connectionReady" class="text-caption text-medium-emphasis mt-1">
+        {{ connectionStatusText }}
+      </div>
+      <div v-else class="text-caption text-medium-emphasis mt-1">
+        실시간으로 연결되었습니다.
+      </div>
+    </div>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { useAuthStore } from '../stores/auth'
+import { createRealtimeClient } from '../services/ws'
+import { resolveClientIdentity } from '../utils/identity'
+import { camelizeKeys } from '../utils/case'
+
+const props = defineProps({
+  roomId: {
+    type: [Number, String],
+    default: null,
+  },
+  partnerName: {
+    type: String,
+    default: '',
+  },
+})
+
+const auth = useAuthStore()
+const draft = ref('')
+const messages = ref([])
+const connectionState = ref('idle')
+const connectionError = ref('')
+const messagesContainer = ref(null)
+
+let realtimeClient = null
+let teardownHandlers = []
+let manualDisconnect = false
+let reconnectTimer = null
+
+const normalizedRoomId = computed(() => {
+  const value = Number(props.roomId)
+  return Number.isFinite(value) ? value : null
+})
+
+const connectionReady = computed(() => connectionState.value === 'open')
+const canSend = computed(() => connectionReady.value && normalizedRoomId.value != null)
+const placeholderMessage = computed(() => {
+  if (!normalizedRoomId.value) {
+    return '채팅방이 활성화되면 메시지를 주고받을 수 있습니다.'
+  }
+  if (!connectionReady.value) {
+    return '채팅 서버에 연결하는 중입니다...'
+  }
+  return `${props.partnerName || '상대방'}님과 첫 대화를 시작해보세요!`
+})
+
+const connectionStatusText = computed(() => {
+  switch (connectionState.value) {
+    case 'connecting':
+      return '채팅 서버에 연결 중입니다...'
+    case 'error':
+      return connectionError.value || '연결 오류가 발생했습니다.'
+    case 'closed':
+      return '연결이 종료되었습니다. 잠시 후 다시 시도됩니다.'
+    default:
+      return '연결 준비 중입니다.'
+  }
+})
+
+watch(normalizedRoomId, (nextRoom) => {
+  resetMessages()
+  if (nextRoom != null) {
+    connect()
+  } else {
+    disconnect()
+  }
+}, { immediate: true })
+
+function resetMessages () {
+  messages.value = []
+}
+
+function pushMessage ({ text, sender, me, sentAt }) {
+  const time = formatTime(sentAt)
+  messages.value.push({
+    id: `${sentAt || Date.now()}-${messages.value.length}`,
+    text,
+    sender,
+    me,
+    time,
+  })
+  scrollToBottom()
+}
+
+function formatTime (value) {
+  if (!value) {
+    return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function scrollToBottom () {
+  nextTick(() => {
+    const el = messagesContainer.value
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  })
+}
+
+function ensureClient (loginId) {
+  if (!realtimeClient) {
+    realtimeClient = createRealtimeClient({ queryParams: { loginId } })
+    teardownHandlers.push(
+      realtimeClient.onOpen(() => {
+        connectionState.value = 'open'
+        connectionError.value = ''
+        manualDisconnect = false
+      }),
+      realtimeClient.onClose(() => {
+        connectionState.value = 'closed'
+        if (!manualDisconnect && normalizedRoomId.value != null) {
+          scheduleReconnect()
+        }
+      }),
+      realtimeClient.onError((event) => {
+        connectionState.value = 'error'
+        connectionError.value = event?.message || '연결 오류가 발생했습니다.'
+      }),
+      realtimeClient.onEvent('chat', handleIncomingMessage)
+    )
+  } else {
+    realtimeClient.setQueryParams({ loginId })
+  }
+}
+
+function scheduleReconnect () {
+  if (reconnectTimer) return
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    connect()
+  }, 1500)
+}
+
+async function connect () {
+  if (normalizedRoomId.value == null) {
+    connectionState.value = 'idle'
+    return
+  }
+  const loginId = resolveClientIdentity(auth)
+  manualDisconnect = false
+  ensureClient(loginId)
+  connectionState.value = 'connecting'
+  try {
+    await realtimeClient.connect()
+    connectionState.value = 'open'
+  } catch (error) {
+    connectionState.value = 'error'
+    connectionError.value = error?.message || '연결에 실패했습니다.'
+    scheduleReconnect()
+  }
+}
+
+function disconnect () {
+  manualDisconnect = true
+  if (realtimeClient) {
+    try {
+      realtimeClient.disconnect()
+    } catch (error) {
+      console.warn('[MatchChatPanel] Failed to disconnect WebSocket', error)
+    }
+  }
+  teardownHandlers.forEach((off) => {
+    try { off?.() } catch (error) { console.warn('[MatchChatPanel] Failed to remove handler', error) }
+  })
+  teardownHandlers = []
+  realtimeClient = null
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+  connectionState.value = 'idle'
+}
+
+function handleIncomingMessage (payload) {
+  if (!payload) return
+  const normalized = camelizeKeys(payload)
+  const incomingRoomId = Number(normalized.roomId ?? normalized.room_id)
+  if (!Number.isFinite(incomingRoomId) || incomingRoomId !== normalizedRoomId.value) {
+    return
+  }
+
+  const senderNickname = normalized.senderNickName || normalized.senderNickname || '상대방'
+  const content = normalized.content ?? ''
+  const meNickname = auth.user?.nickName || auth.user?.nickname
+  pushMessage({
+    text: content,
+    sender: senderNickname,
+    me: meNickname ? senderNickname === meNickname : false,
+    sentAt: normalized.sentAt,
+  })
+}
+
+async function sendMessage () {
+  const text = draft.value.trim()
+  if (!text || !canSend.value) return
+
+  try {
+    realtimeClient.send({
+      type: 'CHAT',
+      roomId: normalizedRoomId.value,
+      content: text,
+    })
+    const myNickname = auth.user?.nickName || auth.user?.nickname || '나'
+    pushMessage({
+      text,
+      sender: myNickname,
+      me: true,
+      sentAt: new Date().toISOString(),
+    })
+    draft.value = ''
+  } catch (error) {
+    connectionState.value = 'error'
+    connectionError.value = error?.message || '메시지를 전송하지 못했습니다.'
+  }
+}
+
+onMounted(() => {
+  if (normalizedRoomId.value != null) {
+    connect()
+  }
+})
+
+onBeforeUnmount(() => {
+  disconnect()
+})
+</script>
+
+<style scoped>
+.match-chat-panel {
+  min-height: 320px;
+}
+
+.chat-message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.chat-message--me {
+  margin-left: auto;
+  align-items: flex-end;
+}
+
+.chat-message__meta {
+  margin-bottom: 2px;
+}
+
+.chat-message__bubble {
+  background-color: rgba(255, 192, 203, 0.15);
+  border-radius: 12px;
+  padding: 8px 12px;
+  word-break: break-word;
+}
+
+.chat-message--me .chat-message__bubble {
+  background-color: rgba(255, 105, 180, 0.2);
+}
+</style>

--- a/Matcha-Talk/frontend/src/stores/match.js
+++ b/Matcha-Talk/frontend/src/stores/match.js
@@ -10,7 +10,7 @@ function readFromStorage () {
   if (!hasWindow()) return null
   try {
     const raw = sessionStorage.getItem(STORAGE_KEY)
-    return raw ? JSON.parse(raw) : null
+    return raw ? normalizeBootstrap(JSON.parse(raw)) : null
   } catch (error) {
     console.warn('Failed to parse stored match bootstrap payload', error)
     sessionStorage.removeItem(STORAGE_KEY)
@@ -31,6 +31,102 @@ function writeToStorage (payload) {
   }
 }
 
+function toNumberOrNull (value) {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeBootstrap (payload) {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  const partnerName = payload.partnerName || payload.partnerNickName || payload.partnerNickname || ''
+  const partnerLoginId = payload.partnerLoginId ?? payload.partnerLoginID ?? null
+  const partnerUserPid = toNumberOrNull(payload.partnerUserPid ?? payload.partnerUserId ?? payload.partnerPid)
+  const rawRoomId = payload.roomId ?? payload.roomID ?? payload.matchRoomId
+
+  const handshakeSource = typeof payload.handshake === 'object' && payload.handshake
+    ? payload.handshake
+    : {}
+
+  const handshake = {
+    myRequestId: toNumberOrNull(payload.myRequestId ?? payload.requestId ?? handshakeSource.myRequestId),
+    partnerRequestId: toNumberOrNull(payload.partnerRequestId ?? handshakeSource.partnerRequestId),
+    handshakeKey: payload.handshakeKey ?? handshakeSource.handshakeKey ?? null,
+    expiresAt: payload.expiresAt ?? handshakeSource.expiresAt ?? null,
+    status: (payload.status || handshakeSource.status || '').toString().toUpperCase() || null,
+    roomId: toNumberOrNull(handshakeSource.roomId ?? rawRoomId),
+  }
+
+  const roomId = toNumberOrNull(rawRoomId ?? handshake.roomId)
+  const status = handshake.status
+
+  const computedHandshakeReady = status === 'MATCHED' && !roomId
+  const computedChatReady = roomId != null && (status === 'CONFIRMED' || status === 'ARCHIVED' || status === 'MATCHED' || payload.chatReady === true)
+
+  const followRelationId = toNumberOrNull(payload.followRelationId ?? payload.followId ?? handshakeSource.followRelationId)
+  const followStatus = payload.followStatus || handshakeSource.followStatus || null
+
+  return {
+    matchFound: payload.matchFound ?? (computedHandshakeReady || computedChatReady),
+    handshakeReady: payload.handshakeReady ?? computedHandshakeReady,
+    chatReady: payload.chatReady ?? computedChatReady,
+    partnerName,
+    partnerLoginId: partnerLoginId || null,
+    partnerUserPid,
+    roomId,
+    status,
+    handshake,
+    followStatus,
+    followRelationId,
+  }
+}
+
+function mergeBootstrapPayload (current, patch) {
+  if (!current) {
+    return normalizeBootstrap(patch)
+  }
+  const merged = { ...current, ...patch }
+  merged.partnerName = patch?.partnerName || current.partnerName || ''
+  merged.partnerLoginId = patch?.partnerLoginId ?? current.partnerLoginId ?? null
+  merged.partnerUserPid = patch?.partnerUserPid ?? current.partnerUserPid ?? null
+  merged.roomId = patch?.roomId ?? current.roomId ?? null
+  merged.status = patch?.status ?? current.status ?? null
+  merged.matchFound = patch?.matchFound ?? current.matchFound ?? false
+  merged.handshakeReady = patch?.handshakeReady ?? current.handshakeReady ?? false
+  merged.chatReady = patch?.chatReady ?? current.chatReady ?? false
+  merged.followStatus = patch?.followStatus ?? current.followStatus ?? null
+  merged.followRelationId = patch?.followRelationId ?? current.followRelationId ?? null
+
+  const nextHandshake = {
+    ...(current.handshake || {}),
+    ...(patch?.handshake || {}),
+  }
+  if (patch?.myRequestId !== undefined) {
+    nextHandshake.myRequestId = patch.myRequestId
+  }
+  if (patch?.partnerRequestId !== undefined) {
+    nextHandshake.partnerRequestId = patch.partnerRequestId
+  }
+  if (patch?.handshakeKey !== undefined) {
+    nextHandshake.handshakeKey = patch.handshakeKey
+  }
+  if (patch?.expiresAt !== undefined) {
+    nextHandshake.expiresAt = patch.expiresAt
+  }
+  if (patch?.status !== undefined) {
+    nextHandshake.status = patch.status
+  }
+  if (patch?.roomId !== undefined) {
+    nextHandshake.roomId = patch.roomId
+  }
+  merged.handshake = nextHandshake
+
+  return normalizeBootstrap(merged)
+}
+
 export const useMatchStore = defineStore('match', {
   state: () => ({
     bootstrap: readFromStorage(),
@@ -38,8 +134,16 @@ export const useMatchStore = defineStore('match', {
 
   actions: {
     setBootstrap (payload) {
-      this.bootstrap = payload || null
+      this.bootstrap = normalizeBootstrap(payload)
       writeToStorage(this.bootstrap)
+    },
+    mergeBootstrap (payload) {
+      this.bootstrap = mergeBootstrapPayload(this.bootstrap, payload)
+      writeToStorage(this.bootstrap)
+    },
+    updateHandshake (payload) {
+      const next = { handshake: payload }
+      this.mergeBootstrap(next)
     },
     clearBootstrap () {
       this.bootstrap = null

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -321,6 +321,9 @@ async function loadRooms() {
 
     data.forEach((room) => {
       const entry = normalizeRoomListEntry(room, meNickname)
+      if (!entry || entry.type === 'RANDOM' || entry.temporary) {
+        return
+      }
       ensureConversation(entry.id)
       if (entry.type === 'GROUP') {
         groupRooms.push(entry)
@@ -345,6 +348,7 @@ async function loadRooms() {
 function normalizeRoomListEntry(room, meNickname) {
   const participants = room.memberNicknames ?? []
   const type = (room.roomType || 'PRIVATE').toString().toUpperCase()
+  const temporary = Boolean(room.temporary ?? room.temp ?? false)
   const others = meNickname ? participants.filter((nick) => nick !== meNickname) : participants
 
   let displayName
@@ -361,7 +365,8 @@ function normalizeRoomListEntry(room, meNickname) {
     participants,
     participantLogins: room.memberLoginIds || [],
     participantsDetail: [],
-    type
+    type,
+    temporary,
   }
 }
 

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -3,59 +3,171 @@
     <v-row justify="center">
       <v-col cols="12" md="10">
         <v-card class="pa-6">
-          <!-- 매칭 상태 표시 -->
-          <div v-if="!matchFound" class="text-center py-8">
-            <v-progress-circular indeterminate color="pink" size="64" class="mb-4"></v-progress-circular>
+          <div v-if="isPending" class="text-center py-8">
+            <v-progress-circular
+              indeterminate
+              color="pink"
+              size="64"
+              class="mb-4"
+            />
             <div class="text-h6 mb-2">매칭 상대를 찾고 있습니다...</div>
             <div class="text-caption text-medium-emphasis">{{ sessionStatus }}</div>
           </div>
 
-          <!-- 매칭 성공 시 -->
+          <div v-else-if="matchDeclined">
+            <v-alert type="error" variant="tonal" class="mb-6">
+              상대방이 매칭을 거절했습니다. 새로운 인연을 찾아볼까요?
+            </v-alert>
+            <div class="text-center">
+              <v-btn color="pink" variant="tonal" @click="restartMatching">다시 매칭 시도</v-btn>
+            </div>
+          </div>
+
           <div v-else>
-            <v-row class="align-center mb-6">
-              <v-avatar size="40" class="me-3">
+            <v-row class="align-center mb-4" no-gutters>
+              <v-avatar size="48" class="me-3">
                 <v-img :src="partnerAvatar" alt="avatar" />
               </v-avatar>
               <div>
                 <div class="text-h6 text-pink-darken-2">{{ partnerName }}님과 매칭되었습니다</div>
-                <div class="text-caption text-medium-emphasis">{{ sessionStatus }}</div>
+                <div class="text-caption text-medium-emphasis">
+                  {{ partnerLoginId || '로그인 아이디 확인 중' }}
+                </div>
+              </div>
+              <v-spacer />
+              <div class="text-caption text-medium-emphasis">
+                {{ handshakeStatusLabel }}
               </div>
             </v-row>
 
-            <v-row>
-              <v-col cols="12" md="9">
-                <v-img
-                  v-if="mediaUrl"
-                  :src="mediaUrl"
-                  class="rounded-lg bg-grey-lighten-2 media-wrapper"
-                  cover
+            <v-alert
+              v-if="promotionNotice"
+              type="success"
+              variant="tonal"
+              class="mb-4 promotion-alert"
+            >
+              서로 팔로우를 완료했습니다. 채팅 탭에서도 대화를 이어갈 수 있어요!
+              <template #append>
+                <v-btn
+                  v-if="chatReady && roomId"
+                  color="success"
+                  variant="flat"
+                  size="small"
+                  class="ms-2"
+                  @click="goToChatRoom"
                 >
-                  <template #placeholder>
-                    <v-row class="fill-height ma-0" align="center" justify="center">
-                      <v-progress-circular indeterminate color="pink" />
-                    </v-row>
-                  </template>
-                </v-img>
-                <div
-                  v-else
-                  class="rounded-lg bg-pink-lighten-5 d-flex align-center justify-center media-wrapper"
-                >
-                  <div class="text-subtitle-1">매칭 이미지 / 영상이 없습니다.</div>
-                </div>
-              </v-col>
-              <v-col cols="12" md="3">
-                <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
-                  <div class="text-subtitle-2 mb-3">채팅</div>
-                  <div class="flex-grow-1 overflow-y-auto">
-                    <div class="text-caption text-center text-grey">{{ partnerName }}님과 대화를 시작해보세요!</div>
+                  채팅 탭 열기
+                </v-btn>
+              </template>
+            </v-alert>
+
+            <v-alert type="info" variant="tonal" class="mb-4">
+              {{ sessionStatus }}
+              <div v-if="handshakeReady && countdown" class="text-caption text-medium-emphasis countdown">
+                수락 마감까지 {{ countdown }}
+              </div>
+            </v-alert>
+
+            <v-row class="gap-y-4">
+              <v-col cols="12" md="7">
+                <v-card variant="outlined" class="pa-4 h-100 status-card">
+                  <div class="text-subtitle-2 mb-3">매칭 정보</div>
+                  <div class="text-body-2 mb-2">
+                    <span class="text-medium-emphasis">상대 닉네임</span>
+                    : {{ partnerName || '알 수 없음' }}
                   </div>
+                  <div class="text-body-2 mb-2" v-if="partnerLoginId">
+                    <span class="text-medium-emphasis">상대 아이디</span>
+                    : {{ partnerLoginId }}
+                  </div>
+                  <div class="text-body-2 mb-2" v-if="handshakeInfo?.handshakeKey">
+                    <span class="text-medium-emphasis">핸드셰이크 키</span>
+                    : {{ handshakeInfo.handshakeKey }}
+                  </div>
+                  <div class="text-body-2 mb-2" v-if="roomId">
+                    <span class="text-medium-emphasis">채팅방 번호</span>
+                    : {{ roomId }}
+                  </div>
+                  <div class="text-body-2 mb-2" v-if="handshakeInfo?.partnerRequestId">
+                    <span class="text-medium-emphasis">상대 요청 ID</span>
+                    : {{ handshakeInfo.partnerRequestId }}
+                  </div>
+                  <div class="text-body-2 mb-2" v-if="followStatusMessage">
+                    <span class="text-medium-emphasis">팔로우 상태</span>
+                    : {{ followStatusMessage }}
+                  </div>
+                  <div class="text-body-2 text-medium-emphasis mt-3" v-if="chatReady">
+                    이제 바로 이 화면에서 대화를 시작해보세요!
+                  </div>
+                  <div class="text-body-2 text-medium-emphasis mt-3" v-else-if="handshakeReady">
+                    상대방도 수락하면 실시간 채팅이 열립니다.
+                  </div>
+                </v-card>
+              </v-col>
+              <v-col cols="12" md="5">
+                <MatchChatPanel
+                  v-if="chatReady && roomId"
+                  :room-id="roomId"
+                  :partner-name="partnerName"
+                />
+                <v-card
+                  v-else
+                  variant="outlined"
+                  class="pa-4 h-100 d-flex align-center justify-center text-center text-body-2 text-medium-emphasis"
+                >
+                  양측이 수락하면 실시간 채팅을 이용할 수 있습니다.
                 </v-card>
               </v-col>
             </v-row>
 
-            <div class="d-flex justify-center gap-4 mt-6">
-              <v-btn color="pink" variant="tonal" @click="acceptMatch">채팅방 입장</v-btn>
-              <v-btn color="grey" variant="outlined" @click="declineMatch">거절</v-btn>
+            <div v-if="handshakeReady" class="d-flex justify-center mt-6 gap-4 match-action-buttons">
+              <v-btn
+                color="pink"
+                variant="flat"
+                size="large"
+                :loading="acceptLoading"
+                @click="acceptMatch"
+              >
+                매칭 수락
+              </v-btn>
+              <v-btn
+                color="grey"
+                variant="outlined"
+                size="large"
+                :loading="declineLoading"
+                @click="declineMatch"
+              >
+                거절
+              </v-btn>
+            </div>
+
+            <div class="d-flex justify-center gap-4 mt-6 follow-actions">
+              <v-btn
+                v-if="canRequestFollow"
+                color="pink"
+                variant="tonal"
+                :loading="followRequestLoading"
+                @click="requestFollow"
+              >
+                팔로우 요청 보내기
+              </v-btn>
+              <v-btn
+                v-if="canAcceptFollow"
+                color="success"
+                variant="tonal"
+                :loading="followAcceptLoading"
+                @click="acceptFollowRequest"
+              >
+                팔로우 수락
+              </v-btn>
+              <v-btn
+                v-if="chatReady && roomId"
+                color="primary"
+                variant="text"
+                @click="goToChatRoom"
+              >
+                채팅 탭으로 이동
+              </v-btn>
             </div>
           </div>
         </v-card>
@@ -65,7 +177,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { createRealtimeClient } from '../services/ws'
@@ -73,46 +185,412 @@ import { camelizeKeys } from '../utils/case'
 import { resolveClientIdentity } from '../utils/identity'
 import api from '../services/api'
 import { useMatchStore } from '../stores/match'
+import followService from '../services/follow'
+import MatchChatPanel from '../components/MatchChatPanel.vue'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 const matchStore = useMatchStore()
 
-const matchFound = ref(false)
 const partnerName = ref('')
 const partnerAvatar = ref('https://via.placeholder.com/150')
-const sessionStatus = ref('대기 중')
-const mediaUrl = ref('')
+const partnerLoginId = ref(null)
+const partnerUserPid = ref(null)
+const sessionStatus = ref('매칭 대기 중입니다...')
 const roomId = ref(null)
+const handshakeInfo = ref(null)
+const handshakeStatus = ref(null)
+const handshakeReady = ref(false)
+const chatReady = ref(false)
+const matchReady = ref(false)
+const matchDeclined = ref(false)
+const countdown = ref('')
+const promotionNotice = ref(false)
+
+const followState = reactive({
+  status: null,
+  relationId: null,
+})
+const followRequestLoading = ref(false)
+const followAcceptLoading = ref(false)
+const acceptLoading = ref(false)
+const declineLoading = ref(false)
+
+let countdownTimer = null
+
+const isPending = computed(() => !matchReady.value && !matchDeclined.value)
+const handshakeStatusLabel = computed(() => {
+  if (!handshakeStatus.value) return '상태 확인 중'
+  switch (handshakeStatus.value) {
+    case 'MATCHED':
+      return '상대 수락 대기중'
+    case 'CONFIRMED':
+      return '채팅 준비 완료'
+    case 'DECLINED':
+      return '매칭 거절됨'
+    case 'ARCHIVED':
+      return '대화 이력 보관됨'
+    default:
+      return handshakeStatus.value
+  }
+})
+const followStatusUpper = computed(() => (followState.status || '').toString().toUpperCase())
+const followStatusMessage = computed(() => {
+  if (!followState.status) return ''
+  if (followStatusUpper.value.includes('ACCEPT')) {
+    return '서로 팔로우 상태입니다.'
+  }
+  if (followStatusUpper.value.includes('INCOMING') || followStatusUpper.value.includes('RECEIVED')) {
+    return '상대방이 팔로우 요청을 보냈습니다.'
+  }
+  if (followStatusUpper.value.includes('PENDING') || followStatusUpper.value.includes('REQUEST')) {
+    return '팔로우 응답을 기다리고 있습니다.'
+  }
+  return followState.status
+})
+const canRequestFollow = computed(() => {
+  if (partnerUserPid.value == null) return false
+  if (!followStatusUpper.value) return true
+  if (followStatusUpper.value.includes('ACCEPT')) return false
+  if (followStatusUpper.value.includes('OUTGOING')) return false
+  if (followStatusUpper.value.includes('PENDING') &&
+    !followStatusUpper.value.includes('INCOMING') &&
+    !followStatusUpper.value.includes('RECEIVED')) {
+    return false
+  }
+  return true
+})
+const canAcceptFollow = computed(() => {
+  if (!followState.relationId) return false
+  if (!followStatusUpper.value) return true
+  if (followStatusUpper.value.includes('ACCEPT')) return false
+  return followStatusUpper.value.includes('INCOMING') ||
+    followStatusUpper.value.includes('RECEIVED') ||
+    followStatusUpper.value === 'PENDING'
+})
+
+const chatRouteQuery = computed(() => {
+  if (!roomId.value) return {}
+  return {
+    roomId: String(roomId.value),
+    partner: partnerName.value || undefined,
+  }
+})
+
+watch(() => matchStore.bootstrap, (next) => {
+  applyBootstrap(next)
+}, { immediate: true })
+
+watch(chatReady, (ready) => {
+  if (!ready) {
+    promotionNotice.value = false
+  }
+})
+
+function startCountdown (expiresAt) {
+  if (countdownTimer) {
+    clearInterval(countdownTimer)
+    countdownTimer = null
+  }
+  if (!expiresAt || !handshakeReady.value) {
+    countdown.value = ''
+    return
+  }
+
+  const target = new Date(expiresAt)
+  if (Number.isNaN(target.getTime())) {
+    countdown.value = ''
+    return
+  }
+
+  const update = () => {
+    const diff = target.getTime() - Date.now()
+    if (diff <= 0) {
+      countdown.value = '만료됨'
+      if (countdownTimer) {
+        clearInterval(countdownTimer)
+        countdownTimer = null
+      }
+      return
+    }
+    const minutes = Math.floor(diff / 60000)
+    const seconds = Math.floor((diff % 60000) / 1000)
+    countdown.value = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+
+  update()
+  countdownTimer = setInterval(update, 1000)
+}
+
+function applyBootstrap (payload, options = {}) {
+  if (!payload) {
+    partnerName.value = ''
+    partnerLoginId.value = null
+    partnerUserPid.value = null
+    roomId.value = null
+    handshakeInfo.value = null
+    handshakeStatus.value = null
+    handshakeReady.value = false
+    chatReady.value = false
+    matchReady.value = false
+    matchDeclined.value = false
+    followState.status = null
+    followState.relationId = null
+    sessionStatus.value = options.statusMessage || '매칭 대기 중입니다...'
+    startCountdown(null)
+    return
+  }
+
+  partnerName.value = payload.partnerName || partnerName.value || ''
+  partnerLoginId.value = payload.partnerLoginId || payload.partnerLoginID || partnerLoginId.value || null
+  partnerUserPid.value = payload.partnerUserPid ?? partnerUserPid.value ?? null
+  roomId.value = payload.roomId ?? payload.handshake?.roomId ?? roomId.value ?? null
+  handshakeInfo.value = payload.handshake || handshakeInfo.value || null
+  handshakeStatus.value = payload.status || payload.handshake?.status || handshakeStatus.value || null
+  followState.status = payload.followStatus ?? followState.status ?? null
+  followState.relationId = payload.followRelationId ?? payload.followId ?? followState.relationId ?? null
+
+  handshakeReady.value = !!payload.handshakeReady
+  chatReady.value = !!payload.chatReady || (roomId.value != null && (handshakeStatus.value === 'CONFIRMED' || handshakeStatus.value === 'ARCHIVED'))
+  matchReady.value = handshakeReady.value || chatReady.value
+  matchDeclined.value = handshakeStatus.value === 'DECLINED'
+
+  if (matchDeclined.value) {
+    sessionStatus.value = options.statusMessage || '매칭이 거절되었습니다.'
+  } else if (chatReady.value) {
+    sessionStatus.value = options.statusMessage || '채팅이 가능합니다!'
+  } else if (handshakeReady.value) {
+    sessionStatus.value = options.statusMessage || '상대방의 수락을 기다리는 중입니다.'
+  } else {
+    sessionStatus.value = options.statusMessage || '매칭 대기 중입니다...'
+  }
+
+  startCountdown(payload.handshake?.expiresAt ?? handshakeInfo.value?.expiresAt ?? null)
+}
+
+function ingestMatchPayload (payload, options = {}) {
+  if (!payload) return
+  const normalized = camelizeKeys(payload)
+  const patch = {
+    matchFound: true,
+    partnerName: normalized.partnerNickName || normalized.partnerNickname || partnerName.value,
+    partnerLoginId: normalized.partnerLoginId ?? partnerLoginId.value ?? null,
+    partnerUserPid: normalized.partnerUserPid ?? partnerUserPid.value ?? null,
+    roomId: normalized.roomId ?? roomId.value ?? null,
+    status: normalized.status ?? handshakeStatus.value ?? null,
+    followStatus: normalized.followStatus ?? followState.status ?? null,
+    followRelationId: normalized.followRelationId ?? normalized.followId ?? followState.relationId ?? null,
+    handshake: {
+      myRequestId: normalized.myRequestId ?? handshakeInfo.value?.myRequestId ?? null,
+      partnerRequestId: normalized.partnerRequestId ?? handshakeInfo.value?.partnerRequestId ?? null,
+      handshakeKey: normalized.handshakeKey ?? handshakeInfo.value?.handshakeKey ?? null,
+      expiresAt: normalized.expiresAt ?? handshakeInfo.value?.expiresAt ?? null,
+      status: normalized.status ?? handshakeInfo.value?.status ?? null,
+      roomId: normalized.roomId ?? handshakeInfo.value?.roomId ?? null,
+      followStatus: normalized.followStatus ?? handshakeInfo.value?.followStatus ?? null,
+      followRelationId: normalized.followRelationId ?? handshakeInfo.value?.followRelationId ?? null,
+    },
+  }
+  matchStore.mergeBootstrap(patch)
+  applyBootstrap(matchStore.bootstrap, { statusMessage: options.statusMessage })
+}
+
+function handleMatchFound (payload) {
+  ingestMatchPayload(payload, { statusMessage: '새로운 매칭이 성사되었습니다. 수락을 진행해주세요.' })
+}
+
+function handleMatchRoomReady (payload) {
+  promotionNotice.value = false
+  ingestMatchPayload(payload, { statusMessage: '채팅방이 준비되었습니다!' })
+}
+
+function handleMatchDeclined (payload) {
+  ingestMatchPayload(payload, { statusMessage: '상대방이 매칭을 거절했습니다.' })
+  matchDeclined.value = true
+}
+
+function handleRoomPromoted (payload) {
+  const normalized = camelizeKeys(payload || {})
+  if (normalized.roomId) {
+    matchStore.mergeBootstrap({
+      roomId: normalized.roomId,
+      chatReady: true,
+    })
+    roomId.value = normalized.roomId
+  }
+  followState.status = 'ACCEPTED'
+  matchStore.mergeBootstrap({
+    followStatus: 'ACCEPTED',
+    followRelationId: normalized.followRelationId ?? matchStore.bootstrap?.followRelationId ?? null,
+  })
+  promotionNotice.value = true
+}
+
+function handleMatchStatus (payload) {
+  if (typeof payload === 'string') {
+    sessionStatus.value = payload || sessionStatus.value
+    return
+  }
+  if (payload) {
+    const normalized = camelizeKeys(payload)
+    sessionStatus.value = normalized.message || sessionStatus.value
+  }
+}
+
+async function acceptMatch () {
+  if (acceptLoading.value) return
+  const requestId = handshakeInfo.value?.myRequestId ?? matchStore.bootstrap?.handshake?.myRequestId
+  if (!requestId) {
+    alert('매칭 요청 정보를 찾을 수 없습니다.')
+    return
+  }
+  acceptLoading.value = true
+  try {
+    const loginId = resolveClientIdentity(auth)
+    const { data } = await api.post(`/match/requests/${requestId}/accept`, {}, {
+      headers: {
+        'X-Login-Id': loginId,
+      },
+      skipSnakifyParams: true,
+    })
+    if (data) {
+      ingestMatchPayload(data, { statusMessage: '매칭을 수락했습니다. 상대방을 기다리는 중입니다.' })
+    }
+  } catch (error) {
+    console.error('Failed to accept match', error)
+    alert('매칭 수락에 실패했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
+  } finally {
+    acceptLoading.value = false
+  }
+}
+
+async function declineMatch () {
+  if (declineLoading.value) return
+  const requestId = handshakeInfo.value?.myRequestId ?? matchStore.bootstrap?.handshake?.myRequestId
+  if (!requestId) {
+    alert('매칭 요청 정보를 찾을 수 없습니다.')
+    return
+  }
+  if (!confirm('매칭을 거절하시겠습니까?')) return
+  declineLoading.value = true
+  try {
+    const loginId = resolveClientIdentity(auth)
+    const { data } = await api.post(`/match/requests/${requestId}/decline`, {}, {
+      headers: {
+        'X-Login-Id': loginId,
+      },
+      skipSnakifyParams: true,
+    })
+    ingestMatchPayload(data, { statusMessage: '매칭을 거절했습니다.' })
+    matchDeclined.value = true
+  } catch (error) {
+    console.error('Failed to decline match', error)
+    alert('매칭 거절에 실패했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
+  } finally {
+    declineLoading.value = false
+  }
+}
+
+async function requestFollow () {
+  if (!canRequestFollow.value || followRequestLoading.value) return
+  const followeeId = Number(partnerUserPid.value)
+  if (!Number.isFinite(followeeId) || followeeId <= 0) {
+    alert('팔로우 요청 대상 정보를 확인할 수 없습니다.')
+    return
+  }
+  followRequestLoading.value = true
+  try {
+    await followService.requestFollow(followeeId)
+    followState.status = 'PENDING_OUTGOING'
+    matchStore.mergeBootstrap({ followStatus: followState.status })
+    sessionStatus.value = '팔로우 요청을 전송했습니다.'
+  } catch (error) {
+    console.error('Failed to send follow request', error)
+    alert('팔로우 요청에 실패했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
+  } finally {
+    followRequestLoading.value = false
+  }
+}
+
+async function acceptFollowRequest () {
+  if (!canAcceptFollow.value || followAcceptLoading.value) return
+  const followId = followState.relationId
+  followAcceptLoading.value = true
+  try {
+    await followService.acceptFollow(followId)
+    followState.status = 'ACCEPTED'
+    matchStore.mergeBootstrap({ followStatus: 'ACCEPTED', followRelationId: followId })
+    promotionNotice.value = true
+  } catch (error) {
+    console.error('Failed to accept follow request', error)
+    alert('팔로우 수락에 실패했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
+  } finally {
+    followAcceptLoading.value = false
+  }
+}
+
+function goToChatRoom () {
+  if (!roomId.value) return
+  router.push({ name: 'chat', query: { ...chatRouteQuery.value } })
+}
+
+function restartMatching () {
+  matchStore.clearBootstrap()
+  router.push({ name: 'match' })
+}
+
+async function fetchLatestMatchFromRest () {
+  try {
+    const loginId = resolveClientIdentity(auth)
+    if (!loginId) return
+    const response = await api.get('/match/results/latest', {
+      headers: {
+        'X-Login-Id': loginId,
+      },
+      skipSnakifyParams: true,
+    })
+    if (response.status === 204 || !response.data) {
+      return
+    }
+    ingestMatchPayload(response.data, { statusMessage: '최근 매칭 정보를 불러왔습니다.' })
+  } catch (error) {
+    console.warn('Failed to fetch latest match result', error?.response?.data || error?.message)
+  }
+}
+
+function extractBootstrapFromRoute () {
+  const { matched, roomId: routeRoomId, partner, status, requestId } = route.query
+  if (matched === '1' || matched === 'true') {
+    const parsedRoomId = typeof routeRoomId !== 'undefined' ? Number(routeRoomId) : null
+    const parsedRequestId = typeof requestId !== 'undefined' ? Number(requestId) : null
+    return {
+      matchFound: true,
+      partnerName: typeof partner === 'string' ? partner : '',
+      roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
+      status: typeof status === 'string' ? status : null,
+      handshake: {
+        myRequestId: Number.isFinite(parsedRequestId) ? parsedRequestId : null,
+        status: typeof status === 'string' ? status : null,
+        roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
+      },
+    }
+  }
+  return null
+}
+
+function isQueuedFromRoute () {
+  const { queued } = route.query
+  return queued === '1' || queued === 'true'
+}
 
 const connectionAttempts = ref(0)
 const maxConnectionAttempts = 3
 const isConnecting = ref(false)
-
 let websocketClient = null
 let reconnectTimer = null
 let manualDisconnect = false
 const teardownHandlers = []
-
-onMounted(async () => {
-  const routeBootstrap = extractBootstrapFromRoute()
-  const queuedFromRoute = isQueuedFromRoute()
-  if (routeBootstrap) {
-    applyMatchBootstrap(routeBootstrap, { persist: true })
-  } else if (queuedFromRoute) {
-    matchStore.clearBootstrap()
-    sessionStatus.value = '매칭 대기열에 등록되었습니다.'
-  } else if (matchStore.bootstrap) {
-    applyMatchBootstrap(matchStore.bootstrap)
-  }
-
-  if (!matchFound.value) {
-    await fetchLatestMatchFromRest()
-  }
-
-  connectWebSocket()
-})
 
 async function connectWebSocket () {
   if (isConnecting.value || manualDisconnect) return
@@ -123,13 +601,11 @@ async function connectWebSocket () {
     websocketClient = createRealtimeClient({ queryParams: { loginId } })
     teardownHandlers.push(
       websocketClient.onOpen(() => {
-        console.log('✅ WebSocket connected for matching results')
         isConnecting.value = false
         connectionAttempts.value = 0
-        sessionStatus.value = '매칭 서버에 연결되었습니다.'
+        sessionStatus.value = chatReady.value ? '채팅이 가능합니다!' : '매칭 서버에 연결되었습니다.'
       }),
       websocketClient.onClose((event) => {
-        console.log('🔌 WebSocket connection closed:', event)
         isConnecting.value = false
         if (manualDisconnect) return
         if (!event.wasClean) {
@@ -139,98 +615,62 @@ async function connectWebSocket () {
       websocketClient.onError((event) => {
         console.error('❌ WebSocket error:', event)
       }),
-      websocketClient.onEvent('match-result', handleMatchResult),
+      websocketClient.onEvent('match-found', handleMatchFound),
+      websocketClient.onEvent('match-room-ready', handleMatchRoomReady),
+      websocketClient.onEvent('match-declined', handleMatchDeclined),
+      websocketClient.onEvent('match-room-promoted', handleRoomPromoted),
       websocketClient.onEvent('match-status', handleMatchStatus),
       websocketClient.onEvent('connected', () => {
-        sessionStatus.value = '매칭 대기 중입니다...'
-      })
+        sessionStatus.value = '매칭 서버에 연결되었습니다.'
+      }),
     )
   } else {
     websocketClient.setQueryParams({ loginId })
   }
 
   isConnecting.value = true
-
   try {
     await websocketClient.connect()
   } catch (error) {
     console.error('❌ Failed to establish WebSocket connection:', error)
     isConnecting.value = false
+    scheduleReconnect()
   }
 }
 
 function scheduleReconnect () {
   if (manualDisconnect) return
   if (connectionAttempts.value >= maxConnectionAttempts) {
-    console.error('❌ Max connection attempts reached')
     sessionStatus.value = '매칭 서버 연결에 실패했습니다. 잠시 후 다시 시도해주세요.'
     return
   }
-
-  if (reconnectTimer) {
-    console.log('⏳ Reconnect already scheduled, skip new timer')
-    return
-  }
+  if (reconnectTimer) return
 
   connectionAttempts.value += 1
-  console.log(`🔄 Retrying WebSocket connection (${connectionAttempts.value}/${maxConnectionAttempts})`)
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null
     connectWebSocket()
   }, 2000)
 }
 
-function handleMatchResult (payload) {
-  if (!payload) return
-
-  const normalized = camelizeKeys(payload)
-
-  console.log('🎉 Match found!', normalized)
-  matchFound.value = true
-  partnerName.value = normalized.partnerNickName || normalized.partnerNickname || '상대방'
-  roomId.value = normalized.roomId ?? normalized.room_id ?? null
-  sessionStatus.value = '매칭 성공!'
-  matchStore.setBootstrap({
-    matchFound: matchFound.value,
-    partnerName: partnerName.value,
-    roomId: roomId.value,
-  })
-}
-
-function handleMatchStatus (payload) {
-  if (typeof payload === 'string') {
-    sessionStatus.value = payload || '매칭 대기 중입니다...'
-  } else if (payload) {
-    const normalized = camelizeKeys(payload)
-    sessionStatus.value = normalized.message || '매칭 대기 중입니다...'
-  } else {
-    sessionStatus.value = '매칭 대기 중입니다...'
-  }
-}
-
-function acceptMatch () {
-  if (!roomId.value) {
-    alert('채팅방 정보가 없습니다.')
-    return
-  }
-
-  manualDisconnect = true
-  matchStore.clearBootstrap()
-  router.push({
-    name: 'chat',
-    query: {
-      roomId: String(roomId.value),
-      partner: partnerName.value || undefined
-    }
-  })
-}
-
-function declineMatch () {
-  if (confirm('매칭을 거절하시겠습니까?')) {
+onMounted(async () => {
+  const routeBootstrap = extractBootstrapFromRoute()
+  const queuedFromRoute = isQueuedFromRoute()
+  if (routeBootstrap) {
+    matchStore.mergeBootstrap(routeBootstrap)
+  } else if (queuedFromRoute) {
     matchStore.clearBootstrap()
-    router.push({ name: 'match' })
+    applyBootstrap(null, { statusMessage: '매칭 대기열에 등록되었습니다.' })
+  } else if (matchStore.bootstrap) {
+    applyBootstrap(matchStore.bootstrap)
   }
-}
+
+  if (!matchReady.value) {
+    await fetchLatestMatchFromRest()
+  }
+
+  connectWebSocket()
+})
 
 onBeforeUnmount(() => {
   manualDisconnect = true
@@ -250,89 +690,40 @@ onBeforeUnmount(() => {
   teardownHandlers.length = 0
 
   if (websocketClient) {
-    websocketClient.disconnect()
+    try {
+      websocketClient.disconnect()
+    } catch (error) {
+      console.warn('Failed to disconnect WebSocket cleanly', error)
+    }
     websocketClient = null
   }
+
+  if (countdownTimer) {
+    clearInterval(countdownTimer)
+    countdownTimer = null
+  }
 })
-
-function extractBootstrapFromRoute () {
-  const { matched, roomId: routeRoomId, partner } = route.query
-  if (matched === '1' || matched === 'true') {
-    const parsedRoomId = typeof routeRoomId !== 'undefined' ? Number(routeRoomId) : null
-    return {
-      matchFound: true,
-      roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
-      partnerName: typeof partner === 'string' ? partner : '',
-    }
-  }
-  return null
-}
-
-function isQueuedFromRoute () {
-  const { queued } = route.query
-  return queued === '1' || queued === 'true'
-}
-
-function applyMatchBootstrap (payload, options = {}) {
-  if (!payload) return
-
-  const { persist = false, statusMessage } = options
-  const normalizedName = payload.partnerName || payload.partnerNickName || payload.partnerNickname || ''
-  const normalizedRoomId = typeof payload.roomId === 'number' ? payload.roomId : payload.roomId != null ? Number(payload.roomId) : null
-
-  matchFound.value = !!payload.matchFound
-  partnerName.value = normalizedName
-  roomId.value = Number.isFinite(normalizedRoomId) ? normalizedRoomId : null
-  sessionStatus.value = statusMessage || (matchFound.value ? '매칭 성공!' : '매칭 대기 중입니다...')
-
-  if (persist) {
-    if (matchFound.value) {
-      matchStore.setBootstrap({
-        matchFound: true,
-        partnerName: partnerName.value,
-        roomId: roomId.value,
-      })
-    } else {
-      matchStore.clearBootstrap()
-    }
-  }
-}
-
-async function fetchLatestMatchFromRest () {
-  try {
-    const loginId = resolveClientIdentity(auth)
-    if (!loginId) return
-
-    const response = await api.get('/match/results/latest', {
-      headers: {
-        'X-Login-Id': loginId,
-      },
-      skipSnakifyParams: true,
-    })
-
-    if (response.status === 204 || !response.data) {
-      return
-    }
-
-    const payload = {
-      matchFound: true,
-      roomId: response.data.roomId ?? null,
-      partnerName: response.data.partnerNickName ?? response.data.partnerNickname ?? '',
-    }
-
-    applyMatchBootstrap(payload, { persist: true, statusMessage: '최근 매칭 정보를 불러왔습니다.' })
-  } catch (error) {
-    console.warn('Failed to fetch latest match result', error?.response?.data || error?.message)
-  }
-}
 </script>
 
 <style scoped>
-.media-wrapper {
-  max-height: 380px;
+.status-card {
+  min-height: 240px;
 }
 
-.chat-wrapper {
-  max-height: 380px;
+.match-action-buttons {
+  gap: 16px;
+}
+
+.follow-actions {
+  flex-wrap: wrap;
+}
+
+.countdown {
+  font-variant-numeric: tabular-nums;
+  margin-top: 8px;
+}
+
+.promotion-alert {
+  border-radius: 12px;
 }
 </style>

--- a/Matcha-Talk/frontend/src/views/MatchingSetup.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingSetup.vue
@@ -109,6 +109,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useMatchStore } from '../stores/match'
 import { resolveClientIdentity } from '../utils/identity'
+import { camelizeKeys } from '../utils/case'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -156,18 +157,34 @@ async function startMatch(){
       }
     })
     if (data?.matchedNow && data?.match) {
-      const bootstrapPayload = {
+      const normalizedMatch = camelizeKeys(data.match)
+
+      const handshakePayload = {
         matchFound: true,
-        roomId: data.match.roomId ?? null,
-        partnerName: data.match.partnerNickName ?? data.match.partnerNickname ?? '',
+        partnerName: normalizedMatch.partnerNickName || normalizedMatch.partnerNickname || '',
+        partnerLoginId: normalizedMatch.partnerLoginId ?? null,
+        partnerUserPid: normalizedMatch.partnerUserPid ?? null,
+        roomId: normalizedMatch.roomId ?? null,
+        status: normalizedMatch.status ?? null,
+        followStatus: normalizedMatch.followStatus ?? null,
+        followRelationId: normalizedMatch.followRelationId ?? normalizedMatch.followId ?? null,
+        handshake: {
+          myRequestId: normalizedMatch.myRequestId ?? data.requestId ?? null,
+          partnerRequestId: normalizedMatch.partnerRequestId ?? null,
+          handshakeKey: normalizedMatch.handshakeKey ?? null,
+          expiresAt: normalizedMatch.expiresAt ?? null,
+          status: normalizedMatch.status ?? null,
+          roomId: normalizedMatch.roomId ?? null,
+          followStatus: normalizedMatch.followStatus ?? null,
+          followRelationId: normalizedMatch.followRelationId ?? normalizedMatch.followId ?? null,
+        },
       }
-      matchStore.setBootstrap(bootstrapPayload)
+
+      matchStore.setBootstrap(handshakePayload)
       router.push({
         name: 'match-result',
         query: {
           matched: '1',
-          roomId: bootstrapPayload.roomId != null ? String(bootstrapPayload.roomId) : undefined,
-          partner: bootstrapPayload.partnerName || undefined,
         },
       })
     } else {


### PR DESCRIPTION
## Summary
- parse the match bootstrap response without assuming room IDs and persist handshake metadata in the match store
- overhaul the matching result view to handle handshake/chat readiness, follow actions, and WebSocket events while embedding an inline chat panel
- add a reusable MatchChatPanel component and filter temporary random rooms out of the chat room list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c01abc00832596d7f2714332f5ad