### PR TITLE
Improve matching result websocket initialization

### DIFF
--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -593,7 +593,14 @@ let manualDisconnect = false
 const teardownHandlers = []
 
 async function connectWebSocket () {
-  if (isConnecting.value || manualDisconnect) return
+  if (manualDisconnect) return
+
+  if (websocketClient?.isConnected?.()) {
+    isConnecting.value = false
+    return
+  }
+
+  if (isConnecting.value) return
 
   const loginId = resolveClientIdentity(auth)
 
@@ -626,6 +633,10 @@ async function connectWebSocket () {
     )
   } else {
     websocketClient.setQueryParams({ loginId })
+    if (websocketClient.isConnected()) {
+      isConnecting.value = false
+      return
+    }
   }
 
   isConnecting.value = true
@@ -665,11 +676,13 @@ onMounted(async () => {
     applyBootstrap(matchStore.bootstrap)
   }
 
+  const websocketPromise = connectWebSocket()
+
   if (!matchReady.value) {
     await fetchLatestMatchFromRest()
   }
 
-  connectWebSocket()
+  await websocketPromise
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- start the MatchingResult websocket connection before waiting for the REST bootstrap
- guard the websocket connector against redundant calls when a session is already active

## Testing
- Not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8ca5ebbd083259ca55bcbb3798200