### PR TITLE
Improve match readiness polling and media setup

### DIFF
--- a/Matcha-Talk/frontend/src/components/VideoChat.vue
+++ b/Matcha-Talk/frontend/src/components/VideoChat.vue
@@ -29,6 +29,13 @@ let remoteStream = null
 let peerConnection = null
 let activeReceiver = null
 let initializing = null
+let acquiringLocalStream = null
+
+function isMediaDeviceSupported () {
+  return typeof navigator !== 'undefined' &&
+    navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === 'function'
+}
 
 function updateStatus(message) {
   statusMessage.value = message
@@ -74,6 +81,15 @@ function ensurePeerConnection() {
     }
   }
 
+  pc.onconnectionstatechange = () => {
+    const state = pc.connectionState
+    if (state === 'connected') {
+      updateStatus('통화 연결 완료')
+    } else if (state === 'failed' || state === 'disconnected') {
+      updateStatus('통화 연결이 불안정합니다. 다시 시도해주세요.')
+    }
+  }
+
   if (localStream) {
     attachLocalTracks(localStream, pc)
   }
@@ -82,24 +98,60 @@ function ensurePeerConnection() {
   return pc
 }
 
+function bindLocalStreamEvents (stream) {
+  if (!stream) return
+  stream.getTracks().forEach((track) => {
+    track.onended = () => {
+      if (localStream === stream) {
+        updateStatus('카메라 연결이 종료되었습니다. 다시 시도해주세요.')
+        localStream = null
+        if (localVideo.value) {
+          localVideo.value.srcObject = null
+        }
+      }
+    }
+  })
+}
+
 async function ensureLocalStream() {
   if (localStream) {
+    if (localVideo.value && localVideo.value.srcObject !== localStream) {
+      localVideo.value.srcObject = localStream
+    }
     return localStream
   }
 
-  try {
-    localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true })
-    if (localVideo.value) {
-      localVideo.value.srcObject = localStream
-    }
-    const pc = ensurePeerConnection()
-    attachLocalTracks(localStream, pc)
-    updateStatus('카메라 연결됨')
-    return localStream
-  } catch (error) {
-    updateStatus('미디어 권한을 확인해주세요')
-    throw error
+  if (!isMediaDeviceSupported()) {
+    updateStatus('브라우저에서 카메라를 사용할 수 없습니다.')
+    throw new Error('Media devices are not supported in this environment.')
   }
+
+  if (acquiringLocalStream) {
+    return acquiringLocalStream
+  }
+
+  acquiringLocalStream = (async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: { facingMode: 'user' } })
+      localStream = stream
+      bindLocalStreamEvents(stream)
+      if (localVideo.value) {
+        localVideo.value.srcObject = stream
+      }
+      const pc = ensurePeerConnection()
+      attachLocalTracks(stream, pc)
+      updateStatus('카메라 준비 완료')
+      return stream
+    } catch (error) {
+      console.error('[webrtc] Failed to obtain local media stream', error)
+      updateStatus('미디어 권한을 확인해주세요')
+      throw error
+    } finally {
+      acquiringLocalStream = null
+    }
+  })()
+
+  return acquiringLocalStream
 }
 
 async function initializeRealtime() {
@@ -244,9 +296,19 @@ watch(() => auth.loginId, () => {
   }
 })
 
+watch(localVideo, (element) => {
+  if (element && localStream) {
+    element.srcObject = localStream
+  }
+})
+
 onMounted(() => {
   initializeRealtime().catch((error) => {
     console.warn('[webrtc] 초기화 실패', error)
+  })
+
+  ensureLocalStream().catch((error) => {
+    console.warn('[webrtc] Local media preview failed', error)
   })
 })
 

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -226,6 +226,7 @@ const declineLoading = ref(false)
 let countdownTimer = null
 
 const isPending = computed(() => !matchReady.value && !matchDeclined.value)
+const shouldPollMatchStatus = computed(() => !chatReady.value && !matchDeclined.value)
 const handshakeStatusLabel = computed(() => {
   if (!handshakeStatus.value) return '상태 확인 중'
   switch (handshakeStatus.value) {
@@ -299,10 +300,10 @@ watch(chatReady, (ready) => {
 let matchStatusPollTimer = null
 
 function startMatchStatusPolling () {
-  if (matchStatusPollTimer || !isPending.value) return
+  if (matchStatusPollTimer || !shouldPollMatchStatus.value) return
 
   matchStatusPollTimer = setInterval(() => {
-    if (!isPending.value) {
+    if (!shouldPollMatchStatus.value) {
       stopMatchStatusPolling()
       return
     }
@@ -316,9 +317,10 @@ function stopMatchStatusPolling () {
   matchStatusPollTimer = null
 }
 
-watch(isPending, (pending) => {
-  if (pending) {
+watch(shouldPollMatchStatus, (shouldPoll) => {
+  if (shouldPoll) {
     startMatchStatusPolling()
+    void fetchLatestMatchFromRest({ silent: true })
   } else {
     stopMatchStatusPolling()
   }


### PR DESCRIPTION
## Summary
- keep polling the latest match result until a chat room is ready so the session button appears once the backend is prepared
- harden the WebRTC video component by validating media support, pre-loading the local preview, and reacting to track interruptions for better camera detection

## Testing
- npm run build *(fails: vite not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f045da5883258f0c6da60ad462e2