### PR TITLE
Fix latest match API to surface matched handshakes

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/MatchRequestRepository.java
@@ -18,6 +18,11 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
 
     Optional<MatchRequest> findFirstByUserAndStatusOrderByRequestedAtDesc(User user, MatchRequest.MatchStatus status);
 
+    Optional<MatchRequest> findFirstByUserAndStatusInOrderByRequestedAtDesc(
+            User user,
+            Collection<MatchRequest.MatchStatus> statuses
+    );
+
     @Query("SELECT mr FROM MatchRequest mr JOIN FETCH mr.user WHERE mr.requestId = :id")
     Optional<MatchRequest> findByIdWithUser(@Param("id") Long id);
 

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -119,10 +119,23 @@ public class MatchService {
         User me = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        return matchRequestRepository.findFirstByUserAndStatusOrderByRequestedAtDesc(me, MatchRequest.MatchStatus.CONFIRMED)
-                .filter(request -> request.getRoom() != null)
-                .flatMap(request -> findConfirmedPartner(request)
-                        .map(partner -> buildMatchFoundResponse(request, partner)));
+        List<MatchRequest.MatchStatus> candidateStatuses = List.of(
+                MatchRequest.MatchStatus.CONFIRMED,
+                MatchRequest.MatchStatus.MATCHED
+        );
+
+        return matchRequestRepository.findFirstByUserAndStatusInOrderByRequestedAtDesc(me, candidateStatuses)
+                .flatMap(request -> {
+                    if (request.getStatus() == MatchRequest.MatchStatus.MATCHED && isHandshakeExpired(request)) {
+                        return Optional.empty();
+                    }
+
+                    Optional<MatchRequest> partner = request.getStatus() == MatchRequest.MatchStatus.CONFIRMED
+                            ? findConfirmedPartner(request)
+                            : findHandshakePartner(request);
+
+                    return Optional.of(buildMatchFoundResponse(request, partner.orElse(null)));
+                });
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose a repository helper that fetches the latest request across a set of statuses
- update `MatchService.findLatestMatch` to return matches that are still in the MATCHED handshake state instead of filtering for confirmed rooms only
- guard against expired handshakes when reading the latest match to avoid surfacing stale data

## Testing
- `./gradlew test` *(fails: Gradle toolchain could not locate JDK 17 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d6a567208325a9364e4430e70173