### PR TITLE
Add direct chat support for follow relationships

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -2,6 +2,7 @@ package net.datasa.project01.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.datasa.project01.domain.dto.DirectChatRequestDto;
 import net.datasa.project01.domain.dto.RoomDetailResponseDto;
 import net.datasa.project01.domain.dto.RoomCreateResponseDto;
 import net.datasa.project01.domain.dto.RoomListResponseDto;
@@ -9,6 +10,7 @@ import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.dto.RoomCleanupResponseDto;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.service.ChatService;
+import jakarta.validation.Valid;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -46,6 +48,14 @@ public class ChatController {
             log.error("Error creating group room", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @PostMapping("/direct")
+    public ResponseEntity<RoomDetailResponseDto> ensureDirectRoom(@AuthenticationPrincipal UserDetails userDetails,
+                                                                  @Valid @RequestBody DirectChatRequestDto requestDto) {
+        String loginId = requireLoginId(userDetails);
+        RoomDetailResponseDto responseDto = chatService.ensureDirectRoom(loginId, requestDto.targetUserPid());
+        return ResponseEntity.ok(responseDto);
     }
 
     /**

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/DirectChatRequestDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/DirectChatRequestDto.java
@@ -1,0 +1,6 @@
+package net.datasa.project01.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DirectChatRequestDto(@NotNull(message = "대상 사용자를 선택해주세요.") Long targetUserPid) {
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/MatchRequestDto.java
@@ -34,4 +34,12 @@ public class MatchRequestDto {
     private List<String> interests; // 'interestsJson' -> 'interests'로 필드명 변경
 
     private String loginId;
+
+    @AssertTrue(message = "최소 나이는 최대 나이보다 클 수 없습니다.")
+    public boolean isValidAgeRange() {
+        if (minAge == null || maxAge == null) {
+            return true;
+        }
+        return minAge <= maxAge;
+    }
 }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomListResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/RoomListResponseDto.java
@@ -15,6 +15,7 @@ public class RoomListResponseDto {
     private final Room.RoomType roomType;
     private final int memberCount;
     private final List<String> memberNicknames;
+    private final List<String> memberLoginIds;
     private final boolean temporary;
 
     public static RoomListResponseDto fromEntity(Room room, List<RoomMember> members) {
@@ -22,11 +23,16 @@ public class RoomListResponseDto {
                 .map(member -> member.getUser().getNickName())
                 .collect(Collectors.toList());
 
+        List<String> loginIds = members.stream()
+                .map(member -> member.getUser().getLoginId())
+                .collect(Collectors.toList());
+
         return RoomListResponseDto.builder()
                 .roomId(room.getRoomId())
                 .roomType(room.getRoomType())
                 .memberCount(members.size())
                 .memberNicknames(nicknames)
+                .memberLoginIds(loginIds)
                 .temporary(room.isTemporary())
                 .build();
     }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -206,6 +207,38 @@ public class ChatService {
                         .filter(entry -> !entry.getKey().isTemporary())
                         .map(entry -> RoomListResponseDto.fromEntity(entry.getKey(), entry.getValue()))
                         .collect(Collectors.toList());
+        }
+
+        @Transactional
+        public RoomDetailResponseDto ensureDirectRoom(String loginId, Long targetUserPid) {
+                if (targetUserPid == null) {
+                        throw new IllegalArgumentException("대상 사용자를 선택해주세요.");
+                }
+
+                User requester = userRepository.findByLoginId(loginId)
+                        .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+                if (requester.getUserPid().equals(targetUserPid)) {
+                        throw new IllegalArgumentException("자기 자신과는 채팅방을 만들 수 없습니다.");
+                }
+
+                User target = userRepository.findById(targetUserPid)
+                        .orElseThrow(() -> new IllegalArgumentException("대상 사용자를 찾을 수 없습니다."));
+
+                boolean hasAcceptedFollow = followRepository.findByFollowerAndFolloweeAndStatus(requester, target, Follow.FollowStatus.ACCEPTED)
+                        .isPresent()
+                        || followRepository.findByFollowerAndFolloweeAndStatus(target, requester, Follow.FollowStatus.ACCEPTED)
+                        .isPresent();
+
+                if (!hasAcceptedFollow) {
+                        throw new IllegalStateException("상대방과 팔로우가 수락된 상태에서만 1:1 채팅을 시작할 수 있습니다.");
+                }
+
+                Room existing = findExistingDirectRoom(requester, target);
+                Room resolved = existing != null ? existing : createPrivateRoom(requester, target);
+
+                List<RoomMember> members = roomMemberRepository.findByRoom(resolved);
+                return RoomDetailResponseDto.fromEntity(resolved, members);
         }
 
         @Transactional(readOnly = true)
@@ -396,6 +429,29 @@ public class ChatService {
                 boolean forward = followRepository.findByFollowerAndFolloweeAndStatus(first, second, Follow.FollowStatus.ACCEPTED).isPresent();
                 boolean reverse = followRepository.findByFollowerAndFolloweeAndStatus(second, first, Follow.FollowStatus.ACCEPTED).isPresent();
                 return forward && reverse;
+        }
+
+        private Room findExistingDirectRoom(User user1, User user2) {
+                List<RoomMember> memberships = roomMemberRepository.findByUser(user1);
+                Set<Long> requiredMembers = Set.of(user1.getUserPid(), user2.getUserPid());
+
+                for (RoomMember membership : memberships) {
+                        Room room = membership.getRoom();
+                        if (room == null || room.getRoomType() != Room.RoomType.PRIVATE) {
+                                continue;
+                        }
+
+                        List<RoomMember> participants = roomMemberRepository.findByRoom(room);
+                        Set<Long> participantIds = participants.stream()
+                                .map(member -> member.getUser().getUserPid())
+                                .collect(Collectors.toSet());
+
+                        if (participantIds.containsAll(requiredMembers) && participantIds.size() == requiredMembers.size()) {
+                                return room;
+                        }
+                }
+
+                return null;
         }
 
         private void removeRoomWithDependencies(Room room, List<RoomMember> existingMembers) {

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -239,11 +239,20 @@ public class MatchService {
     }
 
     private MatchRequest buildMatchRequest(User user, MatchRequestDto requestDto, MatchRequest.MatchStatus status) throws JsonProcessingException {
+        Integer minAge = requestDto.getMinAge();
+        Integer maxAge = requestDto.getMaxAge();
+
+        if (minAge != null && maxAge != null && minAge > maxAge) {
+            int swappedMin = maxAge;
+            maxAge = minAge;
+            minAge = swappedMin;
+        }
+
         return MatchRequest.builder()
                 .user(user)
                 .choiceGender(MatchRequest.Gender.valueOf(requestDto.getChoiceGender()))
-                .minAge(requestDto.getMinAge())
-                .maxAge(requestDto.getMaxAge())
+                .minAge(minAge)
+                .maxAge(maxAge)
                 .regionCode(requestDto.getRegionCode())
                 .interestsJson(objectMapper.writeValueAsString(requestDto.getInterests()))
                 .status(status)

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -37,7 +37,14 @@
                 lines="two"
               >
                 <template #prepend>
-                  <v-avatar size="40"><v-icon color="primary">mdi-account</v-icon></v-avatar>
+                  <v-avatar size="40">
+                    <template v-if="item.avatarUrl">
+                      <v-img :src="item.avatarUrl" alt="프로필 이미지" cover />
+                    </template>
+                    <template v-else>
+                      <v-icon color="primary">mdi-account</v-icon>
+                    </template>
+                  </v-avatar>
                 </template>
                 <v-list-item-title>{{ item.name }}</v-list-item-title>
                 <v-list-item-subtitle>{{ item.last }}</v-list-item-subtitle>
@@ -226,6 +233,7 @@ import { translate } from '../services/translator'
 import { useVocabularyStore } from '../stores/vocabulary'
 import { resolveClientIdentity } from '../utils/identity'
 import VideoChat from '../components/VideoChat.vue'
+import followService from '../services/follow'
 import {
   createFileSelectHandler,
   createIncomingMessageHandler,
@@ -239,6 +247,7 @@ const groups = ref([])
 const conversations = ref({})
 const current = ref({})
 const draft = ref('')
+const followings = ref([])
 
 const chatMessagesContainer = ref(null)
 const fileInput = ref(null)
@@ -280,6 +289,10 @@ const {
   maxReconnectAttempts: 3,
   onChat: (payload) => handleIncomingMessage(payload),
   onMatchResult: (payload) => handleMatchResultEvent(payload),
+  events: {
+    'match-follow-updated': () => { void loadRooms({ preserveCurrent: true }) },
+    'match-room-promoted': () => { void loadRooms({ preserveCurrent: true }) },
+  },
 })
 
 onMounted(async () => {
@@ -297,7 +310,7 @@ watch(
   () => auth.user?.userPid,
   async (userPid, prev) => {
     if (userPid && userPid !== prev) {
-      await loadRooms()
+      await loadRooms({ preserveCurrent: true })
       await ensureActiveRoomFromRoute()
     }
   }
@@ -323,10 +336,16 @@ onUnmounted(() => {
   disconnectRealtime()
 })
 
-async function loadRooms() {
+async function loadRooms(options = {}) {
   try {
     isLoadingRooms.value = true
-    const { data } = await api.get('/rooms/my')
+    const { preserveCurrent = false } = options
+    const [roomsResponse, followingList] = await Promise.all([
+      api.get('/rooms/my'),
+      fetchFollowingList(),
+    ])
+
+    const data = Array.isArray(roomsResponse?.data) ? roomsResponse.data : []
     const meNickname = auth.user?.nickName || auth.user?.nickname
     const directRooms = []
     const groupRooms = []
@@ -344,17 +363,84 @@ async function loadRooms() {
       }
     })
 
-    chats.value = directRooms
+    followings.value = Array.isArray(followingList) ? followingList : []
+    const followEntries = buildFollowEntries(followings.value, directRooms)
+
+    chats.value = [...directRooms, ...followEntries]
     groups.value = groupRooms
 
-    if (current.value?.id) {
+    const hasActiveRoom = Boolean(current.value?.id)
+
+    if (hasActiveRoom) {
       await selectRoomById(current.value.id, { skipRouteUpdate: true })
+    } else if (!preserveCurrent) {
+      const fallback = [...chats.value.filter((room) => !room.virtual), ...groups.value][0]
+      if (fallback) {
+        await openChat(fallback, { skipRouteUpdate: true })
+      }
     }
   } catch (error) {
     console.error('[chat] Failed to load rooms', error)
   } finally {
     isLoadingRooms.value = false
   }
+}
+
+async function fetchFollowingList() {
+  const userPid = auth.user?.userPid ?? auth.user?.user_pid ?? null
+  if (!userPid) {
+    return []
+  }
+
+  try {
+    const { data } = await followService.getFollowing(userPid)
+    return Array.isArray(data) ? data : []
+  } catch (error) {
+    console.warn('[chat] Failed to load follow list', error)
+    return []
+  }
+}
+
+function buildFollowEntries(followList, directRooms) {
+  if (!Array.isArray(followList) || followList.length === 0) {
+    return []
+  }
+
+  const existingLogins = new Set()
+  directRooms.forEach((room) => {
+    (room.participantLogins || []).forEach((login) => {
+      if (login) {
+        existingLogins.add(String(login).toLowerCase())
+      }
+    })
+  })
+
+  return followList
+    .map((follow) => {
+      const loginId = follow?.loginId || follow?.login_id || null
+      const userPid = follow?.userPid ?? follow?.user_pid ?? null
+      if (!loginId || userPid == null) {
+        return null
+      }
+      if (existingLogins.has(String(loginId).toLowerCase())) {
+        return null
+      }
+      const displayName = follow?.nickName || follow?.nickname || loginId
+      return {
+        id: `follow-${userPid}`,
+        name: displayName,
+        last: '클릭하여 채팅을 시작하세요.',
+        participants: [displayName],
+        participantLogins: [loginId],
+        participantsDetail: [],
+        type: 'DIRECT',
+        virtual: true,
+        targetUserPid: userPid,
+        avatarUrl: follow?.avatarUrl || null,
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.name.localeCompare(b.name, 'ko'))
 }
 
 function normalizeRoomListEntry(room, meNickname) {
@@ -441,7 +527,7 @@ async function ensureActiveRoomFromRoute() {
   }
 
   if (!current.value?.id) {
-    const fallback = chats.value[0] || groups.value[0]
+    const fallback = [...chats.value.filter((room) => !room.virtual), ...groups.value][0]
     if (fallback) {
       await openChat(fallback, { skipRouteUpdate: true })
     }
@@ -475,6 +561,11 @@ const messages = computed(() => conversations.value[current.value?.id] ?? [])
 async function openChat(item, options = {}) {
   if (!item) return
 
+  if (item.virtual && item.targetUserPid) {
+    await openDirectFollowRoom(item, options)
+    return
+  }
+
   const room = await ensureRoomExists(item.id, item.name)
   current.value = room
   tab.value = item.type === 'GROUP' ? 'group' : 'direct'
@@ -486,6 +577,23 @@ async function openChat(item, options = {}) {
   }
 
   scrollToBottom()
+}
+
+async function openDirectFollowRoom(item, options = {}) {
+  try {
+    const { data } = await api.post('/rooms/direct', { targetUserPid: item.targetUserPid })
+    const entry = normalizeRoomDetail(data)
+    followings.value = followings.value.filter((follow) => {
+      const pid = follow?.userPid ?? follow?.user_pid ?? null
+      return pid === null || pid !== item.targetUserPid
+    })
+    chats.value = chats.value.filter((chat) => chat.id !== item.id)
+    const persisted = addOrUpdateRoom(entry)
+    await openChat(persisted, options)
+  } catch (error) {
+    console.error('[chat] Failed to prepare direct chat room', error)
+    alert('채팅방을 준비하지 못했습니다: ' + (error?.response?.data?.message || error?.message || '알 수 없는 오류'))
+  }
 }
 
 function ensureConversation(roomId) {
@@ -550,7 +658,7 @@ async function handleMatchResultEvent(payload) {
   if (roomId) {
     await ensureRoomExists(roomId, partner)
   }
-  await loadRooms()
+  await loadRooms({ preserveCurrent: true })
   if (roomId) {
     selectRoomById(Number(roomId))
   }

--- a/Matcha-Talk/frontend/src/views/MatchSession.vue
+++ b/Matcha-Talk/frontend/src/views/MatchSession.vue
@@ -757,6 +757,8 @@ function goBackToResult() {
 <style scoped>
 .match-session {
   min-height: calc(100vh - var(--v-layout-top));
+  display: flex;
+  flex-direction: column;
 }
 
 .session-header {
@@ -766,6 +768,9 @@ function goBackToResult() {
 .session-card {
   background: #fff;
   min-height: 75vh;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .session-content {
@@ -774,6 +779,7 @@ function goBackToResult() {
   gap: 24px;
   padding: 24px;
   height: 100%;
+  min-height: 0;
 }
 
 .video-pane {
@@ -781,7 +787,7 @@ function goBackToResult() {
   max-width: 55%;
   display: flex;
   flex-direction: column;
-  min-height: 420px;
+  min-height: 0;
 }
 
 .session-video {
@@ -800,6 +806,7 @@ function goBackToResult() {
   display: flex;
   flex-direction: column;
   border-left: 1px solid #f0f0f0;
+  min-height: 0;
 }
 
 .chat-messages {
@@ -809,21 +816,21 @@ function goBackToResult() {
   background: #fafafa;
   display: flex;
   flex-direction: column;
-  min-height: 420px;
+  min-height: 0;
 }
 
 .chat-messages__list {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin-top: auto;
+  justify-content: flex-end;
+  flex: 1;
 }
 
 .message-row {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-bottom: 16px;
 }
 
 .message-row--me {


### PR DESCRIPTION
## Summary
- validate match request age ranges and swap invalid boundaries before saving
- add a direct chat creation endpoint plus service logic that reuses existing private rooms and exposes member login IDs
- update the chat view to surface accepted follows as quick-start entries and stabilize the match session chat layout sizing

## Testing
- npm run build
- ./gradlew test *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da756413508325a8de8d66e18adc6a