### PR TITLE
Add sender login id to chat message responses

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/ChatMessageResponseDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Builder // <-- 이 어노테이션이 추가되어야 합니다.
 public class ChatMessageResponseDto {
     private final Long roomId;
+    private final String senderLoginId;
     private final String senderNickName;
     private final String senderLanguageCode; // 발신자의 언어 코드
     private final String content;

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -392,6 +392,7 @@ public class ChatService {
 
                 return ChatMessageResponseDto.builder()
                         .roomId(message.getRoom().getRoomId())
+                        .senderLoginId(message.getSender() != null ? message.getSender().getLoginId() : null)
                         .senderNickName(message.getSender() != null ? message.getSender().getNickName() : "시스템")
                         .senderLanguageCode(message.getSender() != null ? message.getSender().getLanguageCode() : null)
                         .content(message.getTextContent())

--- a/Matcha-Talk/backend/src/test/java/net/datasa/project01/domain/dto/ChatMessageResponseDtoTest.java
+++ b/Matcha-Talk/backend/src/test/java/net/datasa/project01/domain/dto/ChatMessageResponseDtoTest.java
@@ -1,0 +1,38 @@
+package net.datasa.project01.domain.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatMessageResponseDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesSenderLoginId() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+
+        ChatMessageResponseDto dto = ChatMessageResponseDto.builder()
+                .roomId(1L)
+                .senderLoginId("user123")
+                .senderNickName("테스터")
+                .senderLanguageCode("ko")
+                .content("hello")
+                .contentType("TEXT")
+                .fileName(null)
+                .fileUrl(null)
+                .mimeType(null)
+                .sizeBytes(null)
+                .sentAt(now)
+                .build();
+
+        String json = objectMapper.writeValueAsString(dto);
+        JsonNode root = objectMapper.readTree(json);
+
+        assertThat(root.path("senderLoginId").asText()).isEqualTo("user123");
+    }
+}

--- a/Matcha-Talk/frontend/src/composables/useChatClient.js
+++ b/Matcha-Talk/frontend/src/composables/useChatClient.js
@@ -24,29 +24,27 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
     if (!roomKey) return
 
     const content = payload.content ?? ''
-    const senderNickname = payload.senderNickName || payload.senderNickname || '상대방'
-    const senderLoginId = payload.senderLoginId ||
-      payload.senderLoginID ||
-      payload.sender_login_id ||
-      payload.senderLogin ||
+    const senderNickname = payload.senderNickName ?? payload.senderNickname ?? null
+    const senderLoginId = payload.senderLoginId ??
+      payload.senderLoginID ??
+      payload.sender_login_id ??
+      payload.senderLogin ??
       null
+    if (!senderLoginId) {
+      console.warn('[chat] Received message without senderLoginId', payload)
+    }
     const messagesForRoom = ensureConversation(roomKey)
-    const myNickname = auth.user?.nickName || auth.user?.nickname
     const myLoginId = resolveClientIdentity(auth)
     const normalizedMyLogin = myLoginId ? String(myLoginId).toLowerCase() : null
     const normalizedSenderLogin = senderLoginId ? String(senderLoginId).toLowerCase() : null
-    let isMine = false
-    if (normalizedMyLogin && normalizedSenderLogin) {
-      isMine = normalizedMyLogin === normalizedSenderLogin
-    } else if (myNickname) {
-      isMine = senderNickname === myNickname
-    }
+    const isMine = Boolean(normalizedMyLogin && normalizedSenderLogin && normalizedMyLogin === normalizedSenderLogin)
+    const displayName = senderNickname || senderLoginId || '상대방'
 
     const message = {
       id: `${roomKey}-${Date.now()}-${messagesForRoom.length}`,
       text: content,
       time: timeFormatter(payload.sentAt),
-      sender: senderNickname,
+      sender: displayName,
       senderLoginId,
       me: isMine,
       contentType: (payload.contentType || 'TEXT').toUpperCase(),
@@ -61,7 +59,7 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
 
     messagesForRoom.push(message)
 
-    const roomEntry = await ensureRoomExists(roomKey, senderNickname)
+    const roomEntry = await ensureRoomExists(roomKey, displayName)
     if (roomEntry && Object.prototype.hasOwnProperty.call(roomEntry, 'last')) {
       if (message.contentType === 'TEXT') {
         roomEntry.last = content


### PR DESCRIPTION
## Summary
- include the sender's login ID in `ChatMessageResponseDto` and populate it when building responses
- adjust the chat client composable to rely on the login ID as the primary identity marker and warn if it is missing
- add a serialization test to ensure the new field is emitted in JSON payloads

## Testing
- ./gradlew test *(fails: toolchain for Java 17 is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa0eabe508325b1f190bd77a496c3