### PR TITLE
Handle missing participant arrays in chat room normalization

### DIFF
--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -666,12 +666,18 @@ function buildFollowEntries(relationshipMap, directRooms) {
   const existingUserPids = new Set()
 
   directRooms.forEach((room) => {
-    (room.participantLogins || []).forEach((login) => {
+    const participantLogins = Array.isArray(room.participantLogins)
+      ? room.participantLogins
+      : []
+    participantLogins.forEach((login) => {
       if (login) {
         existingLogins.add(String(login).toLowerCase())
       }
     })
-    (room.participantsDetail || []).forEach((participant) => {
+    const participantsDetail = Array.isArray(room.participantsDetail)
+      ? room.participantsDetail
+      : []
+    participantsDetail.forEach((participant) => {
       const pid = participant?.userPid ?? participant?.user_pid ?? null
       if (pid != null) {
         existingUserPids.add(Number(pid))
@@ -734,7 +740,7 @@ function normalizeRoomListEntry(room, meNickname) {
     name: displayName,
     last: '',
     participants,
-    participantLogins: room.memberLoginIds || [],
+    participantLogins: Array.isArray(room.memberLoginIds) ? room.memberLoginIds : [],
     participantsDetail: [],
     type,
     temporary,


### PR DESCRIPTION
## Summary
- guard against non-array participant lists when building follow entries
- ensure normalized room entries always expose an array of member login IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db6990fb9083259e232e5c9712cfc2