### PR TITLE
Add follow state sync and random room cleanup

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -6,6 +6,7 @@ import net.datasa.project01.domain.dto.RoomDetailResponseDto;
 import net.datasa.project01.domain.dto.RoomCreateResponseDto;
 import net.datasa.project01.domain.dto.RoomListResponseDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
+import net.datasa.project01.domain.dto.RoomCleanupResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.service.ChatService;
 import org.springframework.core.io.Resource;
@@ -103,6 +104,15 @@ public class ChatController {
             log.error("Failed to store attachment for room {}", roomId, exception);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @DeleteMapping("/{roomId}/temporary")
+    public ResponseEntity<RoomCleanupResponseDto> cleanupTemporaryRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String loginId = requireLoginId(userDetails);
+        RoomCleanupResponseDto response = RoomCleanupResponseDto.from(chatService.cleanupTemporaryRoom(roomId, loginId));
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{roomId}/attachments/{messageId}")

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/FollowController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/FollowController.java
@@ -3,6 +3,7 @@ package net.datasa.project01.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.FollowRequestDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
 import net.datasa.project01.domain.dto.FollowUpdateDto;
 import net.datasa.project01.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -28,11 +29,11 @@ public class FollowController {
      * @return 성공 시 201 Created
      */
     @PostMapping
-    public ResponseEntity<Void> createFollow(@Valid @RequestBody FollowRequestDto req,
-                                             @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<FollowResponseDto> createFollow(@Valid @RequestBody FollowRequestDto req,
+                                                          @AuthenticationPrincipal UserDetails userDetails) {
         String loginId = requireLoginId(userDetails);
-        userService.createFollow(req, loginId);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        FollowResponseDto response = userService.createFollow(req, loginId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchFoundResponseDto.java
@@ -15,9 +15,18 @@ public class MatchFoundResponseDto {
     private final Long partnerRequestId;
     private final String partnerLoginId;
     private final String partnerNickName;
+    private final Long partnerUserPid;
     private final Long roomId;
     private final String handshakeKey;
     private final LocalDateTime expiresAt;
     private final MatchRequest.MatchStatus status;
+    private final String followStatus;
+    private final Long followRelationId;
+    private final Long incomingFollowId;
+    private final String incomingFollowStatus;
+    private final Long outgoingFollowId;
+    private final String outgoingFollowStatus;
+    private final Boolean mutualFollow;
+    private final Boolean roomTemporary;
     // 향후 파트너의 프로필 사진, 관심사 등 추가 정보 포함 가능
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomCleanupResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomCleanupResponseDto.java
@@ -1,0 +1,33 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import net.datasa.project01.service.ChatService;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RoomCleanupResponseDto {
+    private final boolean deleted;
+    private final boolean temporary;
+    private final boolean mutualFollow;
+    private final String reason;
+
+    public static RoomCleanupResponseDto from(ChatService.RoomCleanupResult result) {
+        if (result == null) {
+            return RoomCleanupResponseDto.builder()
+                    .deleted(false)
+                    .temporary(false)
+                    .mutualFollow(false)
+                    .reason("UNKNOWN")
+                    .build();
+        }
+        return RoomCleanupResponseDto.builder()
+                .deleted(result.deleted())
+                .temporary(result.temporary())
+                .mutualFollow(result.mutualFollow())
+                .reason(result.reason())
+                .build();
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMessageRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/RoomMessageRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RoomMessageRepository extends JpaRepository<RoomMessage, Long> {
 
     /**
@@ -15,5 +17,7 @@ public interface RoomMessageRepository extends JpaRepository<RoomMessage, Long> 
      * @return 페이징된 메시지 목록
      */
     Page<RoomMessage> findByRoomOrderByCreatedAtDesc(Room room, Pageable pageable);
+
+    List<RoomMessage> findByRoom(Room room);
 
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -1,6 +1,7 @@
 package net.datasa.project01.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.RoomDetailResponseDto;
 import net.datasa.project01.domain.dto.RoomListResponseDto;
 import net.datasa.project01.domain.entity.Room;
@@ -10,10 +11,14 @@ import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.RoomMessageRepository;
 import net.datasa.project01.repository.RoomRepository;
 import net.datasa.project01.repository.UserRepository;
+import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.dto.ChatMessageRequestDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.entity.RoomMessage;
 import net.datasa.project01.websocket.RealTimeMessagingService;
+import net.datasa.project01.repository.MatchRequestRepository;
+import net.datasa.project01.repository.FollowRepository;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
@@ -21,16 +26,21 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.datasa.project01.domain.entity.Room.RoomType;
 
@@ -39,12 +49,15 @@ import net.datasa.project01.service.TranslationService;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChatService {
 
         private final RoomRepository roomRepository;
         private final RoomMemberRepository roomMemberRepository;
         private final UserRepository userRepository;
         private final RoomMessageRepository roomMessageRepository;
+        private final MatchRequestRepository matchRequestRepository;
+        private final FollowRepository followRepository;
         private final TranslationService translationService;
         private final RealTimeMessagingService messagingService;
 
@@ -225,6 +238,32 @@ public class ChatService {
         }
 
         @Transactional
+        public RoomCleanupResult cleanupTemporaryRoom(Long roomId, String loginId) {
+                User user = userRepository.findByLoginId(loginId)
+                        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+                Room room = roomRepository.findById(roomId)
+                        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+                roomMemberRepository.findByRoomAndUser(room, user)
+                        .orElseThrow(() -> new IllegalArgumentException("채팅방 멤버만 정리할 수 있습니다."));
+
+                boolean temporary = room.getRoomType() == Room.RoomType.RANDOM;
+                if (!temporary) {
+                        return new RoomCleanupResult(false, false, false, "ROOM_NOT_TEMPORARY");
+                }
+
+                List<RoomMember> members = roomMemberRepository.findByRoom(room);
+                boolean mutualFollow = hasMutualFollow(members);
+                if (mutualFollow) {
+                        return new RoomCleanupResult(false, true, true, "MUTUAL_FOLLOW");
+                }
+
+                removeRoomWithDependencies(room, members);
+                return new RoomCleanupResult(true, true, false, "DELETED");
+        }
+
+        @Transactional
         public ChatMessageResponseDto saveAttachment(Long roomId, MultipartFile file, String loginId) throws IOException {
                 if (file == null || file.isEmpty()) {
                         throw new IllegalArgumentException("업로드할 파일이 존재하지 않습니다.");
@@ -331,6 +370,106 @@ public class ChatService {
                         .build();
         }
 
+        private boolean hasMutualFollow(List<RoomMember> members) {
+                if (members == null) {
+                        return false;
+                }
+
+                Map<Long, User> distinct = new LinkedHashMap<>();
+                for (RoomMember member : members) {
+                        User participant = member.getUser();
+                        if (participant != null) {
+                                distinct.putIfAbsent(participant.getUserPid(), participant);
+                        }
+                }
+
+                Iterator<User> iterator = distinct.values().iterator();
+                if (!iterator.hasNext()) {
+                        return false;
+                }
+                User first = iterator.next();
+                if (!iterator.hasNext()) {
+                        return false;
+                }
+                User second = iterator.next();
+
+                boolean forward = followRepository.findByFollowerAndFolloweeAndStatus(first, second, Follow.FollowStatus.ACCEPTED).isPresent();
+                boolean reverse = followRepository.findByFollowerAndFolloweeAndStatus(second, first, Follow.FollowStatus.ACCEPTED).isPresent();
+                return forward && reverse;
+        }
+
+        private void removeRoomWithDependencies(Room room, List<RoomMember> existingMembers) {
+                List<RoomMessage> messages = roomMessageRepository.findByRoom(room);
+                for (RoomMessage message : messages) {
+                        deleteAttachmentFile(message.getFilePath());
+                }
+                if (!messages.isEmpty()) {
+                        roomMessageRepository.deleteAll(messages);
+                }
+
+                List<RoomMember> membersToRemove = existingMembers;
+                if (membersToRemove == null || membersToRemove.isEmpty()) {
+                        membersToRemove = roomMemberRepository.findByRoom(room);
+                }
+                if (membersToRemove != null && !membersToRemove.isEmpty()) {
+                        roomMemberRepository.deleteAll(membersToRemove);
+                }
+
+                archiveMatchRequestsForRoom(room);
+
+                roomRepository.delete(room);
+                deleteAttachmentDirectory(room.getRoomId());
+        }
+
+        private void archiveMatchRequestsForRoom(Room room) {
+                List<MatchRequest> relatedRequests = matchRequestRepository.findByRoom(room);
+                if (relatedRequests.isEmpty()) {
+                        return;
+                }
+
+                for (MatchRequest request : relatedRequests) {
+                        request.setStatus(MatchRequest.MatchStatus.ARCHIVED);
+                        request.setRoom(null);
+                        request.setHandshakeKey(null);
+                        request.setHandshakeExpiresAt(null);
+                }
+
+                matchRequestRepository.saveAll(relatedRequests);
+        }
+
+        private void deleteAttachmentFile(String filePath) {
+                if (!StringUtils.hasText(filePath)) {
+                        return;
+                }
+                try {
+                        Files.deleteIfExists(Paths.get(filePath));
+                } catch (IOException e) {
+                        log.warn("Failed to delete attachment file {}", filePath, e);
+                }
+        }
+
+        private void deleteAttachmentDirectory(Long roomId) {
+                if (roomId == null) {
+                        return;
+                }
+                Path directory = attachmentBasePath.resolve(String.valueOf(roomId));
+                if (!Files.exists(directory)) {
+                        return;
+                }
+                try (Stream<Path> walk = Files.walk(directory)) {
+                        walk.sorted(Comparator.reverseOrder())
+                                .forEach(path -> {
+                                        try {
+                                                Files.deleteIfExists(path);
+                                        } catch (IOException e) {
+                                                log.warn("Failed to delete path {}", path, e);
+                                        }
+                                });
+                } catch (IOException e) {
+                        log.warn("Failed to remove attachment directory for room {}", roomId, e);
+                }
+        }
+
         private RoomMessage.ContentType determineContentType(String mimeType) {
                 if (mimeType != null && mimeType.startsWith("image")) {
                         return RoomMessage.ContentType.IMAGE;
@@ -347,6 +486,8 @@ public class ChatService {
         }
 
         public record AttachmentResource(Resource resource, String fileName, String mimeType) {}
+
+        public record RoomCleanupResult(boolean deleted, boolean temporary, boolean mutualFollow, String reason) {}
 
     // TODO: 추가 필요한 메서드들
     // public void joinRoom(Long roomId, String loginId) { }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -7,9 +7,11 @@ import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.MatchFoundResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
+import net.datasa.project01.domain.entity.Follow;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.FollowRepository;
 import net.datasa.project01.websocket.RealTimeMessagingService;
 import net.datasa.project01.repository.MatchRequestRepository;
 import net.datasa.project01.repository.UserRepository;
@@ -33,6 +35,7 @@ public class MatchService {
     private final MatchRequestRepository matchRequestRepository;
     private final UserRepository userRepository;
     private final ChatService chatService;
+    private final FollowRepository followRepository;
     private final RealTimeMessagingService messagingService;
     private final ObjectMapper objectMapper;
 
@@ -249,19 +252,36 @@ public class MatchService {
 
     private MatchFoundResponseDto buildMatchFoundResponse(MatchRequest myRequest, MatchRequest partnerRequest) {
         Long partnerRequestId = partnerRequest != null ? partnerRequest.getRequestId() : null;
-        String partnerLoginId = partnerRequest != null ? partnerRequest.getUser().getLoginId() : null;
-        String partnerNickName = partnerRequest != null ? partnerRequest.getUser().getNickName() : null;
-        Long roomId = myRequest.getRoom() != null ? myRequest.getRoom().getRoomId() : null;
+        User partnerUser = partnerRequest != null ? partnerRequest.getUser() : null;
+        String partnerLoginId = partnerUser != null ? partnerUser.getLoginId() : null;
+        String partnerNickName = partnerUser != null ? partnerUser.getNickName() : null;
+
+        Room resolvedRoom = myRequest.getRoom() != null
+                ? myRequest.getRoom()
+                : (partnerRequest != null ? partnerRequest.getRoom() : null);
+        Long roomId = resolvedRoom != null ? resolvedRoom.getRoomId() : null;
+        Boolean roomTemporary = resolvedRoom != null ? resolvedRoom.isTemporary() : null;
+
+        FollowSnapshot followSnapshot = resolveFollowSnapshot(myRequest.getUser(), partnerUser);
 
         return MatchFoundResponseDto.builder()
                 .myRequestId(myRequest.getRequestId())
                 .partnerRequestId(partnerRequestId)
                 .partnerLoginId(partnerLoginId)
                 .partnerNickName(partnerNickName)
+                .partnerUserPid(partnerUser != null ? partnerUser.getUserPid() : null)
                 .roomId(roomId)
                 .handshakeKey(myRequest.getHandshakeKey())
                 .expiresAt(myRequest.getHandshakeExpiresAt())
                 .status(myRequest.getStatus())
+                .followStatus(followSnapshot.displayStatus())
+                .followRelationId(followSnapshot.relationId())
+                .incomingFollowId(followSnapshot.incomingId())
+                .incomingFollowStatus(followSnapshot.incomingStatus())
+                .outgoingFollowId(followSnapshot.outgoingId())
+                .outgoingFollowStatus(followSnapshot.outgoingStatus())
+                .mutualFollow(followSnapshot.mutualAccepted())
+                .roomTemporary(roomTemporary)
                 .build();
     }
 
@@ -280,6 +300,75 @@ public class MatchService {
         }
 
         matchRequestRepository.saveAll(requests);
+    }
+
+    private FollowSnapshot resolveFollowSnapshot(User currentUser, User partnerUser) {
+        if (currentUser == null || partnerUser == null) {
+            return FollowSnapshot.empty();
+        }
+
+        Optional<Follow> outgoing = followRepository.findByFollowerAndFollowee(currentUser, partnerUser);
+        Optional<Follow> incoming = followRepository.findByFollowerAndFollowee(partnerUser, currentUser);
+
+        return FollowSnapshot.from(outgoing, incoming);
+    }
+
+    private record FollowSnapshot(Long outgoingId,
+                                  String outgoingStatus,
+                                  Long incomingId,
+                                  String incomingStatus,
+                                  String displayStatus,
+                                  Long relationId,
+                                  boolean mutualAccepted) {
+        static FollowSnapshot empty() {
+            return new FollowSnapshot(null, null, null, null, null, null, false);
+        }
+
+        static FollowSnapshot from(Optional<Follow> outgoing, Optional<Follow> incoming) {
+            Follow.FollowStatus outgoingStatusEnum = outgoing.map(Follow::getStatus).orElse(null);
+            Follow.FollowStatus incomingStatusEnum = incoming.map(Follow::getStatus).orElse(null);
+
+            String outgoingStatus = outgoingStatusEnum != null ? outgoingStatusEnum.name() : null;
+            String incomingStatus = incomingStatusEnum != null ? incomingStatusEnum.name() : null;
+
+            boolean mutualAccepted = outgoingStatusEnum == Follow.FollowStatus.ACCEPTED
+                    && incomingStatusEnum == Follow.FollowStatus.ACCEPTED;
+
+            String displayStatus = null;
+            Long relationId = null;
+
+            if (incomingStatusEnum == Follow.FollowStatus.PENDING) {
+                displayStatus = "PENDING_INCOMING";
+                relationId = incoming.map(Follow::getFollowId).orElse(null);
+            } else if (outgoingStatusEnum == Follow.FollowStatus.PENDING) {
+                displayStatus = "PENDING_OUTGOING";
+                relationId = outgoing.map(Follow::getFollowId).orElse(null);
+            } else if (mutualAccepted) {
+                displayStatus = "ACCEPTED";
+                relationId = outgoing.map(Follow::getFollowId)
+                        .orElseGet(() -> incoming.map(Follow::getFollowId).orElse(null));
+            } else if (incomingStatusEnum == Follow.FollowStatus.ACCEPTED) {
+                displayStatus = "ACCEPTED_INCOMING";
+                relationId = incoming.map(Follow::getFollowId).orElse(null);
+            } else if (outgoingStatusEnum == Follow.FollowStatus.ACCEPTED) {
+                displayStatus = "ACCEPTED_OUTGOING";
+                relationId = outgoing.map(Follow::getFollowId).orElse(null);
+            } else if (incomingStatusEnum == Follow.FollowStatus.REJECTED) {
+                displayStatus = "REJECTED_INCOMING";
+            } else if (outgoingStatusEnum == Follow.FollowStatus.REJECTED) {
+                displayStatus = "REJECTED_OUTGOING";
+            }
+
+            return new FollowSnapshot(
+                    outgoing.map(Follow::getFollowId).orElse(null),
+                    outgoingStatus,
+                    incoming.map(Follow::getFollowId).orElse(null),
+                    incomingStatus,
+                    displayStatus,
+                    relationId,
+                    mutualAccepted
+            );
+        }
     }
 
     private Optional<MatchRequest> findHandshakePartner(MatchRequest request) {

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datasa.project01.domain.dto.FollowRequestDto;
+import net.datasa.project01.domain.dto.FollowResponseDto;
 import net.datasa.project01.domain.dto.FollowUpdateDto;
 import net.datasa.project01.domain.dto.UserProfileUpdateRequest;
 import net.datasa.project01.domain.dto.UserResponse;
@@ -216,7 +217,7 @@ public class UserService {
      * 팔로우 관리
      * ============================== */
     @Transactional
-    public void createFollow(FollowRequestDto req, String followerLoginId) {
+    public FollowResponseDto createFollow(FollowRequestDto req, String followerLoginId) {
         User follower = userRepository.findByLoginId(normalizeLoginId(followerLoginId))
                 .orElseThrow(() -> new IllegalArgumentException("요청한 사용자를 찾을 수 없습니다."));
         User followee = userRepository.findById(req.getFolloweeId())
@@ -235,6 +236,10 @@ public class UserService {
                 .status(Follow.FollowStatus.PENDING)
                 .build();
         followRepository.save(follow);
+
+        FollowResponseDto response = FollowResponseDto.fromEntity(follow, followee);
+        broadcastFollowStatus(follower, followee);
+        return response;
     }
 
     @Transactional
@@ -258,6 +263,8 @@ public class UserService {
         if (newStatus == Follow.FollowStatus.ACCEPTED) {
             handleMutualFollowPromotion(follow);
         }
+
+        broadcastFollowStatus(follow.getFollower(), follow.getFollowee());
     }
 
     @Transactional
@@ -271,7 +278,10 @@ public class UserService {
                 && !follow.getFollowee().getUserPid().equals(currentUser.getUserPid())) {
             throw new IllegalStateException("이 관계를 삭제할 권한이 없습니다.");
         }
+        User follower = follow.getFollower();
+        User followee = follow.getFollowee();
         followRepository.delete(follow);
+        broadcastFollowStatus(follower, followee);
     }
 
     public List<UserResponse> getFollowingList(Long userId) {
@@ -292,6 +302,34 @@ public class UserService {
                 .map(Follow::getFollower)
                 .map(UserResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    private void broadcastFollowStatus(User follower, User followee) {
+        if (follower == null || followee == null) {
+            return;
+        }
+
+        try {
+            matchService.findLatestMatch(follower.getLoginId())
+                    .ifPresent(payload -> messagingService.sendEventToUser(
+                            follower.getLoginId(),
+                            RealTimeMessagingService.EVENT_MATCH_FOLLOW_UPDATED,
+                            payload
+                    ));
+        } catch (Exception e) {
+            log.warn("Failed to broadcast follow update to {}", follower.getLoginId(), e);
+        }
+
+        try {
+            matchService.findLatestMatch(followee.getLoginId())
+                    .ifPresent(payload -> messagingService.sendEventToUser(
+                            followee.getLoginId(),
+                            RealTimeMessagingService.EVENT_MATCH_FOLLOW_UPDATED,
+                            payload
+                    ));
+        } catch (Exception e) {
+            log.warn("Failed to broadcast follow update to {}", followee.getLoginId(), e);
+        }
     }
 
     private void handleMutualFollowPromotion(Follow follow) {

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/websocket/RealTimeMessagingService.java
@@ -24,6 +24,7 @@ public class RealTimeMessagingService {
     public static final String EVENT_MATCH_DECLINED = "match-declined";
     public static final String EVENT_MATCH_STATUS = "match-status";
     public static final String EVENT_MATCH_ROOM_PROMOTED = "match-room-promoted";
+    public static final String EVENT_MATCH_FOLLOW_UPDATED = "match-follow-updated";
 
     public void sendEventToUser(String loginId, String event, Object payload) {
         broadcastToUsers(java.util.List.of(loginId), event, payload);

--- a/Matcha-Talk/frontend/src/components/VideoChat.vue
+++ b/Matcha-Talk/frontend/src/components/VideoChat.vue
@@ -347,10 +347,18 @@ defineExpose({
 .video-surfaces {
   position: relative;
   width: 100%;
-  padding-top: 56.25%;
   background-color: #1f1f1f;
   border-radius: 12px;
   overflow: hidden;
+  aspect-ratio: 4 / 3;
+  min-height: 420px;
+}
+
+@supports not (aspect-ratio: 1 / 1) {
+  .video-surfaces {
+    height: 0;
+    padding-top: 75%;
+  }
 }
 
 .video-surface {

--- a/Matcha-Talk/frontend/src/composables/useChatClient.js
+++ b/Matcha-Talk/frontend/src/composables/useChatClient.js
@@ -25,15 +25,30 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
 
     const content = payload.content ?? ''
     const senderNickname = payload.senderNickName || payload.senderNickname || '상대방'
+    const senderLoginId = payload.senderLoginId ||
+      payload.senderLoginID ||
+      payload.sender_login_id ||
+      payload.senderLogin ||
+      null
     const messagesForRoom = ensureConversation(roomKey)
     const myNickname = auth.user?.nickName || auth.user?.nickname
+    const myLoginId = resolveClientIdentity(auth)
+    const normalizedMyLogin = myLoginId ? String(myLoginId).toLowerCase() : null
+    const normalizedSenderLogin = senderLoginId ? String(senderLoginId).toLowerCase() : null
+    let isMine = false
+    if (normalizedMyLogin && normalizedSenderLogin) {
+      isMine = normalizedMyLogin === normalizedSenderLogin
+    } else if (myNickname) {
+      isMine = senderNickname === myNickname
+    }
 
     const message = {
       id: `${roomKey}-${Date.now()}-${messagesForRoom.length}`,
       text: content,
       time: timeFormatter(payload.sentAt),
       sender: senderNickname,
-      me: myNickname ? senderNickname === myNickname : false,
+      senderLoginId,
+      me: isMine,
       contentType: (payload.contentType || 'TEXT').toUpperCase(),
       fileName: payload.fileName || null,
       fileUrl: payload.fileUrl || null,

--- a/Matcha-Talk/frontend/src/stores/match.js
+++ b/Matcha-Talk/frontend/src/stores/match.js
@@ -66,8 +66,46 @@ function normalizeBootstrap (payload) {
   const computedHandshakeReady = status === 'MATCHED' && !roomId
   const computedChatReady = roomId != null && (status === 'CONFIRMED' || status === 'ARCHIVED' || status === 'MATCHED' || payload.chatReady === true)
 
-  const followRelationId = toNumberOrNull(payload.followRelationId ?? payload.followId ?? handshakeSource.followRelationId)
-  const followStatus = payload.followStatus || handshakeSource.followStatus || null
+  const incomingFollowId = toNumberOrNull(payload.incomingFollowId ?? payload.incomingFollow?.id ?? handshakeSource.incomingFollowId)
+  const outgoingFollowId = toNumberOrNull(payload.outgoingFollowId ?? payload.outgoingFollow?.id ?? handshakeSource.outgoingFollowId)
+  const incomingFollowStatusRaw = payload.incomingFollowStatus ?? payload.incomingFollow?.status ?? handshakeSource.incomingFollowStatus
+  const outgoingFollowStatusRaw = payload.outgoingFollowStatus ?? payload.outgoingFollow?.status ?? handshakeSource.outgoingFollowStatus
+  const incomingFollowStatus = incomingFollowStatusRaw ? incomingFollowStatusRaw.toString().toUpperCase() : null
+  const outgoingFollowStatus = outgoingFollowStatusRaw ? outgoingFollowStatusRaw.toString().toUpperCase() : null
+  const mutualFollow = Boolean(payload.mutualFollow ?? handshakeSource.mutualFollow ?? false)
+
+  const roomTemporaryRaw = payload.roomTemporary ?? handshakeSource.roomTemporary ?? null
+  const roomTypeSource = payload.roomType ?? handshakeSource.roomType ?? null
+  const roomTemporary = roomTemporaryRaw === null
+    ? (roomTypeSource ? String(roomTypeSource).toUpperCase() === 'RANDOM' : null)
+    : Boolean(roomTemporaryRaw)
+
+  let followRelationId = toNumberOrNull(payload.followRelationId ?? payload.followId ?? handshakeSource.followRelationId)
+  let followStatus = payload.followStatus || handshakeSource.followStatus || null
+  if (!followStatus) {
+    if (incomingFollowStatus === 'PENDING') {
+      followStatus = 'PENDING_INCOMING'
+      followRelationId = incomingFollowId ?? followRelationId
+    } else if (outgoingFollowStatus === 'PENDING') {
+      followStatus = 'PENDING_OUTGOING'
+      followRelationId = outgoingFollowId ?? followRelationId
+    } else if (mutualFollow || (incomingFollowStatus === 'ACCEPTED' && outgoingFollowStatus === 'ACCEPTED')) {
+      followStatus = 'ACCEPTED'
+      followRelationId = outgoingFollowId ?? incomingFollowId ?? followRelationId
+    } else if (incomingFollowStatus === 'ACCEPTED') {
+      followStatus = 'ACCEPTED_INCOMING'
+      followRelationId = incomingFollowId ?? followRelationId
+    } else if (outgoingFollowStatus === 'ACCEPTED') {
+      followStatus = 'ACCEPTED_OUTGOING'
+      followRelationId = outgoingFollowId ?? followRelationId
+    } else if (incomingFollowStatus === 'REJECTED') {
+      followStatus = 'REJECTED_INCOMING'
+      followRelationId = incomingFollowId ?? followRelationId
+    } else if (outgoingFollowStatus === 'REJECTED') {
+      followStatus = 'REJECTED_OUTGOING'
+      followRelationId = outgoingFollowId ?? followRelationId
+    }
+  }
 
   return {
     matchFound: payload.matchFound ?? (computedHandshakeReady || computedChatReady),
@@ -81,6 +119,12 @@ function normalizeBootstrap (payload) {
     handshake,
     followStatus,
     followRelationId,
+    incomingFollowId,
+    incomingFollowStatus,
+    outgoingFollowId,
+    outgoingFollowStatus,
+    mutualFollow,
+    roomTemporary,
   }
 }
 
@@ -99,6 +143,12 @@ function mergeBootstrapPayload (current, patch) {
   merged.chatReady = patch?.chatReady ?? current.chatReady ?? false
   merged.followStatus = patch?.followStatus ?? current.followStatus ?? null
   merged.followRelationId = patch?.followRelationId ?? current.followRelationId ?? null
+  merged.incomingFollowId = patch?.incomingFollowId ?? current.incomingFollowId ?? null
+  merged.incomingFollowStatus = patch?.incomingFollowStatus ?? current.incomingFollowStatus ?? null
+  merged.outgoingFollowId = patch?.outgoingFollowId ?? current.outgoingFollowId ?? null
+  merged.outgoingFollowStatus = patch?.outgoingFollowStatus ?? current.outgoingFollowStatus ?? null
+  merged.mutualFollow = patch?.mutualFollow ?? current.mutualFollow ?? false
+  merged.roomTemporary = patch?.roomTemporary ?? current.roomTemporary ?? null
 
   const nextHandshake = {
     ...(current.handshake || {}),

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -106,7 +106,7 @@
             >
               좌측 목록에서 채팅방을 선택하세요.
             </div>
-            <template v-else>
+            <div v-else class="chat-messages__list">
               <div
                 v-for="(m, i) in messages"
                 :key="m.id || i"
@@ -189,7 +189,7 @@
                   </div>
                 </template>
               </div>
-            </template>
+            </div>
           </div>
         </div>
         <div class="chat-input d-flex align-center pa-4 ga-2">
@@ -731,9 +731,12 @@ watch(messages, () => scrollToBottom())
   flex: 1 1 55%;
   max-width: 55%;
   display: flex;
+  flex-direction: column;
+  min-height: 420px;
 }
 
 .video-pane :deep(.video-chat) {
+  flex: 1;
   width: 100%;
 }
 
@@ -741,6 +744,16 @@ watch(messages, () => scrollToBottom())
   background: #fff;
   flex: 1 1 45%;
   max-width: 45%;
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+}
+
+.chat-messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: auto;
 }
 
 .chat-input {

--- a/Matcha-Talk/frontend/src/views/MatchSession.vue
+++ b/Matcha-Talk/frontend/src/views/MatchSession.vue
@@ -104,7 +104,7 @@
                 >
                   채팅방 정보를 불러오는 중입니다.
                 </div>
-                <template v-else>
+                <div v-else class="chat-messages__list">
                   <div
                     v-for="(message, index) in messages"
                     :key="message.id || index"
@@ -133,7 +133,7 @@
                       <span>{{ message.time }}</span>
                     </div>
                   </div>
-                </template>
+                </div>
               </div>
               <div class="chat-input pa-4">
                 <input type="file" ref="fileInput" class="d-none" @change="handleFileSelect" />
@@ -183,6 +183,7 @@ import { useAuthStore } from '../stores/auth'
 import { useMatchStore } from '../stores/match'
 import api from '../services/api'
 import followService from '../services/follow'
+import { camelizeKeys } from '../utils/case'
 import { resolveClientIdentity } from '../utils/identity'
 import {
   createFileSelectHandler,
@@ -215,9 +216,16 @@ const videoCallLoading = ref(false)
 const followState = reactive({
   status: null,
   relationId: null,
+  incomingId: null,
+  incomingStatus: null,
+  outgoingId: null,
+  outgoingStatus: null,
+  mutual: false,
 })
 const followRequestLoading = ref(false)
 const followAcceptLoading = ref(false)
+const roomTemporary = ref(null)
+const cleanupState = reactive({ running: false, completed: false })
 
 const messages = computed(() => {
   if (!roomId.value) return []
@@ -244,32 +252,51 @@ const handshakeStatusLabel = computed(() => {
   }
 })
 
-const followStatusUpper = computed(() => (followState.status || '').toUpperCase())
+const followStatusUpper = computed(() => (followState.status || '').toString().toUpperCase())
+const incomingStatusUpper = computed(() => (followState.incomingStatus || '').toString().toUpperCase())
+const outgoingStatusUpper = computed(() => (followState.outgoingStatus || '').toString().toUpperCase())
+const hasMutualFollow = computed(() => {
+  if (followState.mutual) return true
+  if (incomingStatusUpper.value === 'ACCEPTED' && outgoingStatusUpper.value === 'ACCEPTED') {
+    return true
+  }
+  return followStatusUpper.value === 'ACCEPTED'
+})
 const canRequestFollow = computed(() => {
   if (partnerUserPid.value == null) return false
-  if (!followStatusUpper.value) return true
-  if (followStatusUpper.value.includes('ACCEPT')) return false
-  if (followStatusUpper.value.includes('OUTGOING')) return false
-  if (followStatusUpper.value.includes('PENDING') &&
-    !followStatusUpper.value.includes('INCOMING') &&
-    !followStatusUpper.value.includes('RECEIVED')) {
-    return false
-  }
+  if (hasMutualFollow.value) return false
+  const outgoing = outgoingStatusUpper.value
+  if (outgoing === 'PENDING' || outgoing === 'ACCEPTED') return false
   return true
 })
 const canAcceptFollow = computed(() => {
-  if (!followState.relationId) return false
-  if (!followStatusUpper.value) return true
-  if (followStatusUpper.value.includes('ACCEPT')) return false
-  return followStatusUpper.value.includes('INCOMING') ||
-    followStatusUpper.value.includes('RECEIVED') ||
-    followStatusUpper.value === 'PENDING'
+  if (!followState.incomingId) return false
+  return incomingStatusUpper.value === 'PENDING'
+})
+
+const isTemporaryRoom = computed(() => {
+  if (roomTemporary.value != null) {
+    return Boolean(roomTemporary.value)
+  }
+  if (roomInfo.value?.type) {
+    return String(roomInfo.value.type).toUpperCase() === 'RANDOM'
+  }
+  const bootstrapTemporary = matchStore.bootstrap?.roomTemporary
+  if (bootstrapTemporary != null) {
+    return Boolean(bootstrapTemporary)
+  }
+  return null
 })
 
 const canStartCall = computed(() => {
   if (!roomId.value) return false
   return participantLoginIds.value.some((loginId) => loginId && loginId !== resolveClientIdentity(auth))
 })
+
+function toFiniteNumber (value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
 
 function ensureConversation(roomKey) {
   if (!conversations.value[roomKey]) {
@@ -297,13 +324,42 @@ async function ensureRoomExists(roomKey, fallbackName) {
   try {
     const { data } = await api.get(`/rooms/${roomKey}`)
     const participants = (data.participants || []).map((participant) => participant.loginId).filter(Boolean)
+    const roomType = data.roomType || data.room_type || null
+    const temporary = roomType ? String(roomType).toUpperCase() === 'RANDOM' : undefined
+    const myLoginId = resolveClientIdentity(auth)
+    const partnerDetail = (data.participants || []).find((participant) => {
+      const loginId = participant.loginId || participant.login_id || participant.username
+      if (!loginId) return false
+      if (!myLoginId) return true
+      return String(loginId).toLowerCase() !== String(myLoginId).toLowerCase()
+    })
+    if (temporary !== undefined) {
+      roomTemporary.value = temporary
+    }
     roomInfo.value = {
       id: data.roomId,
       name: data.roomName || fallbackName || `대화방 #${data.roomId}`,
+      type: roomType,
+      temporary,
       participantLogins: participants,
       participantsDetail: data.participants || [],
     }
     participantLoginIds.value = participants
+    if (partnerDetail) {
+      const loginId = partnerDetail.loginId || partnerDetail.login_id || partnerDetail.username
+      const nickname = partnerDetail.nickName || partnerDetail.nickname || partnerDetail.name
+      const userPid = partnerDetail.userPid ?? partnerDetail.user_pid ?? null
+      if (loginId) {
+        partnerLoginId.value = loginId
+      }
+      if (nickname) {
+        partnerName.value = nickname
+      }
+      const numericPid = Number(userPid)
+      if (Number.isFinite(numericPid) && numericPid > 0) {
+        partnerUserPid.value = numericPid
+      }
+    }
     return roomInfo.value
   } catch (error) {
     console.warn('[match-session] Failed to fetch room detail', error)
@@ -313,6 +369,8 @@ async function ensureRoomExists(roomKey, fallbackName) {
         name: fallbackName || `대화방 #${roomKey}`,
         participantLogins: participantLoginIds.value,
         participantsDetail: [],
+        type: roomInfo.value?.type ?? null,
+        temporary: roomTemporary.value ?? null,
       }
     }
     return roomInfo.value
@@ -344,16 +402,37 @@ const handleFileSelect = createFileSelectHandler({
 
 async function handleMatchResultEvent(payload) {
   if (!payload) return
-  const nextRoomId = payload?.roomId ?? payload?.room_id
-  const partner = payload?.partnerNickName || payload?.partnerNickname
-  if (nextRoomId) {
-    roomId.value = Number(nextRoomId)
-    await ensureRoomExists(Number(nextRoomId), partner)
+  const normalized = camelizeKeys(payload)
+  matchStore.mergeBootstrap(normalized)
+  applyBootstrap(matchStore.bootstrap)
+  if (roomId.value) {
+    await ensureRoomExists(roomId.value, matchStore.bootstrap?.partnerName)
   }
-  if (partner) {
-    partnerName.value = partner
+}
+
+async function handleFollowUpdateEvent(payload) {
+  if (!payload) return
+  const normalized = camelizeKeys(payload)
+  matchStore.mergeBootstrap(normalized)
+  applyBootstrap(matchStore.bootstrap)
+  if (roomId.value) {
+    await ensureRoomExists(roomId.value, matchStore.bootstrap?.partnerName)
   }
-  await refreshBootstrapFromStore()
+}
+
+async function handleRoomPromotedEvent(payload) {
+  const normalized = camelizeKeys(payload || {})
+  const patch = {
+    ...normalized,
+    roomTemporary: false,
+    mutualFollow: true,
+    followStatus: normalized.followStatus || 'ACCEPTED',
+  }
+  matchStore.mergeBootstrap(patch)
+  applyBootstrap(matchStore.bootstrap)
+  if (roomId.value) {
+    await ensureRoomExists(roomId.value, matchStore.bootstrap?.partnerName)
+  }
 }
 
 const {
@@ -365,6 +444,10 @@ const {
   maxReconnectAttempts: 3,
   onChat: (payload) => handleIncomingMessage(payload),
   onMatchResult: (payload) => handleMatchResultEvent(payload),
+  events: {
+    'match-follow-updated': (payload) => { void handleFollowUpdateEvent(payload) },
+    'match-room-promoted': (payload) => { void handleRoomPromotedEvent(payload) },
+  },
 })
 
 function applyRouteContext() {
@@ -385,6 +468,39 @@ function applyRouteContext() {
   }
 }
 
+function applyFollowSnapshot (patch = {}) {
+  if (!patch || typeof patch !== 'object') return
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'followStatus')) {
+    followState.status = patch.followStatus ? patch.followStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'incomingFollowStatus')) {
+    const nextStatus = patch.incomingFollowStatus
+    followState.incomingStatus = nextStatus ? nextStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'outgoingFollowStatus')) {
+    const nextStatus = patch.outgoingFollowStatus
+    followState.outgoingStatus = nextStatus ? nextStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'incomingFollowId')) {
+    followState.incomingId = toFiniteNumber(patch.incomingFollowId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'outgoingFollowId')) {
+    followState.outgoingId = toFiniteNumber(patch.outgoingFollowId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'followRelationId')) {
+    followState.relationId = toFiniteNumber(patch.followRelationId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'mutualFollow')) {
+    followState.mutual = Boolean(patch.mutualFollow)
+  }
+
+  followState.status = followState.status ? followState.status.toString().toUpperCase() : null
+  followState.incomingStatus = followState.incomingStatus ? followState.incomingStatus.toUpperCase() : null
+  followState.outgoingStatus = followState.outgoingStatus ? followState.outgoingStatus.toUpperCase() : null
+  followState.relationId = followState.incomingId ?? followState.outgoingId ?? followState.relationId ?? null
+}
+
 function applyBootstrap(payload) {
   if (!payload) return
   partnerName.value = payload.partnerName || partnerName.value
@@ -392,8 +508,12 @@ function applyBootstrap(payload) {
   partnerUserPid.value = payload.partnerUserPid ?? partnerUserPid.value
   roomId.value = payload.roomId ?? roomId.value
   handshakeStatus.value = payload.status || payload.handshake?.status || handshakeStatus.value
-  followState.status = payload.followStatus ?? followState.status
-  followState.relationId = payload.followRelationId ?? followState.relationId
+  if (Object.prototype.hasOwnProperty.call(payload, 'roomTemporary')) {
+    roomTemporary.value = payload.roomTemporary
+  } else if (payload.roomType) {
+    roomTemporary.value = String(payload.roomType).toUpperCase() === 'RANDOM'
+  }
+  applyFollowSnapshot(payload)
   if (payload.chatReady) {
     sessionStatus.value = '실시간 대화를 진행해보세요!'
   } else if (payload.handshakeReady) {
@@ -453,6 +573,7 @@ onUnmounted(() => {
   hangUpCall()
   setManualDisconnect(true)
   disconnectRealtime()
+  void cleanupTemporaryRoom('component-unmount')
 })
 
 function bubbleClass(message) {
@@ -539,9 +660,17 @@ async function requestFollow() {
   }
   followRequestLoading.value = true
   try {
-    await followService.requestFollow(followeeId)
+    const { data } = await followService.requestFollow(followeeId)
+    followState.outgoingId = toFiniteNumber(data?.followId) ?? followState.outgoingId
+    followState.outgoingStatus = data?.status ? data.status.toString().toUpperCase() : 'PENDING'
     followState.status = 'PENDING_OUTGOING'
-    matchStore.mergeBootstrap({ followStatus: followState.status })
+    followState.relationId = followState.outgoingId ?? followState.relationId
+    matchStore.mergeBootstrap({
+      followStatus: followState.status,
+      followRelationId: followState.relationId,
+      outgoingFollowId: followState.outgoingId,
+      outgoingFollowStatus: followState.outgoingStatus,
+    })
     sessionStatus.value = '팔로우 요청을 전송했습니다.'
   } catch (error) {
     console.error('Failed to send follow request', error)
@@ -553,12 +682,25 @@ async function requestFollow() {
 
 async function acceptFollowRequest() {
   if (!canAcceptFollow.value || followAcceptLoading.value) return
-  const followId = followState.relationId
+  const followId = followState.incomingId ?? followState.relationId
+  if (!followId) {
+    alert('수락할 팔로우 요청을 찾을 수 없습니다.')
+    return
+  }
   followAcceptLoading.value = true
   try {
     await followService.acceptFollow(followId)
-    followState.status = 'ACCEPTED'
-    matchStore.mergeBootstrap({ followStatus: 'ACCEPTED', followRelationId: followId })
+    followState.incomingStatus = 'ACCEPTED'
+    followState.status = hasMutualFollow.value ? 'ACCEPTED' : 'ACCEPTED_INCOMING'
+    followState.relationId = followState.incomingId ?? followId
+    followState.mutual = hasMutualFollow.value
+    matchStore.mergeBootstrap({
+      followStatus: followState.status,
+      followRelationId: followState.relationId,
+      incomingFollowId: followState.incomingId ?? followId,
+      incomingFollowStatus: followState.incomingStatus,
+      mutualFollow: followState.mutual,
+    })
     sessionStatus.value = '서로 팔로우 상태입니다.'
   } catch (error) {
     console.error('Failed to accept follow request', error)
@@ -568,12 +710,47 @@ async function acceptFollowRequest() {
   }
 }
 
+async function cleanupTemporaryRoom(reason = 'navigation') {
+  if (cleanupState.running || cleanupState.completed) return false
+  if (!roomId.value) return false
+
+  if (isTemporaryRoom.value === null) {
+    await ensureRoomExists(roomId.value)
+  }
+
+  if (isTemporaryRoom.value === false || hasMutualFollow.value) {
+    cleanupState.completed = true
+    return false
+  }
+
+  cleanupState.running = true
+  try {
+    await api.delete(`/rooms/${roomId.value}/temporary`, { params: { reason } })
+    cleanupState.completed = true
+    const cleanedRoom = roomId.value
+    roomId.value = null
+    roomInfo.value = null
+    roomTemporary.value = null
+    matchStore.mergeBootstrap({ roomId: null, chatReady: false, roomTemporary: null })
+    return Boolean(cleanedRoom)
+  } catch (error) {
+    console.warn('[match-session] Failed to cleanup temporary room', error)
+    return false
+  } finally {
+    cleanupState.running = false
+  }
+}
+
 function goBackToMatching() {
-  router.push({ name: 'match' })
+  cleanupTemporaryRoom('user-navigation').finally(() => {
+    router.push({ name: 'match' })
+  })
 }
 
 function goBackToResult() {
-  router.push({ name: 'match-result' })
+  cleanupTemporaryRoom('view-result').finally(() => {
+    router.push({ name: 'match-result' })
+  })
 }
 </script>
 
@@ -588,6 +765,7 @@ function goBackToResult() {
 
 .session-card {
   background: #fff;
+  min-height: 75vh;
 }
 
 .session-content {
@@ -595,6 +773,7 @@ function goBackToResult() {
   flex-direction: row;
   gap: 24px;
   padding: 24px;
+  height: 100%;
 }
 
 .video-pane {
@@ -602,6 +781,7 @@ function goBackToResult() {
   max-width: 55%;
   display: flex;
   flex-direction: column;
+  min-height: 420px;
 }
 
 .session-video {
@@ -627,6 +807,16 @@ function goBackToResult() {
   padding: 16px;
   overflow-y: auto;
   background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+}
+
+.chat-messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: auto;
 }
 
 .message-row {

--- a/Matcha-Talk/frontend/src/views/MatchingResult.vue
+++ b/Matcha-Talk/frontend/src/views/MatchingResult.vue
@@ -217,6 +217,11 @@ const promotionNotice = ref(false)
 const followState = reactive({
   status: null,
   relationId: null,
+  incomingId: null,
+  incomingStatus: null,
+  outgoingId: null,
+  outgoingStatus: null,
+  mutual: false,
 })
 const followRequestLoading = ref(false)
 const followAcceptLoading = ref(false)
@@ -224,6 +229,54 @@ const acceptLoading = ref(false)
 const declineLoading = ref(false)
 
 let countdownTimer = null
+
+function toFiniteNumber (value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function resetFollowState () {
+  followState.status = null
+  followState.relationId = null
+  followState.incomingId = null
+  followState.incomingStatus = null
+  followState.outgoingId = null
+  followState.outgoingStatus = null
+  followState.mutual = false
+}
+
+function applyFollowSnapshot (patch = {}) {
+  if (!patch || typeof patch !== 'object') return
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'followStatus')) {
+    followState.status = patch.followStatus ? patch.followStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'incomingFollowStatus')) {
+    const nextStatus = patch.incomingFollowStatus
+    followState.incomingStatus = nextStatus ? nextStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'outgoingFollowStatus')) {
+    const nextStatus = patch.outgoingFollowStatus
+    followState.outgoingStatus = nextStatus ? nextStatus.toString().toUpperCase() : null
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'incomingFollowId')) {
+    followState.incomingId = toFiniteNumber(patch.incomingFollowId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'outgoingFollowId')) {
+    followState.outgoingId = toFiniteNumber(patch.outgoingFollowId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'followRelationId')) {
+    followState.relationId = toFiniteNumber(patch.followRelationId)
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'mutualFollow')) {
+    followState.mutual = Boolean(patch.mutualFollow)
+  }
+
+  followState.status = followState.status ? followState.status.toUpperCase() : null
+  followState.incomingStatus = followState.incomingStatus ? followState.incomingStatus.toUpperCase() : null
+  followState.outgoingStatus = followState.outgoingStatus ? followState.outgoingStatus.toUpperCase() : null
+  followState.relationId = followState.incomingId ?? followState.outgoingId ?? followState.relationId ?? null
+}
 
 const isPending = computed(() => !matchReady.value && !matchDeclined.value)
 const shouldPollMatchStatus = computed(() => !chatReady.value && !matchDeclined.value)
@@ -243,38 +296,41 @@ const handshakeStatusLabel = computed(() => {
   }
 })
 const followStatusUpper = computed(() => (followState.status || '').toString().toUpperCase())
-const followStatusMessage = computed(() => {
-  if (!followState.status) return ''
-  if (followStatusUpper.value.includes('ACCEPT')) {
-    return '서로 팔로우 상태입니다.'
+const incomingStatusUpper = computed(() => (followState.incomingStatus || '').toString().toUpperCase())
+const outgoingStatusUpper = computed(() => (followState.outgoingStatus || '').toString().toUpperCase())
+const hasMutualFollow = computed(() => {
+  if (followState.mutual) return true
+  if (incomingStatusUpper.value === 'ACCEPTED' && outgoingStatusUpper.value === 'ACCEPTED') {
+    return true
   }
-  if (followStatusUpper.value.includes('INCOMING') || followStatusUpper.value.includes('RECEIVED')) {
+  return followStatusUpper.value === 'ACCEPTED'
+})
+const followStatusMessage = computed(() => {
+  if (hasMutualFollow.value) return '서로 팔로우 상태입니다.'
+  if (incomingStatusUpper.value === 'PENDING') {
     return '상대방이 팔로우 요청을 보냈습니다.'
   }
-  if (followStatusUpper.value.includes('PENDING') || followStatusUpper.value.includes('REQUEST')) {
+  if (outgoingStatusUpper.value === 'PENDING') {
     return '팔로우 응답을 기다리고 있습니다.'
   }
-  return followState.status
+  if (incomingStatusUpper.value === 'ACCEPTED' && outgoingStatusUpper.value !== 'ACCEPTED') {
+    return '상대가 나를 팔로우 중입니다.'
+  }
+  if (outgoingStatusUpper.value === 'ACCEPTED' && incomingStatusUpper.value !== 'ACCEPTED') {
+    return '상대를 팔로우했습니다.'
+  }
+  return followState.status || ''
 })
 const canRequestFollow = computed(() => {
   if (partnerUserPid.value == null) return false
-  if (!followStatusUpper.value) return true
-  if (followStatusUpper.value.includes('ACCEPT')) return false
-  if (followStatusUpper.value.includes('OUTGOING')) return false
-  if (followStatusUpper.value.includes('PENDING') &&
-    !followStatusUpper.value.includes('INCOMING') &&
-    !followStatusUpper.value.includes('RECEIVED')) {
-    return false
-  }
+  if (hasMutualFollow.value) return false
+  const outgoing = outgoingStatusUpper.value
+  if (outgoing === 'PENDING' || outgoing === 'ACCEPTED') return false
   return true
 })
 const canAcceptFollow = computed(() => {
-  if (!followState.relationId) return false
-  if (!followStatusUpper.value) return true
-  if (followStatusUpper.value.includes('ACCEPT')) return false
-  return followStatusUpper.value.includes('INCOMING') ||
-    followStatusUpper.value.includes('RECEIVED') ||
-    followStatusUpper.value === 'PENDING'
+  if (!followState.incomingId) return false
+  return incomingStatusUpper.value === 'PENDING'
 })
 
 const sessionRouteQuery = computed(() => {
@@ -375,8 +431,7 @@ function applyBootstrap (payload, options = {}) {
     chatReady.value = false
     matchReady.value = false
     matchDeclined.value = false
-    followState.status = null
-    followState.relationId = null
+    resetFollowState()
     sessionStatus.value = options.statusMessage || '매칭 대기 중입니다...'
     startCountdown(null)
     return
@@ -388,8 +443,7 @@ function applyBootstrap (payload, options = {}) {
   roomId.value = payload.roomId ?? payload.handshake?.roomId ?? roomId.value ?? null
   handshakeInfo.value = payload.handshake || handshakeInfo.value || null
   handshakeStatus.value = payload.status || payload.handshake?.status || handshakeStatus.value || null
-  followState.status = payload.followStatus ?? followState.status ?? null
-  followState.relationId = payload.followRelationId ?? payload.followId ?? followState.relationId ?? null
+  applyFollowSnapshot(payload)
 
   handshakeReady.value = !!payload.handshakeReady
   chatReady.value = !!payload.chatReady || (roomId.value != null && (handshakeStatus.value === 'CONFIRMED' || handshakeStatus.value === 'ARCHIVED'))
@@ -421,6 +475,12 @@ function ingestMatchPayload (payload, options = {}) {
     status: normalized.status ?? handshakeStatus.value ?? null,
     followStatus: normalized.followStatus ?? followState.status ?? null,
     followRelationId: normalized.followRelationId ?? normalized.followId ?? followState.relationId ?? null,
+    incomingFollowId: normalized.incomingFollowId ?? followState.incomingId ?? null,
+    incomingFollowStatus: normalized.incomingFollowStatus ?? followState.incomingStatus ?? null,
+    outgoingFollowId: normalized.outgoingFollowId ?? followState.outgoingId ?? null,
+    outgoingFollowStatus: normalized.outgoingFollowStatus ?? followState.outgoingStatus ?? null,
+    mutualFollow: normalized.mutualFollow ?? followState.mutual ?? false,
+    roomTemporary: normalized.roomTemporary ?? matchStore.bootstrap?.roomTemporary ?? null,
     handshake: {
       myRequestId: normalized.myRequestId ?? handshakeInfo.value?.myRequestId ?? null,
       partnerRequestId: normalized.partnerRequestId ?? handshakeInfo.value?.partnerRequestId ?? null,
@@ -453,20 +513,19 @@ function handleMatchDeclined (payload) {
   matchDeclined.value = true
 }
 
+function handleFollowUpdated (payload) {
+  ingestMatchPayload(payload, { statusMessage: sessionStatus.value })
+}
+
 function handleRoomPromoted (payload) {
   const normalized = camelizeKeys(payload || {})
-  if (normalized.roomId) {
-    matchStore.mergeBootstrap({
-      roomId: normalized.roomId,
-      chatReady: true,
-    })
-    roomId.value = normalized.roomId
-  }
-  followState.status = 'ACCEPTED'
-  matchStore.mergeBootstrap({
-    followStatus: 'ACCEPTED',
-    followRelationId: normalized.followRelationId ?? matchStore.bootstrap?.followRelationId ?? null,
-  })
+  ingestMatchPayload({
+    ...normalized,
+    chatReady: true,
+    followStatus: normalized.followStatus || 'ACCEPTED',
+    mutualFollow: true,
+    roomTemporary: false,
+  }, { statusMessage: '서로 팔로우 상태입니다.' })
   promotionNotice.value = true
 }
 
@@ -544,9 +603,17 @@ async function requestFollow () {
   }
   followRequestLoading.value = true
   try {
-    await followService.requestFollow(followeeId)
+    const { data } = await followService.requestFollow(followeeId)
+    followState.outgoingId = toFiniteNumber(data?.followId) ?? followState.outgoingId
+    followState.outgoingStatus = data?.status ? data.status.toString().toUpperCase() : 'PENDING'
     followState.status = 'PENDING_OUTGOING'
-    matchStore.mergeBootstrap({ followStatus: followState.status })
+    followState.relationId = followState.outgoingId ?? followState.relationId
+    matchStore.mergeBootstrap({
+      followStatus: followState.status,
+      followRelationId: followState.relationId,
+      outgoingFollowId: followState.outgoingId,
+      outgoingFollowStatus: followState.outgoingStatus,
+    })
     sessionStatus.value = '팔로우 요청을 전송했습니다.'
   } catch (error) {
     console.error('Failed to send follow request', error)
@@ -558,13 +625,26 @@ async function requestFollow () {
 
 async function acceptFollowRequest () {
   if (!canAcceptFollow.value || followAcceptLoading.value) return
-  const followId = followState.relationId
+  const followId = followState.incomingId ?? followState.relationId
+  if (!followId) {
+    alert('수락할 팔로우 요청을 찾을 수 없습니다.')
+    return
+  }
   followAcceptLoading.value = true
   try {
     await followService.acceptFollow(followId)
-    followState.status = 'ACCEPTED'
-    matchStore.mergeBootstrap({ followStatus: 'ACCEPTED', followRelationId: followId })
-    promotionNotice.value = true
+    followState.incomingStatus = 'ACCEPTED'
+    followState.status = hasMutualFollow.value ? 'ACCEPTED' : 'ACCEPTED_INCOMING'
+    followState.relationId = followState.incomingId ?? followId
+    followState.mutual = hasMutualFollow.value
+    matchStore.mergeBootstrap({
+      followStatus: followState.status,
+      followRelationId: followState.relationId,
+      incomingFollowId: followState.incomingId ?? followId,
+      incomingFollowStatus: followState.incomingStatus,
+      mutualFollow: followState.mutual,
+    })
+    promotionNotice.value = followState.mutual || promotionNotice.value
   } catch (error) {
     console.error('Failed to accept follow request', error)
     alert('팔로우 수락에 실패했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
@@ -770,6 +850,7 @@ async function connectWebSocket () {
       websocketClient.onEvent('match-found', handleMatchFound),
       websocketClient.onEvent('match-room-ready', handleMatchRoomReady),
       websocketClient.onEvent('match-declined', handleMatchDeclined),
+      websocketClient.onEvent('match-follow-updated', handleFollowUpdated),
       websocketClient.onEvent('match-room-promoted', handleRoomPromoted),
       websocketClient.onEvent('match-status', handleMatchStatus),
       websocketClient.onEvent('connected', () => {


### PR DESCRIPTION
## Summary
- attach follow relationship metadata to match payloads and websocket notifications so both participants see current follow state
- allow random rooms without mutual follows to be cleaned up from the backend and expose the new endpoint via the controller
- update the match result/session views to enable follow acceptance buttons correctly and call the cleanup endpoint when leaving unfollowed chats

## Testing
- npm run build
- ./gradlew test *(fails: missing JDK 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da54858d2883259e20299b690e802f