### PR TITLE
Expose userPid in login responses and normalize auth cache

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserPenaltyResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserPenaltyResponseDto.java
@@ -24,12 +24,7 @@ public class UserPenaltyResponseDto {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
         String formattedEndsAt = (penalty.getEndsAt() != null) ? penalty.getEndsAt().format(formatter) : null;
 
-        UserSummary userSummary = UserSummary.builder()
-                .id(penalty.getUser().getUserPid())
-                .loginId(penalty.getUser().getLoginId())
-                .nickname(penalty.getUser().getNickName())
-                .email(penalty.getUser().getEmail())
-                .build();
+        UserSummary userSummary = UserSummary.fromEntity(penalty.getUser());
 
         return UserPenaltyResponseDto.builder()
                 .penaltyId(penalty.getPenaltyId())

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserReportResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserReportResponseDto.java
@@ -23,19 +23,8 @@ public class UserReportResponseDto {
     public static UserReportResponseDto fromEntity(UserReport report) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
-        UserSummary reporterSummary = UserSummary.builder()
-                .id(report.getReporter().getUserPid())
-                .loginId(report.getReporter().getLoginId())
-                .nickname(report.getReporter().getNickName())
-                .email(report.getReporter().getEmail())
-                .build();
-
-        UserSummary reportedSummary = UserSummary.builder()
-                .id(report.getReported().getUserPid())
-                .loginId(report.getReported().getLoginId())
-                .nickname(report.getReported().getNickName())
-                .email(report.getReported().getEmail())
-                .build();
+        UserSummary reporterSummary = UserSummary.fromEntity(report.getReporter());
+        UserSummary reportedSummary = UserSummary.fromEntity(report.getReported());
 
         return UserReportResponseDto.builder()
                 .reportId(report.getReportId())

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserSummary.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/UserSummary.java
@@ -12,6 +12,7 @@ import net.datasa.project01.domain.entity.User;
 @AllArgsConstructor
 public class UserSummary {
     private Long id;
+    private Long userPid;
     private String loginId;
     private String nickname;
     private String email;
@@ -19,6 +20,7 @@ public class UserSummary {
     public static UserSummary fromEntity(User user) {
         return UserSummary.builder()
                 .id(user.getUserPid())
+                .userPid(user.getUserPid())
                 .loginId(user.getLoginId())
                 .nickname(user.getNickName())
                 .email(user.getEmail())

--- a/Matcha-Talk/backend/src/test/java/net/datasa/project01/domain/dto/LoginResponseTest.java
+++ b/Matcha-Talk/backend/src/test/java/net/datasa/project01/domain/dto/LoginResponseTest.java
@@ -1,0 +1,31 @@
+package net.datasa.project01.domain.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.datasa.project01.domain.entity.User;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void loginResponseSerializationIncludesUserPid() throws Exception {
+        User user = User.builder()
+                .userPid(42L)
+                .loginId("tester")
+                .nickName("Tester")
+                .email("tester@example.com")
+                .build();
+
+        LoginResponse response = new LoginResponse(UserSummary.fromEntity(user));
+
+        String json = objectMapper.writeValueAsString(response);
+        JsonNode root = objectMapper.readTree(json);
+
+        assertThat(root.path("user").path("userPid").asLong()).isEqualTo(42L);
+        assertThat(root.path("user").path("id").asLong()).isEqualTo(42L);
+    }
+}

--- a/Matcha-Talk/frontend/src/stores/auth.js
+++ b/Matcha-Talk/frontend/src/stores/auth.js
@@ -7,6 +7,33 @@ function safeParse(json, fallback = null) {
 }
 function hasWindow() { return typeof window !== 'undefined' }
 
+function ensureUserPid(user) {
+  if (!user) return null
+
+  if (user.userPid != null) return user
+
+  const fallbackPid =
+    user.user_pid ??
+    user.id ??
+    user.pid ??
+    user.user?.userPid ??
+    user.user?.user_pid ??
+    null
+
+  if (fallbackPid != null) {
+    return { ...user, userPid: fallbackPid }
+  }
+
+  if (hasWindow()) {
+    console.info(
+      '[auth] Cached session did not include userPid. Clearing stale cache. ',
+      'If the issue persists after deployment, manually remove the "user" entry in localStorage and log in again.',
+    )
+  }
+
+  return null
+}
+
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     user: hasWindow() ? safeParse(localStorage.getItem('user')) : null,
@@ -47,12 +74,12 @@ export const useAuthStore = defineStore('auth', {
     },
 
     setUser(user) {
-      this.user = user ?? null
+      this.user = ensureUserPid(user)
       this._persist()
     },
 
     setSession(user) {
-      this.user = user ?? null
+      this.user = ensureUserPid(user)
       this._persist()
     },
 
@@ -64,7 +91,7 @@ export const useAuthStore = defineStore('auth', {
         payload.data ??
         payload ??
         null
-      this.user = user
+      this.user = ensureUserPid(user)
       this._persist()
     },
 
@@ -76,7 +103,14 @@ export const useAuthStore = defineStore('auth', {
     initializeFromStorage() {
       if (!hasWindow()) return
       localStorage.removeItem('token')
-      this.user = safeParse(localStorage.getItem('user'))
+      const storedUser = safeParse(localStorage.getItem('user'))
+      const normalized = ensureUserPid(storedUser)
+
+      if (!normalized && storedUser) {
+        localStorage.removeItem('user')
+      }
+
+      this.user = normalized
     },
 
     // 사용자 정보가 없으면 세션 기반 API로 조회해 보강
@@ -85,7 +119,8 @@ export const useAuthStore = defineStore('auth', {
         if (this.userPid) return
         if (this.user) return
         const { data } = await api.get('/users/profile') // 프로젝트에 맞게 필요시 경로 변경
-        this.user = data?.user ?? data?.data ?? data
+        const nextUser = data?.user ?? data?.data ?? data
+        this.user = ensureUserPid(nextUser)
         this._persist()
       } catch (e) {
         console.warn('hydrateMeIfNeeded failed:', e?.response?.data || e?.message)


### PR DESCRIPTION
## Summary
- add a dedicated userPid field to UserSummary and reuse it across login/report/penalty responses
- normalize cached frontend auth state so stored users always include userPid and advise clearing stale entries
- cover login serialization with a unit test that ensures userPid is emitted alongside id

## Testing
- ./gradlew test *(fails: Gradle toolchain cannot download JDK 17 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa30feffc8325872a31904f69c02c