### PR TITLE
Improve chat history loading and IME handling

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -547,30 +547,63 @@ public class ChatService {
         }
 
         private ChatMessageResponseDto toResponseDto(RoomMessage message) {
-                String downloadUrl = null;
-                if (message.getContentType() != RoomMessage.ContentType.TEXT && StringUtils.hasText(message.getFilePath())) {
-                        downloadUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                .path("/api/rooms/")
-                                .path(String.valueOf(message.getRoom().getRoomId()))
-                                .path("/attachments/")
-                                .path(String.valueOf(message.getMessageId()))
-                                .toUriString();
+                if (message == null) {
+                        throw new IllegalArgumentException("메시지 정보를 확인할 수 없습니다.");
                 }
+
+                RoomMessage.ContentType contentType = message.getContentType() != null
+                        ? message.getContentType()
+                        : RoomMessage.ContentType.TEXT;
+
+                Long roomId = null;
+                try {
+                        roomId = message.getRoom() != null ? message.getRoom().getRoomId() : null;
+                } catch (Exception exception) {
+                        log.warn("Failed to resolve room information for message {}", message.getMessageId(), exception);
+                }
+
+                String downloadUrl = buildAttachmentDownloadUrl(message, contentType, roomId);
 
                 return ChatMessageResponseDto.builder()
                         .messageId(message.getMessageId())
-                        .roomId(message.getRoom().getRoomId())
+                        .roomId(roomId)
                         .senderLoginId(message.getSender() != null ? message.getSender().getLoginId() : null)
                         .senderNickName(message.getSender() != null ? message.getSender().getNickName() : "시스템")
                         .senderLanguageCode(message.getSender() != null ? message.getSender().getLanguageCode() : null)
                         .content(message.getTextContent())
-                        .contentType(message.getContentType().name())
+                        .contentType(contentType.name())
                         .fileName(message.getFileName())
                         .fileUrl(downloadUrl)
                         .mimeType(message.getMimeType())
                         .sizeBytes(message.getSizeBytes())
                         .sentAt(message.getCreatedAt())
                         .build();
+        }
+
+        private String buildAttachmentDownloadUrl(RoomMessage message, RoomMessage.ContentType contentType, Long roomId) {
+                if (message == null || contentType == null || contentType == RoomMessage.ContentType.TEXT) {
+                        return null;
+                }
+                if (!StringUtils.hasText(message.getFilePath())) {
+                        return null;
+                }
+
+                Long messageId = message.getMessageId();
+                if (roomId == null || messageId == null) {
+                        return null;
+                }
+
+                try {
+                        return ServletUriComponentsBuilder.fromCurrentContextPath()
+                                .path("/api/rooms/")
+                                .path(String.valueOf(roomId))
+                                .path("/attachments/")
+                                .path(String.valueOf(messageId))
+                                .toUriString();
+                } catch (IllegalStateException exception) {
+                        log.debug("No request context available while building attachment URL for message {}", messageId, exception);
+                        return String.format("/api/rooms/%s/attachments/%s", roomId, messageId);
+                }
         }
 
         private boolean hasMutualFollow(List<RoomMember> members) {

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -296,7 +296,9 @@
             hide-details
             placeholder="메시지를 입력하세요..."
             class="flex-grow-1"
-            @keydown.enter.prevent="send"
+            @keydown.enter="handleEnterKey"
+            @compositionstart="onCompositionStart"
+            @compositionend="onCompositionEnd"
             :disabled="!current.id"
           />
           <v-btn icon variant="text"><v-icon>mdi-emoticon-outline</v-icon></v-btn>
@@ -402,6 +404,7 @@ const groups = ref([])
 const conversations = ref({})
 const current = ref({})
 const draft = ref('')
+const isComposing = ref(false)
 const followings = ref([])
 const followers = ref([])
 const createGroupDialog = ref(false)
@@ -1026,6 +1029,25 @@ function mergeMessageHistory(roomId, historyMessages) {
   })
 
   conversations.value[roomId] = sorted
+
+  const latest = [...sorted].reverse().find((message) => {
+    if (!message) return false
+    if (message.contentType && message.contentType !== 'TEXT') {
+      return true
+    }
+    return Boolean(message.text && message.text.trim().length)
+  })
+
+  if (latest) {
+    const room = findRoomById(roomId)
+    if (room && Object.prototype.hasOwnProperty.call(room, 'last')) {
+      if (latest.contentType && latest.contentType !== 'TEXT') {
+        room.last = latest.fileName || latest.text || '[첨부파일]'
+      } else {
+        room.last = latest.text
+      }
+    }
+  }
 }
 
 async function ensureMessageHistory(roomId) {
@@ -1208,7 +1230,30 @@ function saveWord(message) {
   vocabularyStore.addWord(message.text, message.translation)
 }
 
+function onCompositionStart () {
+  isComposing.value = true
+}
+
+function onCompositionEnd () {
+  isComposing.value = false
+}
+
+function handleEnterKey(event) {
+  if (!event) return
+  if (event.shiftKey) {
+    return
+  }
+  if (event.isComposing || isComposing.value) {
+    return
+  }
+  event.preventDefault()
+  void send()
+}
+
 async function send() {
+  if (isComposing.value) {
+    return
+  }
   const message = draft.value.trim()
   if (!message) return
 


### PR DESCRIPTION
## Summary
- guard chat message DTO mapping against missing room/context information so history requests no longer fail when attachments are present
- fall back to relative attachment download links when no HTTP request context is available (e.g. WebSocket threads)
- prevent chat submissions while an IME composition is active and refresh conversation previews with the latest history entry

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db724866ec832581302e34443b856e