### PR TITLE
Wait for authenticated identity before connecting matching websocket

### DIFF
--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -592,10 +592,97 @@ let reconnectTimer = null
 let manualDisconnect = false
 const teardownHandlers = []
 
-async function connectWebSocket () {
-  if (isConnecting.value || manualDisconnect) return
+function getAuthLoginId () {
+  if (!auth) return null
+  return auth.loginId || auth.user?.loginId || auth.user?.login_id || auth.user?.username || null
+}
 
-  const loginId = resolveClientIdentity(auth)
+function isGuestLoginId (loginId) {
+  return typeof loginId === 'string' && loginId.startsWith('guest-')
+}
+
+let awaitingIdentityPromise = null
+function waitForStableLoginId (timeout = 3000) {
+  if (!auth) return Promise.resolve(null)
+
+  if (awaitingIdentityPromise) {
+    return awaitingIdentityPromise
+  }
+
+  awaitingIdentityPromise = new Promise((resolve) => {
+    let settled = false
+    let timer = null
+    const stop = watch(
+      () => getAuthLoginId(),
+      (value) => {
+        if (!value || isGuestLoginId(value)) return
+        if (settled) return
+        settled = true
+        if (timer != null) {
+          clearTimeout(timer)
+        }
+        stop()
+        resolve(value)
+      },
+      { immediate: true },
+    )
+
+    timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      stop()
+      resolve(null)
+    }, timeout)
+  }).finally(() => {
+    awaitingIdentityPromise = null
+  })
+
+  return awaitingIdentityPromise
+}
+
+async function ensureRealtimeIdentity () {
+  let loginId = getAuthLoginId()
+  if (loginId && !isGuestLoginId(loginId)) {
+    return loginId
+  }
+
+  if (typeof auth?.hydrateMeIfNeeded === 'function') {
+    try {
+      await auth.hydrateMeIfNeeded()
+    } catch (error) {
+      console.warn('⚠️ Failed to hydrate auth store before realtime connection', error)
+    }
+    loginId = getAuthLoginId()
+    if (loginId && !isGuestLoginId(loginId)) {
+      return loginId
+    }
+  }
+
+  if (auth?.isAuthenticated) {
+    const awaited = await waitForStableLoginId()
+    if (awaited && !isGuestLoginId(awaited)) {
+      return awaited
+    }
+  }
+
+  return null
+}
+
+async function connectWebSocket () {
+  if (manualDisconnect) return
+
+  if (websocketClient?.isConnected?.()) {
+    isConnecting.value = false
+    return
+  }
+
+  if (isConnecting.value) return
+
+  let loginId = await ensureRealtimeIdentity()
+  if (manualDisconnect) return
+  if (!loginId) {
+    loginId = resolveClientIdentity(auth)
+  }
 
   if (!websocketClient) {
     websocketClient = createRealtimeClient({ queryParams: { loginId } })
@@ -626,6 +713,10 @@ async function connectWebSocket () {
     )
   } else {
     websocketClient.setQueryParams({ loginId })
+    if (websocketClient.isConnected()) {
+      isConnecting.value = false
+      return
+    }
   }
 
   isConnecting.value = true
@@ -665,11 +756,13 @@ onMounted(async () => {
     applyBootstrap(matchStore.bootstrap)
   }
 
+  const websocketPromise = connectWebSocket()
+
   if (!matchReady.value) {
     await fetchLatestMatchFromRest()
   }
 
-  connectWebSocket()
+  await websocketPromise
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- ensure MatchingResult waits for a non-guest login identity before opening the realtime client
- reuse a shared watcher-based promise to hydrate the auth store and resolve the login id before connecting

## Testing
- Not run (manual multi-account environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d8ca5ebbd083259ca55bcbb3798200