### PR TITLE
Prevent handshake request id reset when requestId query is absent

### DIFF
--- a/Matcha-Talk/frontend/src/stores/match.js
+++ b/Matcha-Talk/frontend/src/stores/match.js
@@ -102,9 +102,15 @@ function mergeBootstrapPayload (current, patch) {
 
   const nextHandshake = {
     ...(current.handshake || {}),
-    ...(patch?.handshake || {}),
   }
-  if (patch?.myRequestId !== undefined) {
+  const handshakePatch = (patch?.handshake && typeof patch.handshake === 'object') ? patch.handshake : {}
+  for (const [key, value] of Object.entries(handshakePatch)) {
+    if (key === 'myRequestId' && (value === null || value === undefined)) {
+      continue
+    }
+    nextHandshake[key] = value
+  }
+  if (patch?.myRequestId !== undefined && patch.myRequestId !== null) {
     nextHandshake.myRequestId = patch.myRequestId
   }
   if (patch?.partnerRequestId !== undefined) {

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -606,16 +606,19 @@ function extractBootstrapFromRoute () {
   if (matched === '1' || matched === 'true') {
     const parsedRoomId = typeof routeRoomId !== 'undefined' ? Number(routeRoomId) : null
     const parsedRequestId = typeof requestId !== 'undefined' ? Number(requestId) : null
+    const handshake = {
+      status: typeof status === 'string' ? status : null,
+      roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
+    }
+    if (typeof requestId !== 'undefined') {
+      handshake.myRequestId = Number.isFinite(parsedRequestId) ? parsedRequestId : null
+    }
     return {
       matchFound: true,
       partnerName: typeof partner === 'string' ? partner : '',
       roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
       status: typeof status === 'string' ? status : null,
-      handshake: {
-        myRequestId: Number.isFinite(parsedRequestId) ? parsedRequestId : null,
-        status: typeof status === 'string' ? status : null,
-        roomId: Number.isFinite(parsedRoomId) ? parsedRoomId : null,
-      },
+      handshake,
     }
   }
   return null


### PR DESCRIPTION
## Summary
- avoid overwriting the in-memory handshake myRequestId when the matching result route lacks a requestId query parameter
- guard match store merging so null or undefined myRequestId patches keep the previously stored value

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8e6c469708325a6863d046a0590cd