### PR TITLE
Add follow request caching and repositories

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/FollowRequest.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/entity/FollowRequest.java
@@ -1,0 +1,57 @@
+package net.datasa.project01.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Entity
+@Table(name = "follow_requests",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_fr_room_participants",
+                        columnNames = {"room_id", "requester_pid", "receiver_pid"}
+                )
+        })
+public class FollowRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_request_id")
+    private Long followRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "requester_pid", nullable = false)
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receiver_pid", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private Status status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        DECLINED
+    }
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowListRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowListRepository.java
@@ -1,0 +1,12 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.FollowList;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FollowListRepository extends JpaRepository<FollowList, Long> {
+
+    Optional<FollowList> findByOwnerAndTargetAndDirection(User owner, User target, FollowList.FollowDirection direction);
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowRequestRepository.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/repository/FollowRequestRepository.java
@@ -1,0 +1,12 @@
+package net.datasa.project01.repository;
+
+import net.datasa.project01.domain.entity.FollowRequest;
+import net.datasa.project01.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FollowRequestRepository extends JpaRepository<FollowRequest, Long> {
+
+    Optional<FollowRequest> findFirstByRequesterAndReceiverOrderByCreatedAtDesc(User requester, User receiver);
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/MatchService.java
@@ -8,10 +8,11 @@ import net.datasa.project01.domain.dto.MatchFoundResponseDto;
 import net.datasa.project01.domain.dto.MatchRequestDto;
 import net.datasa.project01.domain.dto.MatchStartResponseDto;
 import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.FollowList;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
-import net.datasa.project01.repository.FollowRepository;
+import net.datasa.project01.repository.FollowListRepository;
 import net.datasa.project01.websocket.RealTimeMessagingService;
 import net.datasa.project01.repository.MatchRequestRepository;
 import net.datasa.project01.repository.UserRepository;
@@ -37,7 +38,7 @@ public class MatchService {
     private final MatchRequestRepository matchRequestRepository;
     private final UserRepository userRepository;
     private final ChatService chatService;
-    private final FollowRepository followRepository;
+    private final FollowListRepository followListRepository;
     private final RealTimeMessagingService messagingService;
     private final ObjectMapper objectMapper;
 
@@ -318,8 +319,16 @@ public class MatchService {
             return FollowSnapshot.empty();
         }
 
-        Optional<Follow> outgoing = followRepository.findByFollowerAndFollowee(currentUser, partnerUser);
-        Optional<Follow> incoming = followRepository.findByFollowerAndFollowee(partnerUser, currentUser);
+        Optional<FollowList> outgoing = followListRepository.findByOwnerAndTargetAndDirection(
+                currentUser,
+                partnerUser,
+                FollowList.FollowDirection.FOLLOWING
+        );
+        Optional<FollowList> incoming = followListRepository.findByOwnerAndTargetAndDirection(
+                currentUser,
+                partnerUser,
+                FollowList.FollowDirection.FOLLOWER
+        );
 
         return FollowSnapshot.from(outgoing, incoming);
     }
@@ -335,9 +344,9 @@ public class MatchService {
             return new FollowSnapshot(null, null, null, null, null, null, false);
         }
 
-        static FollowSnapshot from(Optional<Follow> outgoing, Optional<Follow> incoming) {
-            Follow.FollowStatus outgoingStatusEnum = outgoing.map(Follow::getStatus).orElse(null);
-            Follow.FollowStatus incomingStatusEnum = incoming.map(Follow::getStatus).orElse(null);
+        static FollowSnapshot from(Optional<FollowList> outgoing, Optional<FollowList> incoming) {
+            Follow.FollowStatus outgoingStatusEnum = outgoing.map(FollowList::getStatus).orElse(null);
+            Follow.FollowStatus incomingStatusEnum = incoming.map(FollowList::getStatus).orElse(null);
 
             String outgoingStatus = outgoingStatusEnum != null ? outgoingStatusEnum.name() : null;
             String incomingStatus = incomingStatusEnum != null ? incomingStatusEnum.name() : null;
@@ -350,20 +359,31 @@ public class MatchService {
 
             if (incomingStatusEnum == Follow.FollowStatus.PENDING) {
                 displayStatus = "PENDING_INCOMING";
-                relationId = incoming.map(Follow::getFollowId).orElse(null);
+                relationId = incoming.map(FollowList::getFollow)
+                        .map(Follow::getFollowId)
+                        .orElse(null);
             } else if (outgoingStatusEnum == Follow.FollowStatus.PENDING) {
                 displayStatus = "PENDING_OUTGOING";
-                relationId = outgoing.map(Follow::getFollowId).orElse(null);
+                relationId = outgoing.map(FollowList::getFollow)
+                        .map(Follow::getFollowId)
+                        .orElse(null);
             } else if (mutualAccepted) {
                 displayStatus = "ACCEPTED";
-                relationId = outgoing.map(Follow::getFollowId)
-                        .orElseGet(() -> incoming.map(Follow::getFollowId).orElse(null));
+                relationId = outgoing.map(FollowList::getFollow)
+                        .map(Follow::getFollowId)
+                        .orElseGet(() -> incoming.map(FollowList::getFollow)
+                                .map(Follow::getFollowId)
+                                .orElse(null));
             } else if (incomingStatusEnum == Follow.FollowStatus.ACCEPTED) {
                 displayStatus = "ACCEPTED_INCOMING";
-                relationId = incoming.map(Follow::getFollowId).orElse(null);
+                relationId = incoming.map(FollowList::getFollow)
+                        .map(Follow::getFollowId)
+                        .orElse(null);
             } else if (outgoingStatusEnum == Follow.FollowStatus.ACCEPTED) {
                 displayStatus = "ACCEPTED_OUTGOING";
-                relationId = outgoing.map(Follow::getFollowId).orElse(null);
+                relationId = outgoing.map(FollowList::getFollow)
+                        .map(Follow::getFollowId)
+                        .orElse(null);
             } else if (incomingStatusEnum == Follow.FollowStatus.REJECTED) {
                 displayStatus = "REJECTED_INCOMING";
             } else if (outgoingStatusEnum == Follow.FollowStatus.REJECTED) {
@@ -371,9 +391,13 @@ public class MatchService {
             }
 
             return new FollowSnapshot(
-                    outgoing.map(Follow::getFollowId).orElse(null),
+                    outgoing.map(FollowList::getFollow)
+                            .map(Follow::getFollowId)
+                            .orElse(null),
                     outgoingStatus,
-                    incoming.map(Follow::getFollowId).orElse(null),
+                    incoming.map(FollowList::getFollow)
+                            .map(Follow::getFollowId)
+                            .orElse(null),
                     incomingStatus,
                     displayStatus,
                     relationId,

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/UserService.java
@@ -11,10 +11,14 @@ import net.datasa.project01.domain.dto.UserProfileUpdateRequest;
 import net.datasa.project01.domain.dto.UserResponse;
 import net.datasa.project01.domain.dto.UserSignUpRequestDto;
 import net.datasa.project01.domain.entity.Follow;
+import net.datasa.project01.domain.entity.FollowList;
+import net.datasa.project01.domain.entity.FollowRequest;
 import net.datasa.project01.domain.entity.Profile;
 import net.datasa.project01.domain.entity.Room;
 import net.datasa.project01.domain.entity.User;
+import net.datasa.project01.repository.FollowListRepository;
 import net.datasa.project01.repository.FollowRepository;
+import net.datasa.project01.repository.FollowRequestRepository;
 import net.datasa.project01.repository.ProfileRepository;
 import net.datasa.project01.repository.RoomMemberRepository;
 import net.datasa.project01.repository.UserRepository;
@@ -25,6 +29,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,6 +46,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
+    private final FollowListRepository followListRepository;
+    private final FollowRequestRepository followRequestRepository;
     private final ProfileRepository profileRepository;
     private final RoomMemberRepository roomMemberRepository;
     private final ChatService chatService;
@@ -237,6 +244,36 @@ public class UserService {
                 .build();
         followRepository.save(follow);
 
+        FollowList outgoing = FollowList.builder()
+                .follow(follow)
+                .owner(follower)
+                .target(followee)
+                .direction(FollowList.FollowDirection.FOLLOWING)
+                .status(Follow.FollowStatus.PENDING)
+                .build();
+        FollowList incoming = FollowList.builder()
+                .follow(follow)
+                .owner(followee)
+                .target(follower)
+                .direction(FollowList.FollowDirection.FOLLOWER)
+                .status(Follow.FollowStatus.PENDING)
+                .build();
+        followListRepository.save(outgoing);
+        followListRepository.save(incoming);
+
+        Room matchedRoom = roomMemberRepository.findFirstRandomRoomByUsers(
+                        follower.getUserPid(),
+                        followee.getUserPid())
+                .orElseThrow(() -> new IllegalStateException("매칭된 1:1 대화방 정보를 찾을 수 없습니다."));
+
+        FollowRequest followRequest = FollowRequest.builder()
+                .room(matchedRoom)
+                .requester(follower)
+                .receiver(followee)
+                .status(FollowRequest.Status.PENDING)
+                .build();
+        followRequestRepository.save(followRequest);
+
         FollowResponseDto response = FollowResponseDto.fromEntity(follow, followee);
         broadcastFollowStatus(follower, followee);
         return response;
@@ -260,7 +297,11 @@ public class UserService {
         follow.setStatus(newStatus);
         followRepository.save(follow);
 
+        updateFollowListCaches(follow, newStatus);
+        updateFollowRequestStatus(follow, newStatus);
+
         if (newStatus == Follow.FollowStatus.ACCEPTED) {
+            synchronizeMutualAcceptanceCaches(follow);
             handleMutualFollowPromotion(follow);
         }
 
@@ -302,6 +343,64 @@ public class UserService {
                 .map(Follow::getFollower)
                 .map(UserResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    private void synchronizeMutualAcceptanceCaches(Follow follow) {
+        followRepository.findByFollowerAndFolloweeAndStatus(
+                        follow.getFollowee(),
+                        follow.getFollower(),
+                        Follow.FollowStatus.ACCEPTED)
+                .ifPresent(reciprocal -> {
+                    updateFollowListCaches(reciprocal, Follow.FollowStatus.ACCEPTED);
+                    updateFollowRequestStatus(reciprocal, Follow.FollowStatus.ACCEPTED);
+                });
+    }
+
+    private void updateFollowListCaches(Follow follow, Follow.FollowStatus status) {
+        applyFollowListStatus(follow.getFollower(), follow.getFollowee(), FollowList.FollowDirection.FOLLOWING, follow, status);
+        applyFollowListStatus(follow.getFollowee(), follow.getFollower(), FollowList.FollowDirection.FOLLOWER, follow, status);
+    }
+
+    private void applyFollowListStatus(User owner,
+                                       User target,
+                                       FollowList.FollowDirection direction,
+                                       Follow follow,
+                                       Follow.FollowStatus status) {
+        FollowList cache = followListRepository.findByOwnerAndTargetAndDirection(owner, target, direction)
+                .orElseGet(() -> FollowList.builder()
+                        .owner(owner)
+                        .target(target)
+                        .direction(direction)
+                        .follow(follow)
+                        .status(status)
+                        .build());
+        cache.setFollow(follow);
+        cache.setStatus(status);
+        followListRepository.save(cache);
+    }
+
+    private void updateFollowRequestStatus(Follow follow, Follow.FollowStatus status) {
+        followRequestRepository.findFirstByRequesterAndReceiverOrderByCreatedAtDesc(
+                        follow.getFollower(),
+                        follow.getFollowee())
+                .ifPresent(request -> {
+                    FollowRequest.Status mappedStatus = mapFollowRequestStatus(status);
+                    request.setStatus(mappedStatus);
+                    if (mappedStatus == FollowRequest.Status.PENDING) {
+                        request.setRespondedAt(null);
+                    } else if (request.getRespondedAt() == null) {
+                        request.setRespondedAt(LocalDateTime.now());
+                    }
+                    followRequestRepository.save(request);
+                });
+    }
+
+    private FollowRequest.Status mapFollowRequestStatus(Follow.FollowStatus status) {
+        return switch (status) {
+            case PENDING -> FollowRequest.Status.PENDING;
+            case ACCEPTED -> FollowRequest.Status.ACCEPTED;
+            case REJECTED -> FollowRequest.Status.DECLINED;
+        };
     }
 
     private void broadcastFollowStatus(User follower, User followee) {


### PR DESCRIPTION
## Summary
- add a FollowRequest entity and repositories to persist follow cache data
- update UserService follow creation/status logic to manage follow_list rows and follow_requests
- adjust MatchService follow snapshot resolution to read from the new follow_list cache

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db335959408325abefad243793ad1c