### PR TITLE
Improve video and chat layouts

### DIFF
--- a/Matcha-Talk/frontend/src/components/VideoChat.vue
+++ b/Matcha-Talk/frontend/src/components/VideoChat.vue
@@ -347,10 +347,18 @@ defineExpose({
 .video-surfaces {
   position: relative;
   width: 100%;
-  padding-top: 56.25%;
   background-color: #1f1f1f;
   border-radius: 12px;
   overflow: hidden;
+  aspect-ratio: 4 / 3;
+  min-height: 420px;
+}
+
+@supports not (aspect-ratio: 1 / 1) {
+  .video-surfaces {
+    height: 0;
+    padding-top: 75%;
+  }
 }
 
 .video-surface {

--- a/Matcha-Talk/frontend/src/composables/useChatClient.js
+++ b/Matcha-Talk/frontend/src/composables/useChatClient.js
@@ -25,15 +25,30 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
 
     const content = payload.content ?? ''
     const senderNickname = payload.senderNickName || payload.senderNickname || '상대방'
+    const senderLoginId = payload.senderLoginId ||
+      payload.senderLoginID ||
+      payload.sender_login_id ||
+      payload.senderLogin ||
+      null
     const messagesForRoom = ensureConversation(roomKey)
     const myNickname = auth.user?.nickName || auth.user?.nickname
+    const myLoginId = resolveClientIdentity(auth)
+    const normalizedMyLogin = myLoginId ? String(myLoginId).toLowerCase() : null
+    const normalizedSenderLogin = senderLoginId ? String(senderLoginId).toLowerCase() : null
+    let isMine = false
+    if (normalizedMyLogin && normalizedSenderLogin) {
+      isMine = normalizedMyLogin === normalizedSenderLogin
+    } else if (myNickname) {
+      isMine = senderNickname === myNickname
+    }
 
     const message = {
       id: `${roomKey}-${Date.now()}-${messagesForRoom.length}`,
       text: content,
       time: timeFormatter(payload.sentAt),
       sender: senderNickname,
-      me: myNickname ? senderNickname === myNickname : false,
+      senderLoginId,
+      me: isMine,
       contentType: (payload.contentType || 'TEXT').toUpperCase(),
       fileName: payload.fileName || null,
       fileUrl: payload.fileUrl || null,

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -106,7 +106,7 @@
             >
               좌측 목록에서 채팅방을 선택하세요.
             </div>
-            <template v-else>
+            <div v-else class="chat-messages__list">
               <div
                 v-for="(m, i) in messages"
                 :key="m.id || i"
@@ -189,7 +189,7 @@
                   </div>
                 </template>
               </div>
-            </template>
+            </div>
           </div>
         </div>
         <div class="chat-input d-flex align-center pa-4 ga-2">
@@ -731,9 +731,12 @@ watch(messages, () => scrollToBottom())
   flex: 1 1 55%;
   max-width: 55%;
   display: flex;
+  flex-direction: column;
+  min-height: 420px;
 }
 
 .video-pane :deep(.video-chat) {
+  flex: 1;
   width: 100%;
 }
 
@@ -741,6 +744,16 @@ watch(messages, () => scrollToBottom())
   background: #fff;
   flex: 1 1 45%;
   max-width: 45%;
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+}
+
+.chat-messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: auto;
 }
 
 .chat-input {

--- a/Matcha-Talk/frontend/src/views/MatchSession.vue
+++ b/Matcha-Talk/frontend/src/views/MatchSession.vue
@@ -104,7 +104,7 @@
                 >
                   채팅방 정보를 불러오는 중입니다.
                 </div>
-                <template v-else>
+                <div v-else class="chat-messages__list">
                   <div
                     v-for="(message, index) in messages"
                     :key="message.id || index"
@@ -133,7 +133,7 @@
                       <span>{{ message.time }}</span>
                     </div>
                   </div>
-                </template>
+                </div>
               </div>
               <div class="chat-input pa-4">
                 <input type="file" ref="fileInput" class="d-none" @change="handleFileSelect" />
@@ -297,6 +297,13 @@ async function ensureRoomExists(roomKey, fallbackName) {
   try {
     const { data } = await api.get(`/rooms/${roomKey}`)
     const participants = (data.participants || []).map((participant) => participant.loginId).filter(Boolean)
+    const myLoginId = resolveClientIdentity(auth)
+    const partnerDetail = (data.participants || []).find((participant) => {
+      const loginId = participant.loginId || participant.login_id || participant.username
+      if (!loginId) return false
+      if (!myLoginId) return true
+      return String(loginId).toLowerCase() !== String(myLoginId).toLowerCase()
+    })
     roomInfo.value = {
       id: data.roomId,
       name: data.roomName || fallbackName || `대화방 #${data.roomId}`,
@@ -304,6 +311,21 @@ async function ensureRoomExists(roomKey, fallbackName) {
       participantsDetail: data.participants || [],
     }
     participantLoginIds.value = participants
+    if (partnerDetail) {
+      const loginId = partnerDetail.loginId || partnerDetail.login_id || partnerDetail.username
+      const nickname = partnerDetail.nickName || partnerDetail.nickname || partnerDetail.name
+      const userPid = partnerDetail.userPid ?? partnerDetail.user_pid ?? null
+      if (loginId) {
+        partnerLoginId.value = loginId
+      }
+      if (nickname) {
+        partnerName.value = nickname
+      }
+      const numericPid = Number(userPid)
+      if (Number.isFinite(numericPid) && numericPid > 0) {
+        partnerUserPid.value = numericPid
+      }
+    }
     return roomInfo.value
   } catch (error) {
     console.warn('[match-session] Failed to fetch room detail', error)
@@ -588,6 +610,7 @@ function goBackToResult() {
 
 .session-card {
   background: #fff;
+  min-height: 75vh;
 }
 
 .session-content {
@@ -595,6 +618,7 @@ function goBackToResult() {
   flex-direction: row;
   gap: 24px;
   padding: 24px;
+  height: 100%;
 }
 
 .video-pane {
@@ -602,6 +626,7 @@ function goBackToResult() {
   max-width: 55%;
   display: flex;
   flex-direction: column;
+  min-height: 420px;
 }
 
 .session-video {
@@ -627,6 +652,16 @@ function goBackToResult() {
   padding: 16px;
   overflow-y: auto;
   background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+}
+
+.chat-messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: auto;
 }
 
 .message-row {


### PR DESCRIPTION
## Summary
- increase the call surface height and add a fallback ratio so the remote feed is taller
- keep chat logs pinned to the bottom while expanding video panes in the chat and match session views
- tag outgoing messages with the current login and hydrate partner info so follow buttons enable correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da54858d2883259e20299b690e802f