### PR TITLE
Integrate Papago translation into chat

### DIFF
--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/controller/ChatController.java
@@ -8,6 +8,7 @@ import net.datasa.project01.domain.dto.RoomDetailResponseDto;
 import net.datasa.project01.domain.dto.RoomListResponseDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
 import net.datasa.project01.domain.dto.RoomCleanupResponseDto;
+import net.datasa.project01.domain.dto.TranslationResponseDto;
 import net.datasa.project01.service.ChatService;
 import jakarta.validation.Valid;
 import org.springframework.core.io.Resource;
@@ -15,6 +16,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -212,6 +214,27 @@ public class ChatController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         } catch (IOException exception) {
             log.error("Failed to read attachment {} in room {}", messageId, roomId, exception);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PostMapping("/{roomId}/messages/{messageId}/translate")
+    public ResponseEntity<TranslationResponseDto> translateMessage(
+            @PathVariable Long roomId,
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String loginId = requireLoginId(userDetails);
+        try {
+            TranslationResponseDto responseDto = chatService.translateMessage(roomId, messageId, loginId);
+            return ResponseEntity.ok(responseDto);
+        } catch (AccessDeniedException exception) {
+            log.warn("Translation request rejected for room {} by {}: {}", roomId, loginId, exception.getMessage());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalArgumentException exception) {
+            log.warn("Invalid translation request for message {} in room {} by {}: {}", messageId, roomId, loginId, exception.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception exception) {
+            log.error("Unexpected error while translating message {} in room {}", messageId, roomId, exception);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/domain/dto/TranslationResponseDto.java
@@ -1,0 +1,16 @@
+package net.datasa.project01.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TranslationResponseDto {
+    private final Long roomId;
+    private final Long messageId;
+    private final String originalText;
+    private final String translatedText;
+    private final String sourceLanguage;
+    private final String targetLanguage;
+    private final boolean translated;
+}

--- a/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
+++ b/Matcha-Talk/backend/src/main/java/net/datasa/project01/service/ChatService.java
@@ -16,6 +16,7 @@ import net.datasa.project01.domain.entity.Follow;
 import net.datasa.project01.domain.entity.MatchRequest;
 import net.datasa.project01.domain.dto.ChatMessageRequestDto;
 import net.datasa.project01.domain.dto.ChatMessageResponseDto;
+import net.datasa.project01.domain.dto.TranslationResponseDto;
 import net.datasa.project01.domain.entity.RoomMessage;
 import net.datasa.project01.websocket.RealTimeMessagingService;
 import net.datasa.project01.repository.MatchRequestRepository;
@@ -28,6 +29,7 @@ import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -80,6 +82,29 @@ public class ChatService {
         private final CallSessionCoordinator callSessionCoordinator;
 
         private static final String PROMOTION_REASON_MUTUAL_FOLLOW = "MUTUAL_FOLLOW";
+
+        private static final Map<String, String> COUNTRY_TO_LANGUAGE_MAP = Map.ofEntries(
+                Map.entry("KR", "ko"),
+                Map.entry("KP", "ko"),
+                Map.entry("US", "en"),
+                Map.entry("GB", "en"),
+                Map.entry("CA", "en"),
+                Map.entry("AU", "en"),
+                Map.entry("NZ", "en"),
+                Map.entry("PH", "en"),
+                Map.entry("JP", "ja"),
+                Map.entry("CN", "zh-CN"),
+                Map.entry("TW", "zh-TW"),
+                Map.entry("HK", "zh-TW"),
+                Map.entry("MO", "zh-TW"),
+                Map.entry("FR", "fr"),
+                Map.entry("DE", "de"),
+                Map.entry("ES", "es"),
+                Map.entry("IT", "it"),
+                Map.entry("TH", "th"),
+                Map.entry("VN", "vi"),
+                Map.entry("ID", "id")
+        );
 
         private final Path attachmentBasePath = Paths.get("uploads", "attachments");
 
@@ -546,6 +571,69 @@ public class ChatService {
                 return new AttachmentResource(resource, message.getFileName(), message.getMimeType());
         }
 
+        @Transactional(readOnly = true)
+        public TranslationResponseDto translateMessage(Long roomId, Long messageId, String loginId) {
+                User requester = requireUser(loginId);
+                Room room = requireRoom(roomId);
+
+                try {
+                        ensureRoomMembership(room, requester);
+                } catch (IllegalArgumentException exception) {
+                        throw new AccessDeniedException(exception.getMessage());
+                }
+
+                RoomMessage message = roomMessageRepository.findById(messageId)
+                        .orElseThrow(() -> new IllegalArgumentException("메시지를 찾을 수 없습니다."));
+
+                if (message.getRoom() == null || !roomId.equals(message.getRoom().getRoomId())) {
+                        throw new IllegalArgumentException("요청한 메시지가 해당 채팅방에 존재하지 않습니다.");
+                }
+
+                RoomMessage.ContentType contentType = message.getContentType() != null
+                        ? message.getContentType()
+                        : RoomMessage.ContentType.TEXT;
+
+                String originalText = message.getTextContent() != null ? message.getTextContent() : "";
+                String sourceLanguage = sanitizeSourceLanguage(resolvePapagoLanguageFromUser(message.getSender(), "auto"));
+                String targetLanguage = sanitizeTargetLanguage(resolvePapagoLanguageFromUser(requester, "en"));
+
+                if (contentType != RoomMessage.ContentType.TEXT || !StringUtils.hasText(originalText)) {
+                        return TranslationResponseDto.builder()
+                                .roomId(roomId)
+                                .messageId(messageId)
+                                .originalText(originalText)
+                                .translatedText(originalText)
+                                .sourceLanguage(sourceLanguage)
+                                .targetLanguage(targetLanguage)
+                                .translated(false)
+                                .build();
+                }
+
+                boolean languagesEqual = StringUtils.hasText(sourceLanguage)
+                        && StringUtils.hasText(targetLanguage)
+                        && sourceLanguage.equalsIgnoreCase(targetLanguage);
+
+                boolean shouldTranslate = StringUtils.hasText(targetLanguage) && !languagesEqual;
+
+                String translatedText = originalText;
+                boolean translated = false;
+
+                if (shouldTranslate) {
+                        translatedText = translationService.translate(originalText, sourceLanguage, targetLanguage);
+                        translated = !Objects.equals(originalText, translatedText);
+                }
+
+                return TranslationResponseDto.builder()
+                        .roomId(roomId)
+                        .messageId(messageId)
+                        .originalText(originalText)
+                        .translatedText(translatedText)
+                        .sourceLanguage(sourceLanguage)
+                        .targetLanguage(targetLanguage)
+                        .translated(translated)
+                        .build();
+        }
+
         private ChatMessageResponseDto toResponseDto(RoomMessage message) {
                 if (message == null) {
                         throw new IllegalArgumentException("메시지 정보를 확인할 수 없습니다.");
@@ -604,6 +692,53 @@ public class ChatService {
                         log.debug("No request context available while building attachment URL for message {}", messageId, exception);
                         return String.format("/api/rooms/%s/attachments/%s", roomId, messageId);
                 }
+        }
+
+        private String sanitizeSourceLanguage(String language) {
+                if (StringUtils.hasText(language)) {
+                        return language;
+                }
+                return "auto";
+        }
+
+        private String sanitizeTargetLanguage(String language) {
+                if (StringUtils.hasText(language) && !"auto".equalsIgnoreCase(language)) {
+                        return language;
+                }
+                return "en";
+        }
+
+        private String resolvePapagoLanguageFromUser(User user, String fallbackLanguage) {
+                String normalizedFallback = normalizeLanguageCode(fallbackLanguage);
+                if (user == null) {
+                        return normalizedFallback;
+                }
+
+                String languageCode = normalizeLanguageCode(user.getLanguageCode());
+                if (StringUtils.hasText(languageCode)) {
+                        return languageCode;
+                }
+
+                String fromCountry = resolvePapagoLanguageFromCountry(user.getCountryCode());
+                if (StringUtils.hasText(fromCountry)) {
+                        return fromCountry;
+                }
+
+                return normalizedFallback;
+        }
+
+        private String resolvePapagoLanguageFromCountry(String countryCode) {
+                if (!StringUtils.hasText(countryCode)) {
+                        return null;
+                }
+                return COUNTRY_TO_LANGUAGE_MAP.get(countryCode.trim().toUpperCase());
+        }
+
+        private String normalizeLanguageCode(String languageCode) {
+                if (!StringUtils.hasText(languageCode)) {
+                        return null;
+                }
+                return languageCode.trim();
         }
 
         private boolean hasMutualFollow(List<RoomMember> members) {

--- a/Matcha-Talk/frontend/src/composables/useChatClient.js
+++ b/Matcha-Talk/frontend/src/composables/useChatClient.js
@@ -64,7 +64,11 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
       console.warn('[chat] Received message without senderLoginId', payload)
     }
     const messagesForRoom = ensureConversation(roomKey)
-    if (messageId && messagesForRoom.some((existing) => existing?.id === messageId)) {
+    const parsedIncomingId = typeof messageId === 'number' ? messageId : Number(messageId)
+    if (
+      messageId &&
+      messagesForRoom.some((existing) => existing?.id === messageId || existing?.id === parsedIncomingId)
+    ) {
       return
     }
     const myLoginId = resolveClientIdentity(auth)
@@ -72,9 +76,15 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
     const normalizedSenderLogin = senderLoginId ? String(senderLoginId).toLowerCase() : null
     const isMine = Boolean(normalizedMyLogin && normalizedSenderLogin && normalizedMyLogin === normalizedSenderLogin)
     const displayName = senderNickname || senderLoginId || '상대방'
+    const rawMessageId = messageId || `${roomKey}-${Date.now()}-${messagesForRoom.length}`
+    const parsedMessageId = typeof rawMessageId === 'number' ? rawMessageId : Number(rawMessageId)
+    const resolvedMessageId = Number.isFinite(parsedMessageId) ? parsedMessageId : rawMessageId
+    const parsedRoomId = Number(roomKey)
+    const resolvedRoomId = Number.isFinite(parsedRoomId) ? parsedRoomId : roomKey
 
     const message = {
-      id: messageId || `${roomKey}-${Date.now()}-${messagesForRoom.length}`,
+      id: resolvedMessageId,
+      roomId: resolvedRoomId,
       text: content,
       time: timeFormatter(payload.sentAt),
       sender: displayName,
@@ -88,6 +98,9 @@ export function createIncomingMessageHandler ({ auth, ensureConversation, ensure
       translation: null,
       translating: false,
       sentAt: payload.sentAt ?? null,
+      translationError: null,
+      translationUnavailable: false,
+      translationMeta: null,
     }
 
     messagesForRoom.push(message)

--- a/Matcha-Talk/frontend/src/services/translator.js
+++ b/Matcha-Talk/frontend/src/services/translator.js
@@ -1,5 +1,14 @@
-export async function translate(text, targetLang = 'en') {
-  // 간단한 예시 번역기: 실제 서비스 연동 전까지는 문자열을 뒤집어 반환합니다.
-  // TODO: 외부 번역 API와 연동하여 실제 번역 결과를 제공하세요.
-  return text.split('').reverse().join('');
+import api from './api'
+
+export async function translate({ roomId, messageId, signal } = {}) {
+  if (!roomId) {
+    throw new Error('roomId is required to translate a message')
+  }
+  if (!messageId) {
+    throw new Error('messageId is required to translate a message')
+  }
+
+  const config = signal ? { signal } : undefined
+  const response = await api.post(`/rooms/${roomId}/messages/${messageId}/translate`, {}, config)
+  return response?.data
 }

--- a/Matcha-Talk/frontend/src/views/Chat.vue
+++ b/Matcha-Talk/frontend/src/views/Chat.vue
@@ -217,7 +217,7 @@
                     </div>
                     <div class="message-tools">
                       <v-btn
-                        v-if="m.contentType === 'TEXT'"
+                        v-if="m.contentType === 'TEXT' && !m.translationUnavailable"
                         icon
                         variant="text"
                         density="compact"
@@ -259,7 +259,7 @@
                     </div>
                     <div class="message-tools justify-end">
                       <v-btn
-                        v-if="m.contentType === 'TEXT'"
+                        v-if="m.contentType === 'TEXT' && !m.translationUnavailable"
                         icon
                         variant="text"
                         density="compact"
@@ -972,9 +972,14 @@ function normalizeHistoryMessage(entry, roomKey) {
   const normalizedSender = senderLogin ? String(senderLogin).toLowerCase() : null
   const normalizedMyLogin = myLogin ? String(myLogin).toLowerCase() : null
 
-  const messageId = entry.messageId || entry.message_id || `${roomKey}-${entry.sentAt || Date.now()}`
+  const rawMessageId = entry.messageId || entry.message_id || `${roomKey}-${entry.sentAt || Date.now()}`
+  const parsedMessageId = typeof rawMessageId === 'number' ? rawMessageId : Number(rawMessageId)
+  const messageId = Number.isFinite(parsedMessageId) ? parsedMessageId : rawMessageId
+  const parsedRoomId = Number(roomKey)
+  const resolvedRoomId = Number.isFinite(parsedRoomId) ? parsedRoomId : roomKey
   return {
     id: messageId,
+    roomId: resolvedRoomId,
     text: entry.content || '',
     time: formatTime(entry.sentAt),
     sender: entry.senderNickName || entry.senderNickname || senderLogin || '상대방',
@@ -986,6 +991,9 @@ function normalizeHistoryMessage(entry, roomKey) {
     translation: null,
     translating: false,
     sentAt: entry.sentAt || null,
+    translationError: null,
+    translationUnavailable: false,
+    translationMeta: null,
   }
 }
 
@@ -1220,14 +1228,60 @@ function formatTime(isoString) {
 }
 
 async function translateMessage(message) {
-  if (!message || message.translating || message.translation || message.contentType !== 'TEXT') return
+  if (!message || message.translating || message.contentType !== 'TEXT' || message.translationUnavailable) return
+  if (message.translation && !message.translationError) return
+
+  const roomKey = message.roomId ?? current.value?.id
+  const parsedRoomId = typeof roomKey === 'number' ? roomKey : Number(roomKey)
+  const resolvedRoomId = Number.isFinite(parsedRoomId) && parsedRoomId > 0 ? parsedRoomId : null
+  const parsedMessageId = typeof message.id === 'number' ? message.id : Number(message.id)
+  const resolvedMessageId = Number.isFinite(parsedMessageId) && parsedMessageId > 0 ? parsedMessageId : null
+
+  if (!resolvedRoomId) {
+    console.warn('[chat] 번역할 채팅방 정보를 확인할 수 없습니다.', { roomKey })
+    message.translationUnavailable = true
+    message.translationError = '채팅방 정보가 없어 번역할 수 없습니다.'
+    return
+  }
+
+  if (!resolvedMessageId) {
+    console.warn('[chat] 번역할 메시지 ID를 확인할 수 없습니다.', { id: message.id })
+    message.translationUnavailable = true
+    message.translationError = '메시지 정보가 없어 번역할 수 없습니다.'
+    return
+  }
 
   message.translating = true
+  message.translationError = null
+
   try {
-    const targetLang = auth.user?.languageCode || 'en'
-    message.translation = await translate(message.text, targetLang)
+    const result = await translate({ roomId: resolvedRoomId, messageId: resolvedMessageId })
+    if (result && typeof result === 'object') {
+      const { translatedText, originalText, translated } = result
+      const fallbackText = typeof originalText === 'string' ? originalText : message.text
+      const resolvedTranslation = typeof translatedText === 'string' ? translatedText : fallbackText
+      message.translation = resolvedTranslation
+      message.translationMeta = result
+      message.roomId = resolvedRoomId
+      message.translationUnavailable = false
+      if (translated === false && resolvedTranslation === fallbackText) {
+        message.translationUnavailable = true
+      }
+    } else if (typeof result === 'string') {
+      message.translation = result
+      message.roomId = resolvedRoomId
+      message.translationUnavailable = false
+    } else {
+      message.translation = message.text
+      message.translationUnavailable = true
+    }
   } catch (error) {
     console.error('문장을 번역하지 못했습니다.', error)
+    message.translationError = error?.response?.data?.message || error?.message || '번역에 실패했습니다.'
+    if (error?.response?.status === 400 || error?.response?.status === 403) {
+      message.translationUnavailable = true
+    }
+    alert('문장을 번역하지 못했습니다. 잠시 후 다시 시도해주세요.')
   } finally {
     message.translating = false
   }


### PR DESCRIPTION
## Summary
- add a translation response DTO and map country codes to Papago language codes when translating chat messages
- expose a secured translation endpoint in the chat controller that delegates to the new ChatService logic
- wire the chat UI translation button to call the backend API, persist room/message metadata, and handle unavailable translations

## Testing
- `./gradlew test` *(fails: missing JDK toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db7908f5ec83258c84e2d4f163469a